### PR TITLE
[FEAT/#20] DatePicker 바텀시트 구현

### DIFF
--- a/core/common/src/main/java/com/hilingual/core/common/extension/ModfierExt.kt
+++ b/core/common/src/main/java/com/hilingual/core/common/extension/ModfierExt.kt
@@ -15,13 +15,18 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.Paint
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.drawOutline
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.findRootCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -106,3 +111,10 @@ fun Modifier.dropShadow(
         }
     }
 }
+
+fun Modifier.fadingEdge(brush: Brush) = this
+    .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)
+    .drawWithContent {
+        drawContent()
+        drawRect(brush = brush, blendMode = BlendMode.DstIn)
+    }

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/bottomsheet/HilingualYearMonthPickerBottomSheet.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/bottomsheet/HilingualYearMonthPickerBottomSheet.kt
@@ -1,0 +1,50 @@
+package com.hilingual.core.designsystem.component.bottomsheet
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.hilingual.core.designsystem.component.button.HilingualButton
+import com.hilingual.core.designsystem.component.datapicker.HilingualYearMonthPicker
+import com.hilingual.core.designsystem.component.datapicker.rememberPickerState
+import java.time.YearMonth
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HilingualYearMonthPickerBottomSheet(
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+    initialYearMonth: YearMonth = YearMonth.now(),
+    onDateSelected: (YearMonth) -> Unit,
+) {
+    val yearState = rememberPickerState(initialItem = initialYearMonth.year)
+    val monthState = rememberPickerState(initialItem = initialYearMonth.monthValue)
+
+    HilingualBasicBottomSheet(
+        onDismiss = onDismiss,
+        modifier = modifier
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp)
+        ) {
+            HilingualYearMonthPicker(
+                startLocalDate = initialYearMonth,
+                yearPickerState = yearState,
+                monthPickerState = monthState
+            )
+            Spacer(Modifier.height(19.dp))
+            HilingualButton(
+                text = "적용하기",
+                onClick = {
+                    onDateSelected(YearMonth.of(yearState.selectedItem, monthState.selectedItem))
+                    onDismiss()
+                }
+            )
+        }
+    }
+}
+

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/bottomsheet/HilingualYearMonthPickerBottomSheet.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/bottomsheet/HilingualYearMonthPickerBottomSheet.kt
@@ -1,19 +1,27 @@
 package com.hilingual.core.designsystem.component.bottomsheet
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hilingual.core.common.extension.noRippleClickable
 import com.hilingual.core.designsystem.component.button.HilingualButton
 import com.hilingual.core.designsystem.component.datapicker.HilingualYearMonthPicker
+import com.hilingual.core.designsystem.theme.HilingualTheme
 import java.time.YearMonth
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -53,3 +61,38 @@ fun HilingualYearMonthPickerBottomSheet(
     }
 }
 
