### PR TITLE
[FEAT/#16] 공통 컴포넌트 TopAppBar 구현

### DIFF
--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/BackAndMoreTopAppBar.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/BackAndMoreTopAppBar.kt
@@ -13,10 +13,10 @@ import com.hilingual.core.designsystem.R
 import com.hilingual.core.designsystem.theme.HilingualTheme
 
 @Composable
-fun CloseAndMoreTopAppBar(
+fun BackAndMoreTopAppBar(
     modifier: Modifier = Modifier,
     title: String?,
-    onCloseClicked: () -> Unit,
+    onBackClicked: () -> Unit,
     onMoreClicked: () -> Unit
 ) {
     HilingualBasicTopAppBar(
@@ -26,8 +26,8 @@ fun CloseAndMoreTopAppBar(
             Icon(
                 modifier = Modifier
                     .size(24.dp)
-                    .noRippleClickable(onClick = onCloseClicked),
-                imageVector = ImageVector.vectorResource(R.drawable.ic_close_24),
+                    .noRippleClickable(onClick = onBackClicked),
+                imageVector = ImageVector.vectorResource(R.drawable.ic_arrow_left_24),
                 contentDescription = null,
                 tint = HilingualTheme.colors.black
             )
@@ -47,11 +47,11 @@ fun CloseAndMoreTopAppBar(
 
 @Preview
 @Composable
-private fun CloseAndMoreTopAppBarPreview() {
+private fun BackAndMoreTopAppBarPreview() {
     HilingualTheme {
-        CloseAndMoreTopAppBar(
+        BackAndMoreTopAppBar(
             title = "일기장",
-            onCloseClicked = {},
+            onBackClicked = {},
             onMoreClicked = {}
         )
     }

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/BackTopAppBar.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/BackTopAppBar.kt
@@ -1,6 +1,5 @@
 package com.hilingual.core.designsystem.component.topappbar
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -13,21 +12,20 @@ import com.hilingual.core.designsystem.theme.HilingualTheme
 
 @Composable
 fun BackTopAppBar(
+    modifier: Modifier = Modifier,
     title: String?,
     onBackClicked: () -> Unit
 ) {
     HilingualBasicTopAppBar(
+        modifier = modifier,
         title = title,
         navigationIcon = {
-            Box(
-                modifier = Modifier.noRippleClickable(onBackClicked)
-            ) {
-                Icon(
-                    imageVector = ImageVector.vectorResource(R.drawable.ic_arrow_left_24),
-                    contentDescription = null,
-                    tint = HilingualTheme.colors.black
-                )
-            }
+            Icon(
+                modifier = Modifier.noRippleClickable(onClick = onBackClicked),
+                imageVector = ImageVector.vectorResource(R.drawable.ic_arrow_left_24),
+                contentDescription = null,
+                tint = HilingualTheme.colors.black
+            )
         }
     )
 }

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/BackTopAppBar.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/BackTopAppBar.kt
@@ -1,0 +1,44 @@
+package com.hilingual.core.designsystem.component.topappbar
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.hilingual.core.common.extension.noRippleClickable
+import com.hilingual.core.designsystem.R
+import com.hilingual.core.designsystem.theme.HilingualTheme
+
+@Composable
+fun BackTopAppBar(
+    title: String?,
+    onBackClicked: () -> Unit
+) {
+    HilingualBasicTopAppBar(
+        title = title,
+        navigationIcon = {
+            Box(
+                modifier = Modifier.noRippleClickable(onBackClicked)
+            ) {
+                Icon(
+                    imageVector = ImageVector.vectorResource(R.drawable.ic_arrow_left_24),
+                    contentDescription = null,
+                    tint = HilingualTheme.colors.black
+                )
+            }
+        }
+    )
+}
+
+@Preview
+@Composable
+private fun BackTopAppBarPreview() {
+    HilingualTheme {
+        BackTopAppBar(
+            title = "일기 작성하기",
+            onBackClicked = { }
+        )
+    }
+}

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/BackTopAppBar.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/BackTopAppBar.kt
@@ -1,11 +1,13 @@
 package com.hilingual.core.designsystem.component.topappbar
 
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.hilingual.core.common.extension.noRippleClickable
 import com.hilingual.core.designsystem.R
 import com.hilingual.core.designsystem.theme.HilingualTheme
@@ -21,7 +23,9 @@ fun BackTopAppBar(
         title = title,
         navigationIcon = {
             Icon(
-                modifier = Modifier.noRippleClickable(onClick = onBackClicked),
+                modifier = Modifier
+                    .size(24.dp)
+                    .noRippleClickable(onClick = onBackClicked),
                 imageVector = ImageVector.vectorResource(R.drawable.ic_arrow_left_24),
                 contentDescription = null,
                 tint = HilingualTheme.colors.black

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/CloseAndMoreTopAppBar.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/CloseAndMoreTopAppBar.kt
@@ -1,11 +1,13 @@
 package com.hilingual.core.designsystem.component.topappbar
 
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.hilingual.core.common.extension.noRippleClickable
 import com.hilingual.core.designsystem.R
 import com.hilingual.core.designsystem.theme.HilingualTheme
@@ -22,7 +24,9 @@ fun CloseAndMoreTopAppBar(
         title = title,
         navigationIcon = {
             Icon(
-                modifier = Modifier.noRippleClickable(onClick = onCloseClicked),
+                modifier = Modifier
+                    .size(24.dp)
+                    .noRippleClickable(onClick = onCloseClicked),
                 imageVector = ImageVector.vectorResource(R.drawable.ic_close_24),
                 contentDescription = null,
                 tint = HilingualTheme.colors.black
@@ -30,7 +34,9 @@ fun CloseAndMoreTopAppBar(
         },
         actions = {
             Icon(
-                modifier = Modifier.noRippleClickable(onClick = onMoreClicked),
+                modifier = Modifier
+                    .size(24.dp)
+                    .noRippleClickable(onClick = onMoreClicked),
                 imageVector = ImageVector.vectorResource(R.drawable.ic_more_24),
                 contentDescription = null,
                 tint = HilingualTheme.colors.gray400

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/CloseAndMoreTopAppBar.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/CloseAndMoreTopAppBar.kt
@@ -1,0 +1,57 @@
+package com.hilingual.core.designsystem.component.topappbar
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.hilingual.core.common.extension.noRippleClickable
+import com.hilingual.core.designsystem.R
+import com.hilingual.core.designsystem.theme.HilingualTheme
+
+@Composable
+fun CloseAndMoreTopAppBar(
+    title: String?,
+    onCloseClicked: () -> Unit,
+    onMoreClicked: () -> Unit
+) {
+    HilingualBasicTopAppBar(
+        title = title,
+        navigationIcon = {
+            Box(
+                modifier = Modifier.noRippleClickable(onCloseClicked)
+            ) {
+                Icon(
+                    imageVector = ImageVector.vectorResource(R.drawable.ic_close_24),
+                    contentDescription = null,
+                    tint = HilingualTheme.colors.black
+                )
+            }
+        },
+        actions = {
+            Box(
+                modifier = Modifier.noRippleClickable(onMoreClicked)
+            ) {
+                Icon(
+                    imageVector = ImageVector.vectorResource(R.drawable.ic_more_24),
+                    contentDescription = null,
+                    tint = HilingualTheme.colors.gray400
+                )
+            }
+        }
+    )
+}
+
+@Preview
+@Composable
+private fun CloseAndMoreTopAppBarPreview() {
+    HilingualTheme {
+        CloseAndMoreTopAppBar(
+            title = "일기장",
+            onCloseClicked = {},
+            onMoreClicked = {}
+        )
+    }
+}

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/CloseAndMoreTopAppBar.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/CloseAndMoreTopAppBar.kt
@@ -1,6 +1,5 @@
 package com.hilingual.core.designsystem.component.topappbar
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -13,33 +12,29 @@ import com.hilingual.core.designsystem.theme.HilingualTheme
 
 @Composable
 fun CloseAndMoreTopAppBar(
+    modifier: Modifier = Modifier,
     title: String?,
     onCloseClicked: () -> Unit,
     onMoreClicked: () -> Unit
 ) {
     HilingualBasicTopAppBar(
+        modifier = modifier,
         title = title,
         navigationIcon = {
-            Box(
-                modifier = Modifier.noRippleClickable(onCloseClicked)
-            ) {
-                Icon(
-                    imageVector = ImageVector.vectorResource(R.drawable.ic_close_24),
-                    contentDescription = null,
-                    tint = HilingualTheme.colors.black
-                )
-            }
+            Icon(
+                modifier = Modifier.noRippleClickable(onClick = onCloseClicked),
+                imageVector = ImageVector.vectorResource(R.drawable.ic_close_24),
+                contentDescription = null,
+                tint = HilingualTheme.colors.black
+            )
         },
         actions = {
-            Box(
-                modifier = Modifier.noRippleClickable(onMoreClicked)
-            ) {
-                Icon(
-                    imageVector = ImageVector.vectorResource(R.drawable.ic_more_24),
-                    contentDescription = null,
-                    tint = HilingualTheme.colors.gray400
-                )
-            }
+            Icon(
+                modifier = Modifier.noRippleClickable(onClick = onMoreClicked),
+                imageVector = ImageVector.vectorResource(R.drawable.ic_more_24),
+                contentDescription = null,
+                tint = HilingualTheme.colors.gray400
+            )
         }
     )
 }

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/CloseOnlyTopAppBar.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/CloseOnlyTopAppBar.kt
@@ -1,0 +1,43 @@
+package com.hilingual.core.designsystem.component.topappbar
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.hilingual.core.common.extension.noRippleClickable
+import com.hilingual.core.designsystem.R
+import com.hilingual.core.designsystem.theme.HilingualTheme
+
+@Composable
+fun CloseOnlyTopAppBar(
+    onCloseClicked: () -> Unit
+) {
+    HilingualBasicTopAppBar(
+        navigationIcon = {
+            Box(
+                modifier = Modifier.noRippleClickable(onCloseClicked)
+            ) {
+                Icon(
+                    imageVector = ImageVector.vectorResource(R.drawable.ic_close_24),
+                    contentDescription = null,
+                    tint = HilingualTheme.colors.white
+                )
+            }
+        },
+        backgroundColor = Color.Transparent
+    )
+}
+
+@Preview
+@Composable
+private fun CloseOnlyTopAppBarPreview() {
+    HilingualTheme {
+        CloseOnlyTopAppBar(
+            onCloseClicked = {}
+        )
+    }
+}

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/CloseOnlyTopAppBar.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/CloseOnlyTopAppBar.kt
@@ -1,6 +1,5 @@
 package com.hilingual.core.designsystem.component.topappbar
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -14,19 +13,18 @@ import com.hilingual.core.designsystem.theme.HilingualTheme
 
 @Composable
 fun CloseOnlyTopAppBar(
+    modifier: Modifier = Modifier,
     onCloseClicked: () -> Unit
 ) {
     HilingualBasicTopAppBar(
+        modifier = modifier,
         navigationIcon = {
-            Box(
-                modifier = Modifier.noRippleClickable(onCloseClicked)
-            ) {
-                Icon(
-                    imageVector = ImageVector.vectorResource(R.drawable.ic_close_24),
-                    contentDescription = null,
-                    tint = HilingualTheme.colors.white
-                )
-            }
+            Icon(
+                modifier = Modifier.noRippleClickable(onClick = onCloseClicked),
+                imageVector = ImageVector.vectorResource(R.drawable.ic_close_24),
+                contentDescription = null,
+                tint = HilingualTheme.colors.white
+            )
         },
         backgroundColor = Color.Transparent
     )

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/CloseTopAppBar.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/CloseTopAppBar.kt
@@ -1,0 +1,44 @@
+package com.hilingual.core.designsystem.component.topappbar
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.hilingual.core.common.extension.noRippleClickable
+import com.hilingual.core.designsystem.R
+import com.hilingual.core.designsystem.theme.HilingualTheme
+
+@Composable
+fun CloseTopAppBar(
+    title: String?,
+    onCloseClicked: () -> Unit
+) {
+    HilingualBasicTopAppBar(
+        title = title,
+        navigationIcon = {
+            Box(
+                modifier = Modifier.noRippleClickable(onCloseClicked)
+            ) {
+                Icon(
+                    imageVector = ImageVector.vectorResource(R.drawable.ic_close_24),
+                    contentDescription = null,
+                    tint = HilingualTheme.colors.black
+                )
+            }
+        }
+    )
+}
+
+@Preview
+@Composable
+private fun CloseTopAppBarPreview() {
+    HilingualTheme {
+        CloseTopAppBar(
+            title = "일기 작성하기",
+            onCloseClicked = {}
+        )
+    }
+}

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/CloseTopAppBar.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/CloseTopAppBar.kt
@@ -1,11 +1,13 @@
 package com.hilingual.core.designsystem.component.topappbar
 
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.hilingual.core.common.extension.noRippleClickable
 import com.hilingual.core.designsystem.R
 import com.hilingual.core.designsystem.theme.HilingualTheme
@@ -21,7 +23,9 @@ fun CloseTopAppBar(
         title = title,
         navigationIcon = {
             Icon(
-                modifier = Modifier.noRippleClickable(onClick = onCloseClicked),
+                modifier = Modifier
+                    .size(24.dp)
+                    .noRippleClickable(onClick = onCloseClicked),
                 imageVector = ImageVector.vectorResource(R.drawable.ic_close_24),
                 contentDescription = null,
                 tint = HilingualTheme.colors.black

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/CloseTopAppBar.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/CloseTopAppBar.kt
@@ -1,6 +1,5 @@
 package com.hilingual.core.designsystem.component.topappbar
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -13,21 +12,20 @@ import com.hilingual.core.designsystem.theme.HilingualTheme
 
 @Composable
 fun CloseTopAppBar(
+    modifier: Modifier = Modifier,
     title: String?,
     onCloseClicked: () -> Unit
 ) {
     HilingualBasicTopAppBar(
+        modifier = modifier,
         title = title,
         navigationIcon = {
-            Box(
-                modifier = Modifier.noRippleClickable(onCloseClicked)
-            ) {
-                Icon(
-                    imageVector = ImageVector.vectorResource(R.drawable.ic_close_24),
-                    contentDescription = null,
-                    tint = HilingualTheme.colors.black
-                )
-            }
+            Icon(
+                modifier = Modifier.noRippleClickable(onClick = onCloseClicked),
+                imageVector = ImageVector.vectorResource(R.drawable.ic_close_24),
+                contentDescription = null,
+                tint = HilingualTheme.colors.black
+            )
         }
     )
 }

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/HilingualBasicTopAppBar.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/HilingualBasicTopAppBar.kt
@@ -1,12 +1,9 @@
 package com.hilingual.core.designsystem.component.topappbar
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Text
@@ -23,47 +20,41 @@ fun HilingualBasicTopAppBar(
     modifier: Modifier = Modifier,
     title: String? = null,
     navigationIcon: @Composable () -> Unit = {},
-    actions: @Composable RowScope.() -> Unit = {},
+    actions: @Composable () -> Unit = {},
     backgroundColor: Color = HilingualTheme.colors.white,
 ) {
-    Box(
+    Row(
         modifier = modifier
             .fillMaxWidth()
-            .height(50.dp)
             .background(backgroundColor)
-            .padding(horizontal = 16.dp)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
     ) {
+        // 좌측 아이콘
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .align(Alignment.Center),
+            modifier = Modifier.size(24.dp)
         ) {
-            // 좌측 아이콘
-            Row(
-                modifier = Modifier.size(24.dp)
-            ) {
-                navigationIcon()
-            }
+            navigationIcon()
+        }
 
-            Spacer(modifier = Modifier.weight(1f))
+        Spacer(modifier = Modifier.weight(1f))
 
-            // title
-            if (title != null) {
-                Text(
-                    text = title,
-                    color = HilingualTheme.colors.black,
-                    style = HilingualTheme.typography.headB18,
-                )
-            }
+        // title
+        if (title != null) {
+            Text(
+                text = title,
+                color = HilingualTheme.colors.black,
+                style = HilingualTheme.typography.headB18,
+            )
+        }
 
-            Spacer(modifier = Modifier.weight(1f))
+        Spacer(modifier = Modifier.weight(1f))
 
-            // 우측 아이콘
-            Row(
-                modifier = Modifier.size(24.dp)
-            ) {
-                actions()
-            }
+        // 우측 아이콘
+        Row(
+            modifier = Modifier.size(24.dp)
+        ) {
+            actions()
         }
     }
 }

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/HilingualBasicTopAppBar.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/HilingualBasicTopAppBar.kt
@@ -1,11 +1,10 @@
 package com.hilingual.core.designsystem.component.topappbar
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -23,36 +22,34 @@ fun HilingualBasicTopAppBar(
     actions: @Composable () -> Unit = {},
     backgroundColor: Color = HilingualTheme.colors.white,
 ) {
-    Row(
+    Box(
         modifier = modifier
             .fillMaxWidth()
             .background(backgroundColor)
-            .padding(horizontal = 16.dp, vertical = 12.dp),
-        verticalAlignment = Alignment.CenterVertically
+            .padding(horizontal = 16.dp, vertical = 12.dp)
     ) {
         // 좌측 아이콘
         Row(
-            modifier = Modifier.size(24.dp)
+            modifier = Modifier.align(Alignment.CenterStart),
+            verticalAlignment = Alignment.CenterVertically
         ) {
             navigationIcon()
         }
 
-        Spacer(modifier = Modifier.weight(1f))
-
         // title
         if (title != null) {
             Text(
+                modifier = Modifier.align(Alignment.Center),
                 text = title,
                 color = HilingualTheme.colors.black,
                 style = HilingualTheme.typography.headB18,
             )
         }
 
-        Spacer(modifier = Modifier.weight(1f))
-
         // 우측 아이콘
         Row(
-            modifier = Modifier.size(24.dp)
+            modifier = Modifier.align(Alignment.CenterEnd),
+            verticalAlignment = Alignment.CenterVertically
         ) {
             actions()
         }

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/HilingualBasicTopAppBar.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/HilingualBasicTopAppBar.kt
@@ -1,0 +1,77 @@
+package com.hilingual.core.designsystem.component.topappbar
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hilingual.core.designsystem.theme.HilingualTheme
+
+@Composable
+fun HilingualBasicTopAppBar(
+    modifier: Modifier = Modifier,
+    title: String? = null,
+    navigationIcon: @Composable () -> Unit = {},
+    actions: @Composable RowScope.() -> Unit = {},
+    backgroundColor: Color = HilingualTheme.colors.white,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(50.dp)
+            .background(backgroundColor)
+            .padding(horizontal = 16.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.Center),
+        ) {
+            // 좌측 아이콘
+            Row(
+                modifier = Modifier.size(24.dp)
+            ) {
+                navigationIcon()
+            }
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            // title
+            if (title != null) {
+                Text(
+                    text = title,
+                    color = HilingualTheme.colors.black,
+                    style = HilingualTheme.typography.headB18,
+                )
+            }
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            // 우측 아이콘
+            Row(
+                modifier = Modifier.size(24.dp)
+            ) {
+                actions()
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun HilingualBasicTopAppBarPreview() {
+    HilingualTheme {
+        HilingualBasicTopAppBar()
+    }
+}

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/TitleCenterAlignedTopAppBar.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/TitleCenterAlignedTopAppBar.kt
@@ -1,0 +1,24 @@
+package com.hilingual.core.designsystem.component.topappbar
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.hilingual.core.designsystem.theme.HilingualTheme
+
+@Composable
+fun TitleCenterAlignedTopAppBar(
+    title: String
+) {
+    HilingualBasicTopAppBar(
+        title = title
+    )
+}
+
+@Preview
+@Composable
+private fun TitleCenterAlignedTopAppBarPreview() {
+    HilingualTheme {
+        TitleCenterAlignedTopAppBar(
+            title = "일기 작성하기"
+        )
+    }
+}

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/TitleCenterAlignedTopAppBar.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/TitleCenterAlignedTopAppBar.kt
@@ -1,14 +1,17 @@
 package com.hilingual.core.designsystem.component.topappbar
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.hilingual.core.designsystem.theme.HilingualTheme
 
 @Composable
 fun TitleCenterAlignedTopAppBar(
+    modifier: Modifier = Modifier,
     title: String
 ) {
     HilingualBasicTopAppBar(
+        modifier = modifier,
         title = title
     )
 }

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/TitleLeftAlignedTopAppBar.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/TitleLeftAlignedTopAppBar.kt
@@ -1,37 +1,32 @@
 package com.hilingual.core.designsystem.component.topappbar
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hilingual.core.designsystem.theme.HilingualTheme
 
 @Composable
 fun TitleLeftAlignedTopAppBar(
+    modifier: Modifier = Modifier,
     title: String
 ) {
-    Box(
-        modifier = Modifier
+    Text(
+        modifier = modifier
             .fillMaxWidth()
-            .height(50.dp)
             .background(Color.Transparent)
-            .padding(horizontal = 16.dp),
-        contentAlignment = Alignment.CenterStart
-    ) {
-        Text(
-            text = title,
-            color = HilingualTheme.colors.white,
-            style = HilingualTheme.typography.headM18
-        )
-    }
+            .padding(start = 16.dp, top = 15.dp, end = 16.dp, bottom = 14.dp),
+        textAlign = TextAlign.Start,
+        text = title,
+        color = HilingualTheme.colors.white,
+        style = HilingualTheme.typography.headM18
+    )
 }
 
 @Preview

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/TitleLeftAlignedTopAppBar.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/TitleLeftAlignedTopAppBar.kt
@@ -1,0 +1,45 @@
+package com.hilingual.core.designsystem.component.topappbar
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hilingual.core.designsystem.theme.HilingualTheme
+
+@Composable
+fun TitleLeftAlignedTopAppBar(
+    title: String
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(50.dp)
+            .background(Color.Transparent)
+            .padding(horizontal = 16.dp),
+        contentAlignment = Alignment.CenterStart
+    ) {
+        Text(
+            text = title,
+            color = HilingualTheme.colors.white,
+            style = HilingualTheme.typography.headM18
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun TitleLeftAlignedTopAppBarPreview() {
+    HilingualTheme {
+        TitleLeftAlignedTopAppBar(
+            title = "나의 단어장"
+        )
+    }
+}

--- a/core/designsystem/src/main/res/drawable/ic_arrow_left_24.xml
+++ b/core/designsystem/src/main/res/drawable/ic_arrow_left_24.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M16,20L8,12L16,4"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/core/designsystem/src/main/res/drawable/ic_close_24.xml
+++ b/core/designsystem/src/main/res/drawable/ic_close_24.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M18,6L6,18M6,6L18,18"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#101828"
+      android:strokeLineCap="round"/>
+</vector>

--- a/core/designsystem/src/main/res/drawable/ic_more_24.xml
+++ b/core/designsystem/src/main/res/drawable/ic_more_24.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="25dp"
+    android:viewportWidth="24"
+    android:viewportHeight="25">
+  <path
+      android:pathData="M12,19.5m2,-0a2,2 0,1 1,-4 -0a2,2 0,1 1,4 -0"
+      android:fillColor="#9E9E9E"/>
+  <path
+      android:pathData="M12,12.5m2,-0a2,2 0,1 1,-4 -0a2,2 0,1 1,4 -0"
+      android:fillColor="#9E9E9E"/>
+  <path
+      android:pathData="M12,5.5m2,-0a2,2 0,1 1,-4 -0a2,2 0,1 1,4 -0"
+      android:fillColor="#9E9E9E"/>
+</vector>


### PR DESCRIPTION
## Related issue 🛠
- closed #16 

## Work Description ✏️
- 6가지 종류의 TopAppBar를 구현했습니다

## Screenshot 📸
<img width="360" alt="스크린샷 2025-07-06 오전 6 12 48" src="https://github.com/user-attachments/assets/893debae-48aa-4da4-8294-e1cfbe003a85" />
<img width="360" alt="스크린샷 2025-07-06 오전 6 15 36" src="https://github.com/user-attachments/assets/409b54d9-7f02-4056-990a-401b9b332bcb" />
<img width="360" alt="스크린샷 2025-07-06 오전 6 16 06" src="https://github.com/user-attachments/assets/5c5421e5-01c7-4b01-a939-5cc2bf9056be" />
<img width="360" alt="스크린샷 2025-07-06 오전 6 16 26" src="https://github.com/user-attachments/assets/fbc0ef0c-f0d3-407d-be10-b85bc0859431" />
<img width="360" alt="스크린샷 2025-07-06 오전 6 16 57" src="https://github.com/user-attachments/assets/ef26ca02-7677-49ca-bd11-b9f974469ece" />
<img width="360" alt="스크린샷 2025-07-06 오전 6 17 34" src="https://github.com/user-attachments/assets/5652224d-f373-4fd3-ac09-039de50327e7" />

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
- (아이콘)-(텍스트)-(아이콘) 형식을 재활용할 수 있는 다섯 종류의 TopAppBar는 HilingualBasicTopAppBar를 재활용해서 구현했습니다.
- HilingualBasicTopAppBar를 재활용하기에는 애매하다고 판단한 TitleLeftAlignedTopAppBar는 별도로 구현했습니다.
- 각 파일마다 Preview 코드를 넣어두었으니 참고하시면 될 것 같습니다.
- 고칠 부분 있다면 알려주세용!! 많이 배워가겠습니닷 💪🏻