### PR TITLE
[FEAT/#34] TextField 디자인 시스템 구현

### DIFF
--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/textfield/HilingualBasicTextField.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/textfield/HilingualBasicTextField.kt
@@ -1,0 +1,135 @@
+package com.hilingual.core.designsystem.component.textfield
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import com.hilingual.core.designsystem.theme.HilingualTheme
+
+@Composable
+fun HilingualBasicTextField(
+    value: String,
+    placeholder: String,
+    textStyle: TextStyle,
+    onValueChanged: (String) -> Unit,
+    onFocusChanged: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+    borderModifier: Modifier = Modifier,
+    backgroundColor: Color = HilingualTheme.colors.gray100,
+    focusRequester: FocusRequester = FocusRequester(),
+    singleLine: Boolean = true,  // 한 줄 입력만 허용할지 여부
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    keyboardImeAction: ImeAction = ImeAction.Done,  // 키보드 오른쪽 아래 버튼 (기본값: Done)
+    onDoneAction: () -> Unit = {},  // 키보드의 완료 액션이 눌렸을 때 실행되는 콜백
+    onSearchAction: () -> Unit = {},  // 키보드의 검색 액션이 눌렸을 때 실행되는 콜백
+    bottomRightContent: @Composable (() -> Unit)? = null
+) {
+    BasicTextField(
+        value = value,
+        onValueChange = onValueChanged,
+        modifier = modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(backgroundColor)
+            .then(borderModifier)
+            .padding(horizontal = 12.dp)
+            .focusRequester(focusRequester)
+            .onFocusChanged { focusState ->
+                onFocusChanged(focusState.isFocused)
+            },
+        singleLine = singleLine,
+        keyboardOptions = KeyboardOptions(imeAction = keyboardImeAction),
+        keyboardActions = KeyboardActions(
+            onDone = { onDoneAction() },
+            onSearch = { onSearchAction() }
+        ),
+        textStyle = textStyle.copy(
+            color = HilingualTheme.colors.black
+        ),
+        decorationBox = { innerTextField ->
+            Box {
+                val columnModifier = if (bottomRightContent == null) {
+                    Modifier.fillMaxSize()
+                } else {
+                    Modifier
+                        .fillMaxSize()
+                        .padding(top = 12.dp, bottom = 39.dp)
+                }
+
+                val columnVerticalArrangement = if (bottomRightContent == null) {
+                    Arrangement.Center
+                } else {
+                    Arrangement.SpaceBetween
+                }
+
+                val rowVerticalAlignment = if (bottomRightContent == null) {
+                    Alignment.CenterVertically
+                } else {
+                    Alignment.Top
+                }
+
+                Column(
+                    modifier = columnModifier,
+                    verticalArrangement = columnVerticalArrangement
+                ) {
+                    // 아이콘-텍스트-아이콘 영역
+                    Row(
+                        verticalAlignment = rowVerticalAlignment
+                    ) {
+                        // 아이콘
+                        leadingIcon?.let { it() }
+
+                        // 텍스트
+                        Box(
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            innerTextField()
+                            // placeholder
+                            if (value.isEmpty()) {
+                                Text(
+                                    text = placeholder,
+                                    color = HilingualTheme.colors.gray400,
+                                    style = textStyle
+                                )
+                            }
+                        }
+
+                        // 아이콘
+                        trailingIcon?.let { it() }
+                    }
+                }
+
+                // 하단 영역 (존재하는 경우에만)
+                bottomRightContent?.let {
+                    Row(
+                        modifier = Modifier
+                            .align(Alignment.BottomEnd)
+                            .padding(vertical = 12.dp),
+                        horizontalArrangement = Arrangement.End
+                    ) {
+                        it()
+                    }
+                }
+            }
+        }
+    )
+}

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/textfield/HilingualBasicTextField.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/textfield/HilingualBasicTextField.kt
@@ -31,8 +31,8 @@ fun HilingualBasicTextField(
     placeholder: String,
     textStyle: TextStyle,
     onValueChanged: (String) -> Unit,
-    onFocusChanged: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
+    onFocusChanged: (Boolean) -> Unit = {},
     borderModifier: Modifier = Modifier,
     backgroundColor: Color = HilingualTheme.colors.gray100,
     focusRequester: FocusRequester = FocusRequester(),
@@ -120,11 +120,10 @@ fun HilingualBasicTextField(
 
                 // 하단 영역 (존재하는 경우에만)
                 bottomRightContent?.let {
-                    Row(
+                    Box(
                         modifier = Modifier
                             .align(Alignment.BottomEnd)
-                            .padding(vertical = 12.dp),
-                        horizontalArrangement = Arrangement.End
+                            .padding(vertical = 12.dp)
                     ) {
                         it()
                     }

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/textfield/HilingualLongTextField.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/textfield/HilingualLongTextField.kt
@@ -1,0 +1,85 @@
+package com.hilingual.core.designsystem.component.textfield
+
+import android.widget.Toast
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hilingual.core.designsystem.theme.HilingualTheme
+
+@Composable
+fun HilingualLongTextField(
+    value: String,
+    placeholder: String = "What's been going on today?",
+    onValueChanged: (String) -> Unit,
+    onDoneAction: () -> Unit = {},
+    maxLength: Int
+) {
+    var isFocused by remember { mutableStateOf(false) }
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    HilingualBasicTextField(
+        value = value,
+        placeholder = placeholder,
+        textStyle = HilingualTheme.typography.bodyM16,
+        onValueChanged = {
+            if (it.length <= maxLength) onValueChanged(it)
+        },
+        onFocusChanged = { isFocused = it },
+        modifier = Modifier
+            .verticalScroll(rememberScrollState())
+            .height(292.dp),
+        borderModifier = if (isFocused) {
+            Modifier.border(
+                1.dp,
+                HilingualTheme.colors.black,
+                RoundedCornerShape(8.dp)
+            )
+        } else {
+            Modifier
+        },
+        singleLine = false,
+        onDoneAction = {
+            onDoneAction()
+            keyboardController?.hide()
+        },
+        bottomRightContent = {
+            Text(
+                text = "${value.length} / $maxLength",
+                style = HilingualTheme.typography.captionR12,
+                color = HilingualTheme.colors.gray400
+            )
+        }
+    )
+}
+
+@Preview
+@Composable
+private fun HilingualLongTextFieldPreview() {
+    var text by remember { mutableStateOf("") }
+    val context = LocalContext.current
+
+    HilingualTheme {
+        HilingualLongTextField(
+            value = text,
+            onValueChanged = { text = it },
+            onDoneAction = {
+                Toast.makeText(context, "Enter key pressed with text: $text", Toast.LENGTH_SHORT)
+                    .show()
+            },
+            maxLength = 100
+        )
+    }
+}

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/textfield/HilingualLongTextField.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/textfield/HilingualLongTextField.kt
@@ -16,16 +16,19 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.hilingual.core.designsystem.theme.HilingualTheme
 
 @Composable
 fun HilingualLongTextField(
     value: String,
-    placeholder: String = "What's been going on today?",
     onValueChanged: (String) -> Unit,
+    maxLength: Int,
+    modifier: Modifier = Modifier,
+    height: Dp = 292.dp,
+    placeholder: String = "What's been going on today?",
     onDoneAction: () -> Unit = {},
-    maxLength: Int
 ) {
     var isFocused by remember { mutableStateOf(false) }
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -38,9 +41,9 @@ fun HilingualLongTextField(
             if (it.length <= maxLength) onValueChanged(it)
         },
         onFocusChanged = { isFocused = it },
-        modifier = Modifier
+        modifier = modifier
             .verticalScroll(rememberScrollState())
-            .height(292.dp),
+            .height(height),
         borderModifier = if (isFocused) {
             Modifier.border(
                 1.dp,

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/textfield/HilingualSearchTextField.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/textfield/HilingualSearchTextField.kt
@@ -50,11 +50,6 @@ fun HilingualSearchTextField(
                 modifier = Modifier
                     .padding(end = 4.dp)
                     .size(20.dp)
-                    .noRippleClickable(
-                        onClick = {
-                            onValueChanged("")
-                        }
-                    )
             )
         },
         trailingIcon = {

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/textfield/HilingualSearchTextField.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/textfield/HilingualSearchTextField.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.hilingual.core.common.extension.noRippleClickable
 import com.hilingual.core.designsystem.R
@@ -26,11 +27,12 @@ import com.hilingual.core.designsystem.theme.HilingualTheme
 @Composable
 fun HilingualSearchTextField(
     value: String,
-    placeholder: String = "단어나 표현을 검색해 주세요",
     onValueChanged: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    height: Dp = 46.dp,
+    placeholder: String = "단어나 표현을 검색해 주세요",
     onSearchAction: () -> Unit = {}
 ) {
-    var isFocused by remember { mutableStateOf(false) }
     val keyboardController = LocalSoftwareKeyboardController.current
 
     HilingualBasicTextField(
@@ -38,8 +40,7 @@ fun HilingualSearchTextField(
         placeholder = placeholder,
         textStyle = HilingualTheme.typography.bodyM16,
         onValueChanged = onValueChanged,
-        onFocusChanged = { isFocused = it },
-        modifier = Modifier.height(46.dp),
+        modifier = modifier.height(height),
         backgroundColor = HilingualTheme.colors.white,
         leadingIcon = {
             Icon(

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/textfield/HilingualSearchTextField.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/textfield/HilingualSearchTextField.kt
@@ -1,0 +1,100 @@
+package com.hilingual.core.designsystem.component.textfield
+
+import android.widget.Toast
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hilingual.core.common.extension.noRippleClickable
+import com.hilingual.core.designsystem.R
+import com.hilingual.core.designsystem.theme.HilingualTheme
+
+@Composable
+fun HilingualSearchTextField(
+    value: String,
+    placeholder: String = "단어나 표현을 검색해 주세요",
+    onValueChanged: (String) -> Unit,
+    onSearchAction: () -> Unit = {}
+) {
+    var isFocused by remember { mutableStateOf(false) }
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    HilingualBasicTextField(
+        value = value,
+        placeholder = placeholder,
+        textStyle = HilingualTheme.typography.bodyM16,
+        onValueChanged = onValueChanged,
+        onFocusChanged = { isFocused = it },
+        modifier = Modifier.height(46.dp),
+        backgroundColor = HilingualTheme.colors.white,
+        leadingIcon = {
+            Icon(
+                imageVector = ImageVector.vectorResource(R.drawable.ic_search_20),
+                contentDescription = null,
+                tint = HilingualTheme.colors.gray500,
+                modifier = Modifier
+                    .padding(end = 4.dp)
+                    .size(20.dp)
+                    .noRippleClickable(
+                        onClick = {
+                            onValueChanged("")
+                        }
+                    )
+            )
+        },
+        trailingIcon = {
+            if (value.isNotEmpty()) {
+                Icon(
+                    imageVector = ImageVector.vectorResource(R.drawable.ic_cancel_20),
+                    contentDescription = null,
+                    tint = Color.Unspecified,
+                    modifier = Modifier
+                        .padding(start = 4.dp)
+                        .size(20.dp)
+                        .noRippleClickable(
+                            onClick = {
+                                onValueChanged("")
+                            }
+                        )
+                )
+            }
+        },
+        keyboardImeAction = ImeAction.Search,
+        onSearchAction = {
+            onSearchAction()
+            keyboardController?.hide()
+        }
+    )
+}
+
+@Preview
+@Composable
+private fun HilingualSearchTextFieldPreview() {
+    var text by remember { mutableStateOf("") }
+    val context = LocalContext.current
+
+    HilingualTheme {
+        HilingualSearchTextField(
+            value = text,
+            onValueChanged = { text = it },
+            onSearchAction = {
+                Toast.makeText(context, "Enter key pressed with text: $text", Toast.LENGTH_SHORT)
+                    .show()
+            }
+        )
+    }
+}

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/textfield/HilingualShortTextField.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/textfield/HilingualShortTextField.kt
@@ -1,0 +1,114 @@
+package com.hilingual.core.designsystem.component.textfield
+
+import android.widget.Toast
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hilingual.core.designsystem.theme.HilingualTheme
+
+@Composable
+fun HilingualShortTextField(
+    value: String,
+    placeholder: String,
+    onValueChanged: (String) -> Unit,
+    onDoneAction: () -> Unit = {},
+    maxLength: Int,
+    isValid: () -> Boolean,  // 유효성 검사 함수
+    errorMessage: String,
+    successMessage: String
+) {
+    var isFocused by remember { mutableStateOf(false) }
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    // 입력값(value)에 따른 케이스 분기 처리
+    val isError = value.isNotEmpty() && !isValid()
+    val isSuccess = value.isNotEmpty() && isValid()
+
+    Column(
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        HilingualBasicTextField(
+            value = value,
+            placeholder = placeholder,
+            textStyle = HilingualTheme.typography.bodyM16,
+            onValueChanged = {
+                if (it.length <= maxLength) onValueChanged(it)
+            },
+            onFocusChanged = { isFocused = it },
+            modifier = Modifier.height(54.dp),
+            borderModifier = Modifier.border(
+                width = 1.dp,
+                color = if (isError) HilingualTheme.colors.alertRed else Color.Transparent,
+                shape = RoundedCornerShape(8.dp)
+            ),
+            onDoneAction = {
+                onDoneAction()
+                keyboardController?.hide()
+            },
+        )
+        Row {
+            // 오류 또는 성공 메시지
+            Text(
+                text = when {
+                    isError -> errorMessage
+                    isSuccess -> successMessage
+                    else -> ""
+                },
+                style = HilingualTheme.typography.captionR12,
+                color = when {
+                    isError -> HilingualTheme.colors.alertRed
+                    isSuccess -> HilingualTheme.colors.hilingualBlue
+                    else -> Color.Transparent
+                }
+            )
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            // 글자 수 표시
+            Text(
+                text = "${value.length} / $maxLength",
+                style = HilingualTheme.typography.captionR12,
+                color = HilingualTheme.colors.gray300
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun HilingualShortTextFieldPreview() {
+    var text by remember { mutableStateOf("") }
+    val context = LocalContext.current
+
+    HilingualTheme {
+        HilingualShortTextField(
+            value = text,
+            placeholder = "한글, 영문, 숫자 조합만 가능",
+            onValueChanged = { text = it },
+            onDoneAction = {
+                Toast.makeText(context, "Enter key pressed with text: $text", Toast.LENGTH_SHORT)
+                    .show()
+            },
+            maxLength = 10,
+            isValid = { text.matches(Regex("^[가-힣a-zA-Z0-9]+$")) },
+            errorMessage = "한글, 영문, 숫자만 입력 가능합니다.",
+            successMessage = "올바른 형식입니다."
+        )
+    }
+}

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/textfield/HilingualShortTextField.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/textfield/HilingualShortTextField.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.hilingual.core.designsystem.theme.HilingualTheme
 
@@ -27,13 +28,14 @@ fun HilingualShortTextField(
     value: String,
     placeholder: String,
     onValueChanged: (String) -> Unit,
-    onDoneAction: () -> Unit = {},
     maxLength: Int,
     isValid: () -> Boolean,  // 유효성 검사 함수
     errorMessage: String,
-    successMessage: String
+    successMessage: String,
+    modifier: Modifier = Modifier,
+    height: Dp = 54.dp,
+    onDoneAction: () -> Unit = {},
 ) {
-    var isFocused by remember { mutableStateOf(false) }
     val keyboardController = LocalSoftwareKeyboardController.current
 
     // 입력값(value)에 따른 케이스 분기 처리
@@ -50,8 +52,7 @@ fun HilingualShortTextField(
             onValueChanged = {
                 if (it.length <= maxLength) onValueChanged(it)
             },
-            onFocusChanged = { isFocused = it },
-            modifier = Modifier.height(54.dp),
+            modifier = modifier.height(height),
             borderModifier = Modifier.border(
                 width = 1.dp,
                 color = if (isError) HilingualTheme.colors.alertRed else Color.Transparent,

--- a/core/designsystem/src/main/res/drawable/ic_cancel_20.xml
+++ b/core/designsystem/src/main/res/drawable/ic_cancel_20.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+  <path
+      android:pathData="M10,1L10,1A9,9 0,0 1,19 10L19,10A9,9 0,0 1,10 19L10,19A9,9 0,0 1,1 10L1,10A9,9 0,0 1,10 1z"
+      android:fillColor="#9E9E9E"/>
+  <path
+      android:pathData="M13,7L7,13M7,7L13,13"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#F5F5F5"
+      android:strokeLineCap="round"/>
+</vector>

--- a/core/designsystem/src/main/res/drawable/ic_search_20.xml
+++ b/core/designsystem/src/main/res/drawable/ic_search_20.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+  <path
+      android:pathData="M17.5,17.5L13.883,13.883"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.66667"
+      android:fillColor="#00000000"
+      android:strokeColor="#757575"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M9.167,15.833C12.849,15.833 15.833,12.849 15.833,9.167C15.833,5.485 12.849,2.5 9.167,2.5C5.485,2.5 2.5,5.485 2.5,9.167C2.5,12.849 5.485,15.833 9.167,15.833Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.66667"
+      android:fillColor="#00000000"
+      android:strokeColor="#757575"
+      android:strokeLineCap="round"/>
+</vector>


### PR DESCRIPTION
## Related issue 🛠
- closed #34

## Work Description ✏️
- 3가지 종류의 TextField를 구현했습니다

## Screenshot 📸

https://github.com/user-attachments/assets/9931836c-76b8-4b4a-b0b4-f0258953152b

https://github.com/user-attachments/assets/7ee4407a-8e3b-4684-a4e6-86b86859a788

https://github.com/user-attachments/assets/f9f7ee7d-eb9c-471c-860a-59ae44499d21

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
- BasicTextField를 기반으로 Search, Short, Long에 해당하는 TextField를 구현했습니다 (그래서 BasicTextField에는 Preview가 따로 없어요)
- Screenshot 중에 LongTextField에 해당하는 영상에 나오는 Preview는 임시로 세로 길이를 줄여서 캡쳐한 화면입니다. 지금은 다시 292dp로 변경해 뒀어요.
- TextField 디자인이 제각각이라서 BasicTextField에서 케이스를 나누는 작업이 필요했는데, 이렇게 구현하는 게 맞는지, 개선해야 할 부분이 있는지 알려주심 감사하겠습니당