+@Preview(showBackground = true)
+@Composable
+private fun YearMonthPickerBottomSheetPreview() {
+    HilingualTheme {
+        var isDateBottomSheetVisible by remember { mutableStateOf(false) }
+        var selectedYearMonth by remember { mutableStateOf(YearMonth.now()) }
+
+        if (isDateBottomSheetVisible) {
+            HilingualYearMonthPickerBottomSheet (
+                onDismiss = { isDateBottomSheetVisible = false },
+                onDateSelected = { yearMonth ->
+                    selectedYearMonth = yearMonth
+                },
+                initialYearMonth = selectedYearMonth
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = "${selectedYearMonth.year}년 ${selectedYearMonth.monthValue}월",
+                style = HilingualTheme.typography.bodyB14,
+                modifier = Modifier
+                    .padding(5.dp)
+                    .noRippleClickable(
+                        onClick = { isDateBottomSheetVisible = true }
+                    )
+            )
+        }
+    }
+}

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/bottomsheet/HilingualYearMonthPickerBottomSheet.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/bottomsheet/HilingualYearMonthPickerBottomSheet.kt
@@ -35,8 +35,7 @@ fun HilingualYearMonthPickerBottomSheet(
             modifier = Modifier.padding(16.dp)
         ) {
             HilingualYearMonthPicker(
-                selectedYear = selectedYear,
-                selectedMonth = selectedMonth,
+                initialYearMonth = initialYearMonth,
                 onYearSelected = { selectedYear = it },
                 onMonthSelected = { selectedMonth = it },
             )

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/bottomsheet/HilingualYearMonthPickerBottomSheet.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/bottomsheet/HilingualYearMonthPickerBottomSheet.kt
@@ -2,9 +2,7 @@ package com.hilingual.core.designsystem.component.bottomsheet
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
@@ -28,9 +26,9 @@ import java.time.YearMonth
 @Composable
 fun HilingualYearMonthPickerBottomSheet(
     onDismiss: () -> Unit,
-    modifier: Modifier = Modifier,
-    initialYearMonth: YearMonth = YearMonth.now(),
     onDateSelected: (YearMonth) -> Unit,
+    modifier: Modifier = Modifier,
+    initialYearMonth: YearMonth = YearMonth.now()
 ) {
     var selectedYear by remember { mutableIntStateOf(initialYearMonth.year) }
     var selectedMonth by remember { mutableIntStateOf(initialYearMonth.monthValue) }
@@ -40,6 +38,7 @@ fun HilingualYearMonthPickerBottomSheet(
         modifier = modifier
     ) {
         Column(
+            verticalArrangement = Arrangement.spacedBy(19.dp),
             modifier = Modifier.padding(16.dp)
         ) {
             HilingualYearMonthPicker(
@@ -47,8 +46,6 @@ fun HilingualYearMonthPickerBottomSheet(
                 onYearSelected = { selectedYear = it },
                 onMonthSelected = { selectedMonth = it },
             )
-
-            Spacer(Modifier.height(19.dp))
 
             HilingualButton(
                 text = "적용하기",

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/bottomsheet/HilingualYearMonthPickerBottomSheet.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/bottomsheet/HilingualYearMonthPickerBottomSheet.kt
@@ -6,11 +6,14 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.hilingual.core.designsystem.component.button.HilingualButton
 import com.hilingual.core.designsystem.component.datapicker.HilingualYearMonthPicker
-import com.hilingual.core.designsystem.component.datapicker.rememberPickerState
 import java.time.YearMonth
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -21,8 +24,8 @@ fun HilingualYearMonthPickerBottomSheet(
     initialYearMonth: YearMonth = YearMonth.now(),
     onDateSelected: (YearMonth) -> Unit,
 ) {
-    val yearState = rememberPickerState(initialItem = initialYearMonth.year)
-    val monthState = rememberPickerState(initialItem = initialYearMonth.monthValue)
+    var selectedYear by remember { mutableIntStateOf(initialYearMonth.year) }
+    var selectedMonth by remember { mutableIntStateOf(initialYearMonth.monthValue) }
 
     HilingualBasicBottomSheet(
         onDismiss = onDismiss,
@@ -32,15 +35,18 @@ fun HilingualYearMonthPickerBottomSheet(
             modifier = Modifier.padding(16.dp)
         ) {
             HilingualYearMonthPicker(
-                startLocalDate = initialYearMonth,
-                yearPickerState = yearState,
-                monthPickerState = monthState
+                selectedYear = selectedYear,
+                selectedMonth = selectedMonth,
+                onYearSelected = { selectedYear = it },
+                onMonthSelected = { selectedMonth = it },
             )
+
             Spacer(Modifier.height(19.dp))
+
             HilingualButton(
                 text = "적용하기",
                 onClick = {
-                    onDateSelected(YearMonth.of(yearState.selectedItem, monthState.selectedItem))
+                    onDateSelected(YearMonth.of(selectedYear, selectedMonth))
                     onDismiss()
                 }
             )

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/datapicker/HilingualBasicPicker.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/datapicker/HilingualBasicPicker.kt
@@ -1,6 +1,7 @@
 package com.hilingual.core.designsystem.component.datapicker
 
 import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -20,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.hilingual.core.common.extension.fadingEdge
 import com.hilingual.core.designsystem.theme.HilingualTheme
@@ -34,8 +36,9 @@ fun HilingualBasicPicker(
     startIndex: Int,
     onSelectedItemChanged: (String) -> Unit,
     modifier: Modifier = Modifier,
+    itemContentPadding: PaddingValues,
+    itemSpacing: Dp,
     visibleItemsCount: Int = 3,
-    itemPadding: PaddingValues = PaddingValues(8.dp),
     isInfinity: Boolean = true
 ) {
     val density = LocalDensity.current
@@ -62,8 +65,8 @@ fun HilingualBasicPicker(
 
     val itemHeightDp = with(density) {
         HilingualTheme.typography.bodySB14.fontSize.toDp() +
-                itemPadding.calculateTopPadding() +
-                itemPadding.calculateBottomPadding()
+                itemContentPadding.calculateTopPadding() +
+                itemContentPadding.calculateBottomPadding()
     }
 
     val itemHeightPx = with(density) { itemHeightDp.roundToPx() }
@@ -101,10 +104,11 @@ fun HilingualBasicPicker(
             state = listState,
             flingBehavior = flingBehavior,
             horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(itemSpacing),
             modifier = Modifier
                 .align(Alignment.Center)
                 .wrapContentSize()
-                .height(itemHeightDp * visibleItemsCount)
+                .height(itemHeightDp * visibleItemsCount + itemSpacing * (visibleItemsCount - 1))
                 .fadingEdge(fadingEdgeGradient)
         ) {
             items(

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/datapicker/HilingualBasicPicker.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/datapicker/HilingualBasicPicker.kt
@@ -38,9 +38,9 @@ fun HilingualBasicPicker(
     items: ImmutableList<String>,
     startIndex: Int,
     onSelectedItemChanged: (String) -> Unit,
-    modifier: Modifier = Modifier,
     itemContentPadding: PaddingValues,
     itemSpacing: Dp,
+    modifier: Modifier = Modifier,
     visibleItemsCount: Int = 3,
     isInfinity: Boolean = true
 ) {

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/datapicker/HilingualBasicPicker.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/datapicker/HilingualBasicPicker.kt
@@ -1,0 +1,165 @@
+package com.hilingual.core.designsystem.component.datapicker
+
+import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.hilingual.core.common.extension.fadingEdge
+import com.hilingual.core.designsystem.theme.HilingualTheme
+import com.hilingual.core.designsystem.theme.black
+import com.hilingual.core.designsystem.theme.gray200
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.mapNotNull
+
+@Composable
+fun <T> HilingualBasicPicker(
+    items: ImmutableList<String>,
+    modifier: Modifier = Modifier,
+    state: PickerState<T>,
+    startIndex: Int = 0,
+    visibleItemsCount: Int = 3,
+    itemPadding: PaddingValues = PaddingValues(8.dp),
+    isInfinity: Boolean = true
+) {
+    val density = LocalDensity.current
+    val visibleItemsMiddle = remember { visibleItemsCount / 2 }
+
+    val adjustedItems = if (!isInfinity) {
+        listOf(null) + items + listOf(null)
+    } else {
+        items
+    }
+
+    val listScrollCount = if (isInfinity) {
+        Int.MAX_VALUE
+    } else {
+        adjustedItems.size
+    }
+
+    val listScrollMiddle = remember { listScrollCount / 2 }
+    val listStartIndex = remember {
+        if (isInfinity) {
+            listScrollMiddle - listScrollMiddle % adjustedItems.size - visibleItemsMiddle + startIndex
+        } else {
+            startIndex + 1
+        }
+    }
+
+    fun getItem(index: Int) = adjustedItems[index % adjustedItems.size]
+
+    val listState = rememberLazyListState(initialFirstVisibleItemIndex = listStartIndex)
+    val flingBehavior = rememberSnapFlingBehavior(lazyListState = listState)
+
+    val itemHeight = with(density) {
+        HilingualTheme.typography.bodySB14.fontSize.toDp() +
+                itemPadding.calculateTopPadding() +
+                itemPadding.calculateBottomPadding()
+    }
+
+    val fadingEdgeGradient = remember {
+        Brush.verticalGradient(
+            0f to gray200,
+            0.5f to black,
+            1f to gray200
+        )
+    }
+
+    LaunchedEffect(listState) {
+        snapshotFlow { listState.firstVisibleItemIndex }
+            .mapNotNull { index -> getItem(index + visibleItemsMiddle) }
+            .distinctUntilChanged()
+            .collect {
+                state.selectedItem = it as T
+            }
+    }
+
+    Box(modifier = modifier) {
+        LazyColumn(
+            state = listState,
+            flingBehavior = flingBehavior,
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .align(Alignment.Center)
+                .wrapContentSize()
+                .height(itemHeight * visibleItemsCount)
+                .fadingEdge(fadingEdgeGradient)
+        ) {
+            items(
+                listScrollCount,
+                key = { it },
+            ) { index ->
+                val currentItemText by remember {
+                    mutableStateOf(if (getItem(index) == null) "" else getItem(index).toString())
+                }
+
+                Text(
+                    text = currentItemText,
+                    maxLines = 1,
+                    color = HilingualTheme.colors.black,
+                    style = HilingualTheme.typography.headSB20,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .height(itemHeight)
+                        .wrapContentHeight(align = Alignment.CenterVertically)
+                        .fillMaxWidth()
+                )
+            }
+        }
+
+        Box(
+            modifier = Modifier
+                .align(Alignment.Center)
+                .fillMaxWidth()
+                .height(itemHeight)
+        ) {
+            HorizontalDivider(
+                color = HilingualTheme.colors.black,
+                thickness = 1.dp,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .align(Alignment.BottomCenter)
+            )
+
+            HorizontalDivider(
+                color = HilingualTheme.colors.black,
+                thickness = 1.dp,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .align(Alignment.BottomCenter)
+            )
+        }
+    }
+}
+
+@Composable
+fun <T> rememberPickerState(initialItem: T) = remember { PickerState(initialItem) }
+
+class PickerState<String>(
+    initialItem: String
+) {
+    /**
+     * The currently selected item.
+     */
+    var selectedItem by mutableStateOf(initialItem)
+}

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/datapicker/HilingualBasicPicker.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/datapicker/HilingualBasicPicker.kt
@@ -14,7 +14,10 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -58,6 +61,8 @@ fun HilingualBasicPicker(
         startIndex + 1
     }
 
+    var currentCenterIndex by remember(visibleItemsMiddle) { mutableIntStateOf(listStartIndex + visibleItemsMiddle) }
+
     fun getItem(index: Int) = adjustedItems[index % adjustedItems.size]
 
     val listState = rememberLazyListState(initialFirstVisibleItemIndex = listStartIndex)
@@ -86,13 +91,13 @@ fun HilingualBasicPicker(
         }
             .distinctUntilChanged()
             .collect { (index, offset) ->
-                val centerIndex = calculateCenterIndex(
+                currentCenterIndex = calculateCenterIndex(
                     firstVisibleItemIndex = index,
                     firstVisibleItemScrollOffset = offset,
                     itemHeightPx = itemHeightPx,
                     visibleItemsMiddle = visibleItemsMiddle
                 )
-                val selectedItem = getItem(centerIndex)
+                val selectedItem = getItem(currentCenterIndex)
                 if (selectedItem != null) {
                     onSelectedItemChanged(selectedItem)
                 }
@@ -116,11 +121,17 @@ fun HilingualBasicPicker(
                 key = { it }
             ) { index ->
                 val currentItemText = getItem(index)?.toString().orEmpty()
+                val isSelected = index == currentCenterIndex
+
+                val textColor = remember (isSelected) {
+                    if (isSelected) black
+                    else gray200
+                }
 
                 Text(
                     text = currentItemText,
                     maxLines = 1,
-                    color = HilingualTheme.colors.black,
+                    color = textColor,
                     style = HilingualTheme.typography.headSB20,
                     textAlign = TextAlign.Center,
                     modifier = Modifier

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/datapicker/HilingualBasicPicker.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/datapicker/HilingualBasicPicker.kt
@@ -85,7 +85,7 @@ fun HilingualBasicPicker(
     }
 
     // 중앙 아이템 변경 감지
-    LaunchedEffect(listState) {
+    LaunchedEffect(Unit) {
         snapshotFlow {
             listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset
         }
@@ -168,7 +168,7 @@ fun HilingualBasicPicker(
     }
 }
 
-fun calculateCenterIndex(
+private fun calculateCenterIndex(
     firstVisibleItemIndex: Int,
     firstVisibleItemScrollOffset: Int,
     itemHeightPx: Int,

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/datapicker/HilingualYearMonthPicker.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/datapicker/HilingualYearMonthPicker.kt
@@ -9,27 +9,24 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.hilingual.core.designsystem.theme.HilingualTheme
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
-import java.time.YearMonth
 
-private val CURRENT_YEAR_MONTH = YearMonth.now()
 private val YEAR_RANGE = (1000..9999).map { "${it}년" }.toImmutableList()
 private val MONTH_RANGE = (1..12).map { "${it}월" }.toImmutableList()
 
 @Composable
 fun HilingualYearMonthPicker(
+    selectedYear: Int,
+    selectedMonth: Int,
+    onYearSelected: (Int) -> Unit,
+    onMonthSelected: (Int) -> Unit,
     modifier: Modifier = Modifier,
-    yearPickerState: PickerState<Int> = rememberPickerState(CURRENT_YEAR_MONTH.year),
-    monthPickerState: PickerState<Int> = rememberPickerState(CURRENT_YEAR_MONTH.monthValue),
-    startLocalDate: YearMonth = CURRENT_YEAR_MONTH,
     yearItems: ImmutableList<String> = YEAR_RANGE,
     monthItems: ImmutableList<String> = MONTH_RANGE,
     visibleItemsCount: Int = 3,
@@ -42,19 +39,8 @@ fun HilingualYearMonthPicker(
             verticalArrangement = Arrangement.Center,
             modifier = Modifier.fillMaxWidth()
         ) {
-
-            val yearStartIndex = remember {
-                val matchYear = yearItems.find {
-                    it.contains(startLocalDate.year.toString())
-                }
-                yearItems.indexOf(matchYear)
-            }
-            val monthStartIndex = remember {
-                val matchMonth = yearItems.find {
-                    it.contains(startLocalDate.monthValue.toString())
-                }
-                monthItems.indexOf(matchMonth)
-            }
+            val yearStartIndex = yearItems.indexOf("${selectedYear}년")
+            val monthStartIndex = monthItems.indexOf("${selectedMonth}월")
 
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -64,19 +50,24 @@ fun HilingualYearMonthPicker(
                 ),
             ) {
                 HilingualBasicPicker(
-                    state = yearPickerState,
-                    modifier = Modifier.width(89.dp),
                     items = yearItems,
                     startIndex = yearStartIndex,
+                    onSelectedItemChanged = { selected ->
+                        onYearSelected(selected.filter { it.isDigit() }.toInt())
+                    },
+                    modifier = Modifier.width(89.dp),
                     itemPadding = itemPadding,
                 )
+
                 HilingualBasicPicker(
-                    state = monthPickerState,
                     items = monthItems,
                     startIndex = monthStartIndex,
-                    visibleItemsCount = visibleItemsCount,
+                    onSelectedItemChanged = { selected ->
+                        onMonthSelected(selected.filter { it.isDigit() }.toInt())
+                    },
                     modifier = Modifier.width(54.dp),
                     itemPadding = itemPadding,
+                    visibleItemsCount = visibleItemsCount
                 )
             }
         }

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/datapicker/HilingualYearMonthPicker.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/datapicker/HilingualYearMonthPicker.kt
@@ -15,14 +15,14 @@ import androidx.compose.ui.unit.dp
 import com.hilingual.core.designsystem.theme.HilingualTheme
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
+import java.time.YearMonth
 
 private val YEAR_RANGE = (1000..9999).map { "${it}년" }.toImmutableList()
 private val MONTH_RANGE = (1..12).map { "${it}월" }.toImmutableList()
 
 @Composable
 fun HilingualYearMonthPicker(
-    selectedYear: Int,
-    selectedMonth: Int,
+    initialYearMonth: YearMonth,
     onYearSelected: (Int) -> Unit,
     onMonthSelected: (Int) -> Unit,
     modifier: Modifier = Modifier,
@@ -40,8 +40,8 @@ fun HilingualYearMonthPicker(
             .fillMaxWidth()
             .background(HilingualTheme.colors.white)
     ) {
-        val yearStartIndex = yearItems.indexOf("${selectedYear}년")
-        val monthStartIndex = monthItems.indexOf("${selectedMonth}월")
+        val yearStartIndex = yearItems.indexOf("${initialYearMonth.year}년")
+        val monthStartIndex = monthItems.indexOf("${initialYearMonth.monthValue}월")
 
         Row(
             modifier = Modifier.fillMaxWidth(),

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/datapicker/HilingualYearMonthPicker.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/datapicker/HilingualYearMonthPicker.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.width
-import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -34,46 +33,46 @@ fun HilingualYearMonthPicker(
     itemContentPadding: PaddingValues = PaddingValues(vertical = 16.dp, horizontal = 12.dp),
     spacingBetweenPickers: Dp = 44.dp,
 ) {
-    Surface(modifier = modifier.background(HilingualTheme.colors.white)) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center,
-            modifier = Modifier.fillMaxWidth()
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+        modifier = modifier
+            .fillMaxWidth()
+            .background(HilingualTheme.colors.white)
+    ) {
+        val yearStartIndex = yearItems.indexOf("${selectedYear}년")
+        val monthStartIndex = monthItems.indexOf("${selectedMonth}월")
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(
+                spacingBetweenPickers,
+                Alignment.CenterHorizontally
+            ),
         ) {
-            val yearStartIndex = yearItems.indexOf("${selectedYear}년")
-            val monthStartIndex = monthItems.indexOf("${selectedMonth}월")
+            HilingualBasicPicker(
+                items = yearItems,
+                startIndex = yearStartIndex,
+                onSelectedItemChanged = { selected ->
+                    onYearSelected(selected.filter { it.isDigit() }.toInt())
+                },
+                modifier = Modifier.width(89.dp),
+                itemContentPadding = itemContentPadding,
+                itemSpacing = itemSpacing,
+                visibleItemsCount = visibleItemsCount
+            )
 
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(
-                    spacingBetweenPickers,
-                    Alignment.CenterHorizontally
-                ),
-            ) {
-                HilingualBasicPicker(
-                    items = yearItems,
-                    startIndex = yearStartIndex,
-                    onSelectedItemChanged = { selected ->
-                        onYearSelected(selected.filter { it.isDigit() }.toInt())
-                    },
-                    modifier = Modifier.width(89.dp),
-                    itemContentPadding = itemContentPadding,
-                    itemSpacing = itemSpacing,
-                    visibleItemsCount = visibleItemsCount
-                )
-
-                HilingualBasicPicker(
-                    items = monthItems,
-                    startIndex = monthStartIndex,
-                    onSelectedItemChanged = { selected ->
-                        onMonthSelected(selected.filter { it.isDigit() }.toInt())
-                    },
-                    modifier = Modifier.width(54.dp),
-                    itemContentPadding = itemContentPadding,
-                    itemSpacing = itemSpacing,
-                    visibleItemsCount = visibleItemsCount
-                )
-            }
+            HilingualBasicPicker(
+                items = monthItems,
+                startIndex = monthStartIndex,
+                onSelectedItemChanged = { selected ->
+                    onMonthSelected(selected.filter { it.isDigit() }.toInt())
+                },
+                modifier = Modifier.width(54.dp),
+                itemContentPadding = itemContentPadding,
+                itemSpacing = itemSpacing,
+                visibleItemsCount = visibleItemsCount
+            )
         }
     }
 }

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/datapicker/HilingualYearMonthPicker.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/datapicker/HilingualYearMonthPicker.kt
@@ -30,7 +30,8 @@ fun HilingualYearMonthPicker(
     yearItems: ImmutableList<String> = YEAR_RANGE,
     monthItems: ImmutableList<String> = MONTH_RANGE,
     visibleItemsCount: Int = 3,
-    itemPadding: PaddingValues = PaddingValues(10.dp),
+    itemSpacing: Dp = 10.dp,
+    itemContentPadding: PaddingValues = PaddingValues(vertical = 16.dp, horizontal = 12.dp),
     spacingBetweenPickers: Dp = 44.dp,
 ) {
     Surface(modifier = modifier.background(HilingualTheme.colors.white)) {
@@ -56,7 +57,9 @@ fun HilingualYearMonthPicker(
                         onYearSelected(selected.filter { it.isDigit() }.toInt())
                     },
                     modifier = Modifier.width(89.dp),
-                    itemPadding = itemPadding,
+                    itemContentPadding = itemContentPadding,
+                    itemSpacing = itemSpacing,
+                    visibleItemsCount = visibleItemsCount
                 )
 
                 HilingualBasicPicker(
@@ -66,7 +69,8 @@ fun HilingualYearMonthPicker(
                         onMonthSelected(selected.filter { it.isDigit() }.toInt())
                     },
                     modifier = Modifier.width(54.dp),
-                    itemPadding = itemPadding,
+                    itemContentPadding = itemContentPadding,
+                    itemSpacing = itemSpacing,
                     visibleItemsCount = visibleItemsCount
                 )
             }

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/datapicker/HilingualYearMonthPicker.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/datapicker/HilingualYearMonthPicker.kt
@@ -1,0 +1,84 @@
+package com.hilingual.core.designsystem.component.datapicker
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.hilingual.core.designsystem.theme.HilingualTheme
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+import java.time.YearMonth
+
+private val CURRENT_YEAR_MONTH = YearMonth.now()
+private val YEAR_RANGE = (1000..9999).map { "${it}년" }.toImmutableList()
+private val MONTH_RANGE = (1..12).map { "${it}월" }.toImmutableList()
+
+@Composable
+fun HilingualYearMonthPicker(
+    modifier: Modifier = Modifier,
+    yearPickerState: PickerState<Int> = rememberPickerState(CURRENT_YEAR_MONTH.year),
+    monthPickerState: PickerState<Int> = rememberPickerState(CURRENT_YEAR_MONTH.monthValue),
+    startLocalDate: YearMonth = CURRENT_YEAR_MONTH,
+    yearItems: ImmutableList<String> = YEAR_RANGE,
+    monthItems: ImmutableList<String> = MONTH_RANGE,
+    visibleItemsCount: Int = 3,
+    itemPadding: PaddingValues = PaddingValues(10.dp),
+    spacingBetweenPickers: Dp = 44.dp,
+) {
+    Surface(modifier = modifier.background(HilingualTheme.colors.white)) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+
+            val yearStartIndex = remember {
+                val matchYear = yearItems.find {
+                    it.contains(startLocalDate.year.toString())
+                }
+                yearItems.indexOf(matchYear)
+            }
+            val monthStartIndex = remember {
+                val matchMonth = yearItems.find {
+                    it.contains(startLocalDate.monthValue.toString())
+                }
+                monthItems.indexOf(matchMonth)
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(
+                    spacingBetweenPickers,
+                    Alignment.CenterHorizontally
+                ),
+            ) {
+                HilingualBasicPicker(
+                    state = yearPickerState,
+                    modifier = Modifier.width(89.dp),
+                    items = yearItems,
+                    startIndex = yearStartIndex,
+                    itemPadding = itemPadding,
+                )
+                HilingualBasicPicker(
+                    state = monthPickerState,
+                    items = monthItems,
+                    startIndex = monthStartIndex,
+                    visibleItemsCount = visibleItemsCount,
+                    modifier = Modifier.width(54.dp),
+                    itemPadding = itemPadding,
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #20 

## Work Description ✏️
- 캘린더 이동 시에 사용할 YearMonthPicker 들어간 바텀시트 구현했어요.

## Screenshot 📸
https://github.com/user-attachments/assets/a329f967-c804-4401-8890-a6e113ac1fd2


## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
- @angryPodo 달력에서 YearMonth 쓰시는 것 같아서 해당 형태로 넘겨드렸는데.. 혹시 원하시는 타입이 따로 있으시면 말씀해 주세요!
- itemPadding이 GUI 상으로는 10dp인데 실제로 10dp로 설정하면 뭔가 묘하게 좁은 느낌이더라구요. 그래서 좀 더 넓혀서 16dp로 설정했습니다! 감안하고 봐주세요ㅎㅎ.. 혹시 해결 방법을 아신다면 리뷰 부탁드립니다.
- 프리뷰 추가해놔서 Interactive Mode로 설정하시면 피커 동작 확인하실 수 있습니다.
- 처음 구현해보는 거라 잘 구현했는지 모르겠어요.. 부족한 부분은 댓글 마구 남겨주시면 빠르게 확인하고 수정하겠습니다