### PR TITLE
[FEAT/#83] 단어장 뷰의 네비게이션 구현

### DIFF
--- a/presentation/main/src/main/java/com/hilingual/presentation/main/MainScreen.kt
+++ b/presentation/main/src/main/java/com/hilingual/presentation/main/MainScreen.kt
@@ -100,7 +100,8 @@ internal fun MainScreen(
                     paddingValues = innerPadding
                 )
                 vocaNavGraph(
-                    paddingValues = innerPadding
+                    paddingValues = innerPadding,
+                    navigateToHome = navigator::navigateToHome
                 )
             }
         }

--- a/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaScreen.kt
+++ b/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaScreen.kt
@@ -51,7 +51,7 @@ import kotlinx.collections.immutable.toImmutableList
 @Composable
 internal fun VocaRoute(
     paddingValues: PaddingValues,
-    navigateToDiaryWrite: () -> Unit,
+    navigateToHome: () -> Unit,
     viewModel: VocaViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -87,7 +87,7 @@ internal fun VocaRoute(
             onCardClick = viewModel::fetchVocaDetail,
             onBookmarkClick = viewModel::toggleBookmark,
             onSearchTextChanged = viewModel::updateSearchKeywordAndSearch,
-            onWriteDiaryClick = navigateToDiaryWrite,
+            onWriteDiaryClick = navigateToHome,
             onCloseButtonClick = viewModel::clearSearchKeyword
         )
     }

--- a/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaViewModel.kt
+++ b/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaViewModel.kt
@@ -43,41 +43,7 @@ internal class VocaViewModel : ViewModel() {
         )
     )
 
-    private var originalLatestGroupList = persistentListOf<VocaGroup>() /*persistentListOf(
-        VocaGroup(
-            "today",
-            persistentListOf(
-                VocaItem(10, "come across as", persistentListOf("동사", "숙어")),
-                VocaItem(9, "underwhelming", persistentListOf("형용사")),
-                VocaItem(8, "spacious", persistentListOf("형용사")),
-                VocaItem(7, "oversleep", persistentListOf("동사"))
-            )
-        ),
-        VocaGroup(
-            "7days",
-            persistentListOf(
-                VocaItem(6, "resonate with", persistentListOf("동사", "구")),
-                VocaItem(
-                    5,
-                    "rekindle my interest",
-                    persistentListOf("동사", "구")
-                ),
-                VocaItem(
-                    4,
-                    "emotional vulnerability",
-                    persistentListOf("명사", "구")
-                ),
-                VocaItem(3, "out of the blue", persistentListOf("부사")),
-                VocaItem(
-                    2,
-                    "short-lived but impactful",
-                    persistentListOf("형용사", "구")
-                ),
-                VocaItem(1, "ghost", persistentListOf("명사")),
-                VocaItem(0, "run late", persistentListOf("동사", "숙어"))
-            )
-        )
-    )*/
+    private var originalLatestGroupList = persistentListOf<VocaGroup>()
 
     init {
         fetchWords(WordSortType.Latest)

--- a/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaViewModel.kt
+++ b/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaViewModel.kt
@@ -43,7 +43,7 @@ internal class VocaViewModel : ViewModel() {
         )
     )
 
-    private var originalLatestGroupList = persistentListOf(
+    private var originalLatestGroupList = persistentListOf<VocaGroup>() /*persistentListOf(
         VocaGroup(
             "today",
             persistentListOf(
@@ -77,7 +77,7 @@ internal class VocaViewModel : ViewModel() {
                 VocaItem(0, "run late", persistentListOf("동사", "숙어"))
             )
         )
-    )
+    )*/
 
     init {
         fetchWords(WordSortType.Latest)

--- a/presentation/voca/src/main/java/com/hilingual/presentation/voca/navigation/VocaNavigation.kt
+++ b/presentation/voca/src/main/java/com/hilingual/presentation/voca/navigation/VocaNavigation.kt
@@ -22,12 +22,13 @@ fun NavController.navigateToVoca(
 }
 
 fun NavGraphBuilder.vocaNavGraph(
-    paddingValues: PaddingValues
+    paddingValues: PaddingValues,
+    navigateToHome: () -> Unit
 ) {
     composable<Voca> {
         VocaRoute(
             paddingValues = paddingValues,
-            navigateToDiaryWrite = { }
+            navigateToHome = navigateToHome
         )
     }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #83 

## Work Description ✏️
- 단어장 뷰에서 일기 쓰고 단어 추가하러 가기 버튼 클릭시 홈 화면으로 이동하는 네비게이션을 구현했습니다

## Screenshot 📸

https://github.com/user-attachments/assets/6fef04c5-021f-4263-91db-270328fa5a56


## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
단어장 뷰는 이미 바텀 네비로 구현이 되어있어서.. 단어 추가 버튼 클릭하면 홈 뷰로 이동하는 코드 작성했습니다 !! navgationToHome코드를 이미 리드님이 구현해주셔서,,,, 감사합니다
수정해야 하거나 더 좋은 코드 있으면 리뷰 많이 남겨주세요 !! 안드링 화이팅 !!!! 