### PR TITLE
[FEAT/#80] 원본 이미지 확인 화면 UI 구현

### DIFF
--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/PhotoDetailModal.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/PhotoDetailModal.kt
@@ -16,7 +16,7 @@ import com.hilingual.core.designsystem.theme.HilingualTheme
 
 //TODO: sharedTransition 사용
 @Composable
-internal fun PhotoDetailView(
+internal fun PhotoDetailModal(
     imageUrl: String,
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier
@@ -46,7 +46,7 @@ internal fun PhotoDetailView(
 @Composable
 private fun PhotoDetailPreview() {
     HilingualTheme {
-        PhotoDetailView(
+        PhotoDetailModal(
             imageUrl = "",
             onBackClick = {}
         )

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/PhotoDetailView.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/PhotoDetailView.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.tooling.preview.Preview
 import com.hilingual.core.designsystem.component.image.NetworkImage
 import com.hilingual.core.designsystem.component.topappbar.CloseOnlyTopAppBar
@@ -17,7 +18,7 @@ import com.hilingual.core.designsystem.theme.HilingualTheme
 @Composable
 internal fun PhotoDetailView(
     imageUrl: String,
-    onClickBack: () -> Unit,
+    onBackClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Box(
@@ -26,13 +27,14 @@ internal fun PhotoDetailView(
             .background(HilingualTheme.colors.black)
     ) {
         CloseOnlyTopAppBar(
-            onCloseClicked = onClickBack,
+            onCloseClicked = onBackClick,
             modifier = Modifier.align(Alignment.TopCenter)
         )
 
         NetworkImage(
             imageUrl = imageUrl,
             shape = RectangleShape,
+            contentScale = ContentScale.FillWidth,
             modifier = Modifier
                 .fillMaxWidth()
                 .align(Alignment.Center)
@@ -46,7 +48,7 @@ private fun PhotoDetailPreview() {
     HilingualTheme {
         PhotoDetailView(
             imageUrl = "",
-            onClickBack = {}
+            onBackClick = {}
         )
     }
 }

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/PhotoDetailView.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/PhotoDetailView.kt
@@ -1,0 +1,52 @@
+package com.hilingual.presentation.diaryfeedback
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.tooling.preview.Preview
+import com.hilingual.core.designsystem.component.image.NetworkImage
+import com.hilingual.core.designsystem.component.topappbar.CloseOnlyTopAppBar
+import com.hilingual.core.designsystem.theme.HilingualTheme
+
+//TODO: sharedTransition 사용
+@Composable
+internal fun PhotoDetailView(
+    imageUrl: String,
+    onClickBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(HilingualTheme.colors.black)
+    ) {
+        CloseOnlyTopAppBar(
+            onCloseClicked = onClickBack,
+            modifier = Modifier.align(Alignment.TopCenter)
+        )
+
+        NetworkImage(
+            imageUrl = imageUrl,
+            shape = RectangleShape,
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.Center)
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PhotoDetailPreview() {
+    HilingualTheme {
+        PhotoDetailView(
+            imageUrl = "",
+            onClickBack = {}
+        )
+    }
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #80 

## Work Description ✏️
- 원본 이미지 확인 화면 구현햇서요

## Screenshot 📸
<img width="355" height="779" alt="image" src="https://github.com/user-attachments/assets/eebcad6e-036f-49f5-80eb-bdcb9d8224c8" />


## Uncompleted Tasks 😅
- [ ] 이미지에 sharedTransition 사용
- [ ] 아직 화면 연결 안해놨어요..!

## To Reviewers 📢
- 원본 이미지 확인은 네비게이션 그래프에 추가하지 않고, 사진 클릭했을 때 그냥 위에다 띄워주려고 해서 Screen 대신 View라고 지어봤는데 괜찮을까요?