### PR TITLE
[FEAT/#84] 일기 상세 네비게이션 연결

### DIFF
--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
@@ -40,13 +40,13 @@ internal fun DiaryFeedbackRoute(
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val localSystemBarsColor = LocalSystemBarsColor.current
-    var selectedImageUrl by remember { mutableStateOf<String?>(null) }
+    var isImageDetailVisible by remember { mutableStateOf<Boolean>(false) }
 
     BackHandler {
-        if (selectedImageUrl == null) {
-            navigateUp()
+        if (isImageDetailVisible) {
+            isImageDetailVisible = false
         } else {
-            selectedImageUrl = null
+            navigateUp()
         }
     }
 
@@ -71,8 +71,8 @@ internal fun DiaryFeedbackRoute(
                 paddingValues = paddingValues,
                 uiState = (state as UiState.Success<DiaryFeedbackUiState>).data,
                 onBackClick = navigateUp,
-                selectedImageUrl = selectedImageUrl,
-                onChangeSelectedUrl = { selectedImageUrl = it },
+                isImageDetailVisible = isImageDetailVisible,
+                onChangeImageDetailVisible = { isImageDetailVisible = !isImageDetailVisible },
                 onToggleDiaryViewMode = viewModel::toggleDiaryShowOption,
                 onToggleBookmark = viewModel::toggleBookmark
             )
@@ -87,8 +87,8 @@ private fun DiaryFeedbackScreen(
     paddingValues: PaddingValues,
     uiState: DiaryFeedbackUiState,
     onBackClick: () -> Unit,
-    selectedImageUrl: String?,
-    onChangeSelectedUrl: (String?) -> Unit,
+    isImageDetailVisible: Boolean,
+    onChangeImageDetailVisible: () -> Unit,
     onToggleDiaryViewMode: (Boolean) -> Unit,
     onToggleBookmark: (Long, Boolean) -> Unit,
     modifier: Modifier = Modifier
@@ -142,7 +142,7 @@ private fun DiaryFeedbackScreen(
                     feedbackList = feedbackList,
                     onToggleDiaryViewMode = onToggleDiaryViewMode,
                     isAIWritten = isAIWritten,
-                    onImageClick = onChangeSelectedUrl
+                    onImageClick = onChangeImageDetailVisible
                 )
                 1 -> RecommendExpressionScreen(
                     writtenDate = writtenDate,
@@ -153,10 +153,10 @@ private fun DiaryFeedbackScreen(
         }
     }
 
-    if (selectedImageUrl != null) {
+    if (isImageDetailVisible && uiState.diaryContent.imageUrl != null) {
         PhotoDetailModal(
-            imageUrl = selectedImageUrl,
-            onBackClick = { onChangeSelectedUrl(null) },
+            imageUrl = uiState.diaryContent.imageUrl,
+            onBackClick = onChangeImageDetailVisible,
             modifier = modifier.padding(paddingValues)
         )
     }
@@ -178,11 +178,11 @@ private fun DiaryFeedbackScreenPreview() {
                 feedbackList = vm.dummyFeedbacks,
                 recommendExpressionList = vm.dummyRecommendExpressions
             ),
-            selectedImageUrl = "",
-            onChangeSelectedUrl = {},
+            isImageDetailVisible = false,
+            onChangeImageDetailVisible = {},
             onBackClick = {},
             onToggleDiaryViewMode = { isAIWritten = !isAIWritten },
-            onToggleBookmark = { _, _ -> {} }
+            onToggleBookmark = { _, _ -> {} },
         )
     }
 }

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
@@ -83,6 +83,8 @@ private fun DiaryFeedbackScreen(
     var isReportBottomSheetVisible by remember { mutableStateOf(false) }
     var isReportDialogVisible by remember { mutableStateOf(false) }
 
+    var selectedImageUrl by remember { mutableStateOf<String?>(null) }
+
     if (isReportBottomSheetVisible) {
         FeedbackReportBottomSheet(
             onDismiss = { isReportBottomSheetVisible = false },
@@ -127,7 +129,8 @@ private fun DiaryFeedbackScreen(
                     diaryContent = diaryContent,
                     feedbackList = feedbackList,
                     onToggleDiaryViewMode = onToggleDiaryViewMode,
-                    isAIWritten = isAIWritten
+                    isAIWritten = isAIWritten,
+                    onImageClick = { selectedImageUrl = it }
                 )
                 1 -> RecommendExpressionScreen(
                     writtenDate = writtenDate,
@@ -136,6 +139,14 @@ private fun DiaryFeedbackScreen(
                 )
             }
         }
+    }
+
+    if (selectedImageUrl != null) {
+        PhotoDetailModal(
+            imageUrl = selectedImageUrl!!,
+            onBackClick = { selectedImageUrl = null },
+            modifier = modifier.padding(paddingValues)
+        )
     }
 }
 
@@ -157,7 +168,7 @@ private fun DiaryFeedbackScreenPreview() {
             ),
             onBackClick = {},
             onToggleDiaryViewMode = { isAIWritten = !isAIWritten },
-            onToggleBookmark = { _, _ -> {} }
+            onToggleBookmark = { _, _ -> {} },
         )
     }
 }

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
@@ -154,7 +154,7 @@ private fun DiaryFeedbackScreen(
     }
 
     if (isImageDetailVisible && uiState.diaryContent.imageUrl != null) {
-        PhotoDetailModal(
+        ModalImage(
             imageUrl = uiState.diaryContent.imageUrl,
             onBackClick = onChangeImageDetailVisible,
             modifier = modifier.padding(paddingValues)

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
@@ -31,7 +31,6 @@ import com.hilingual.presentation.diaryfeedback.component.FeedbackReportDialog
 import com.hilingual.presentation.diaryfeedback.tab.GrammarSpellingScreen
 import com.hilingual.presentation.diaryfeedback.tab.RecommendExpressionScreen
 
-// TODO: Route 설정
 @Composable
 internal fun DiaryFeedbackRoute(
     paddingValues: PaddingValues,

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
@@ -182,7 +182,7 @@ private fun DiaryFeedbackScreenPreview() {
             onChangeImageDetailVisible = {},
             onBackClick = {},
             onToggleDiaryViewMode = { isAIWritten = !isAIWritten },
-            onToggleBookmark = { _, _ -> {} },
+            onToggleBookmark = { _, _ -> {} }
         )
     }
 }

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
@@ -1,5 +1,6 @@
 package com.hilingual.presentation.diaryfeedback
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -39,6 +40,12 @@ internal fun DiaryFeedbackRoute(
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val localSystemBarsColor = LocalSystemBarsColor.current
+    var selectedImageUrl by remember { mutableStateOf<String?>(null) }
+
+    BackHandler {
+        if (selectedImageUrl == null) navigateUp()
+        else selectedImageUrl = null
+    }
 
     LaunchedEffect(Unit) {
         localSystemBarsColor.setSystemBarColor(
@@ -61,6 +68,8 @@ internal fun DiaryFeedbackRoute(
                 paddingValues = paddingValues,
                 uiState = (state as UiState.Success<DiaryFeedbackUiState>).data,
                 onBackClick = navigateUp,
+                selectedImageUrl = selectedImageUrl,
+                onChangeSelectedUrl = { selectedImageUrl = it },
                 onToggleDiaryViewMode = viewModel::toggleDiaryShowOption,
                 onToggleBookmark = viewModel::toggleBookmark
             )
@@ -75,6 +84,8 @@ private fun DiaryFeedbackScreen(
     paddingValues: PaddingValues,
     uiState: DiaryFeedbackUiState,
     onBackClick: () -> Unit,
+    selectedImageUrl: String?,
+    onChangeSelectedUrl: (String?) -> Unit,
     onToggleDiaryViewMode: (Boolean) -> Unit,
     onToggleBookmark: (Long, Boolean) -> Unit,
     modifier: Modifier = Modifier
@@ -82,8 +93,6 @@ private fun DiaryFeedbackScreen(
     var tabIndex by remember { mutableIntStateOf(0) }
     var isReportBottomSheetVisible by remember { mutableStateOf(false) }
     var isReportDialogVisible by remember { mutableStateOf(false) }
-
-    var selectedImageUrl by remember { mutableStateOf<String?>(null) }
 
     if (isReportBottomSheetVisible) {
         FeedbackReportBottomSheet(
@@ -130,7 +139,7 @@ private fun DiaryFeedbackScreen(
                     feedbackList = feedbackList,
                     onToggleDiaryViewMode = onToggleDiaryViewMode,
                     isAIWritten = isAIWritten,
-                    onImageClick = { selectedImageUrl = it }
+                    onImageClick = onChangeSelectedUrl
                 )
                 1 -> RecommendExpressionScreen(
                     writtenDate = writtenDate,
@@ -143,8 +152,8 @@ private fun DiaryFeedbackScreen(
 
     if (selectedImageUrl != null) {
         PhotoDetailModal(
-            imageUrl = selectedImageUrl!!,
-            onBackClick = { selectedImageUrl = null },
+            imageUrl = selectedImageUrl,
+            onBackClick = { onChangeSelectedUrl(null) },
             modifier = modifier.padding(paddingValues)
         )
     }
@@ -166,6 +175,8 @@ private fun DiaryFeedbackScreenPreview() {
                 feedbackList = vm.dummyFeedbacks,
                 recommendExpressionList = vm.dummyRecommendExpressions
             ),
+            selectedImageUrl = "",
+            onChangeSelectedUrl = {},
             onBackClick = {},
             onToggleDiaryViewMode = { isAIWritten = !isAIWritten },
             onToggleBookmark = { _, _ -> {} },

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
@@ -43,8 +43,11 @@ internal fun DiaryFeedbackRoute(
     var selectedImageUrl by remember { mutableStateOf<String?>(null) }
 
     BackHandler {
-        if (selectedImageUrl == null) navigateUp()
-        else selectedImageUrl = null
+        if (selectedImageUrl == null) {
+            navigateUp()
+        } else {
+            selectedImageUrl = null
+        }
     }
 
     LaunchedEffect(Unit) {
@@ -179,7 +182,7 @@ private fun DiaryFeedbackScreenPreview() {
             onChangeSelectedUrl = {},
             onBackClick = {},
             onToggleDiaryViewMode = { isAIWritten = !isAIWritten },
-            onToggleBookmark = { _, _ -> {} },
+            onToggleBookmark = { _, _ -> {} }
         )
     }
 }

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/ModalImage.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/ModalImage.kt
@@ -16,7 +16,7 @@ import com.hilingual.core.designsystem.theme.HilingualTheme
 
 // TODO: sharedTransition 사용
 @Composable
-internal fun PhotoDetailModal(
+internal fun ModalImage(
     imageUrl: String,
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier
@@ -46,7 +46,7 @@ internal fun PhotoDetailModal(
 @Composable
 private fun PhotoDetailPreview() {
     HilingualTheme {
-        PhotoDetailModal(
+        ModalImage(
             imageUrl = "",
             onBackClick = {}
         )

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/component/DiaryCard.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/component/DiaryCard.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
+import com.hilingual.core.common.extension.noRippleClickable
 import com.hilingual.core.designsystem.component.image.NetworkImage
 import com.hilingual.core.designsystem.theme.HilingualTheme
 import kotlinx.collections.immutable.ImmutableList
@@ -28,6 +29,7 @@ internal fun DiaryCard(
     isAIWritten: Boolean,
     diaryContent: String,
     modifier: Modifier = Modifier,
+    onImageClick: (String) -> Unit,
     diffRanges: ImmutableList<Pair<Int, Int>> = persistentListOf(),
     imageUrl: String? = null
 ) {
@@ -57,6 +59,9 @@ internal fun DiaryCard(
                 modifier = Modifier
                     .fillMaxWidth()
                     .aspectRatio(1f / 0.6f)
+                    .noRippleClickable(
+                        onClick = { onImageClick(imageUrl) }
+                    )
             )
         }
 
@@ -141,7 +146,8 @@ private fun DiaryCardPreview(
             isAIWritten = state.isAIDiary,
             diaryContent = state.content,
             imageUrl = state.imageUrl,
-            diffRanges = state.diffRanges
+            diffRanges = state.diffRanges,
+            onImageClick = {}
         )
     }
 }

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/component/DiaryCard.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/component/DiaryCard.kt
@@ -31,7 +31,7 @@ internal fun DiaryCard(
     isAIWritten: Boolean,
     diaryContent: String,
     modifier: Modifier = Modifier,
-    onImageClick: (String) -> Unit,
+    onImageClick: () -> Unit,
     diffRanges: ImmutableList<Pair<Int, Int>> = persistentListOf(),
     imageUrl: String? = null
 ) {
@@ -62,7 +62,7 @@ internal fun DiaryCard(
                     .fillMaxWidth()
                     .aspectRatio(1f / 0.6f)
                     .noRippleClickable(
-                        onClick = { onImageClick(imageUrl) }
+                        onClick = onImageClick
                     )
             )
 

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/component/DiaryCard.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/component/DiaryCard.kt
@@ -2,8 +2,10 @@ package com.hilingual.presentation.diaryfeedback.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
@@ -63,6 +65,8 @@ internal fun DiaryCard(
                         onClick = { onImageClick(imageUrl) }
                     )
             )
+
+            Spacer(Modifier.height(12.dp))
         }
 
         Text(

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/navigation/DiaryFeedbackNavigation.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/navigation/DiaryFeedbackNavigation.kt
@@ -1,0 +1,37 @@
+package com.hilingual.presentation.diaryfeedback.navigation
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
+import androidx.navigation.compose.composable
+import com.hilingual.core.navigation.Route
+import com.hilingual.presentation.diaryfeedback.DiaryFeedbackRoute
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DiaryFeedback (
+    val diaryId: Long
+): Route
+
+fun NavController.navigateToDiaryFeedback(
+    diaryId: Long,
+    navOptions: NavOptions? = null
+) {
+    navigate(
+        route = DiaryFeedback(diaryId),
+        navOptions = navOptions
+    )
+}
+
+fun NavGraphBuilder.diaryFeedbackNavGraph(
+    paddingValues: PaddingValues,
+    navigateUp: () -> Unit
+) {
+    composable<DiaryFeedback> {
+        DiaryFeedbackRoute(
+            paddingValues = paddingValues,
+            navigateUp = navigateUp
+        )
+    }
+}

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/navigation/DiaryFeedbackNavigation.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/navigation/DiaryFeedbackNavigation.kt
@@ -10,9 +10,9 @@ import com.hilingual.presentation.diaryfeedback.DiaryFeedbackRoute
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class DiaryFeedback (
+data class DiaryFeedback(
     val diaryId: Long
-): Route
+) : Route
 
 fun NavController.navigateToDiaryFeedback(
     diaryId: Long,

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/tab/GrammarSpellingScreen.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/tab/GrammarSpellingScreen.kt
@@ -39,6 +39,7 @@ internal fun GrammarSpellingScreen(
     diaryContent: DiaryContent,
     feedbackList: ImmutableList<FeedbackContent>,
     onToggleDiaryViewMode: (Boolean) -> Unit,
+    onImageClick: (String) -> Unit,
     modifier: Modifier = Modifier,
     isAIWritten: Boolean = true
 ) {
@@ -69,7 +70,8 @@ internal fun GrammarSpellingScreen(
                     isAIWritten = isAIWritten,
                     diaryContent = if (isAIWritten) aiText else originalText,
                     diffRanges = diffRanges,
-                    imageUrl = imageUrl
+                    imageUrl = imageUrl,
+                    onImageClick = onImageClick
                 )
             }
             Spacer(Modifier.height(24.dp))
@@ -136,7 +138,8 @@ private fun GrammarSpellingScreenPreview() {
             isAIWritten = isAI,
             onToggleDiaryViewMode = { isAI = !isAI },
             diaryContent = dummyDiary,
-            feedbackList = DiaryFeedbackViewModel.dummyFeedbacks
+            feedbackList = DiaryFeedbackViewModel.dummyFeedbacks,
+            onImageClick = {}
         )
     }
 }

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/tab/GrammarSpellingScreen.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/tab/GrammarSpellingScreen.kt
@@ -39,7 +39,7 @@ internal fun GrammarSpellingScreen(
     diaryContent: DiaryContent,
     feedbackList: ImmutableList<FeedbackContent>,
     onToggleDiaryViewMode: (Boolean) -> Unit,
-    onImageClick: (String) -> Unit,
+    onImageClick: () -> Unit,
     modifier: Modifier = Modifier,
     isAIWritten: Boolean = true
 ) {

--- a/presentation/home/src/main/java/com/hilingual/presentation/home/navigation/HomeNavigation.kt
+++ b/presentation/home/src/main/java/com/hilingual/presentation/home/navigation/HomeNavigation.kt
@@ -22,13 +22,14 @@ fun NavController.navigateToHome(
 }
 
 fun NavGraphBuilder.homeNavGraph(
-    paddingValues: PaddingValues
+    paddingValues: PaddingValues,
+    navigateToDiaryFeedback: (diaryId: Long) -> Unit
 ) {
     composable<Home> {
         HomeRoute(
             paddingValues = paddingValues,
             navigateToDiaryWrite = {},
-            navigateToDiaryFeedback = {}
+            navigateToDiaryFeedback = navigateToDiaryFeedback
         )
     }
 }

--- a/presentation/main/src/main/java/com/hilingual/presentation/main/MainNavigator.kt
+++ b/presentation/main/src/main/java/com/hilingual/presentation/main/MainNavigator.kt
@@ -10,6 +10,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
 import com.hilingual.presentation.auth.navigation.navigateToAuth
+import com.hilingual.presentation.diaryfeedback.navigation.navigateToDiaryFeedback
 import com.hilingual.presentation.home.navigation.Home
 import com.hilingual.presentation.home.navigation.navigateToHome
 import com.hilingual.presentation.onboarding.navigation.navigateToOnboarding
@@ -86,6 +87,13 @@ internal class MainNavigator(
         }
     ) {
         navController.navigateToOnboarding(navOptions)
+    }
+
+    fun navigateToDiaryFeedback(
+        diaryId: Long,
+        navOptions: NavOptions? = null
+    ) {
+        navController.navigateToDiaryFeedback(diaryId, navOptions)
     }
 
     fun navigateUp() {

--- a/presentation/main/src/main/java/com/hilingual/presentation/main/MainScreen.kt
+++ b/presentation/main/src/main/java/com/hilingual/presentation/main/MainScreen.kt
@@ -26,6 +26,7 @@ import androidx.navigation.compose.NavHost
 import com.hilingual.core.common.provider.LocalSystemBarsColor
 import com.hilingual.core.designsystem.component.snackbar.TextSnackBar
 import com.hilingual.presentation.auth.navigation.authNavGraph
+import com.hilingual.presentation.diaryfeedback.navigation.diaryFeedbackNavGraph
 import com.hilingual.presentation.home.navigation.homeNavGraph
 import com.hilingual.presentation.main.component.MainBottomBar
 import com.hilingual.presentation.onboarding.navigation.onboardingGraph
@@ -97,10 +98,15 @@ internal fun MainScreen(
                     navigateToHome = navigator::navigateToHome
                 )
                 homeNavGraph(
-                    paddingValues = innerPadding
+                    paddingValues = innerPadding,
+                    navigateToDiaryFeedback = navigator::navigateToDiaryFeedback
                 )
                 vocaNavGraph(
                     paddingValues = innerPadding
+                )
+                diaryFeedbackNavGraph(
+                    paddingValues = innerPadding,
+                    navigateUp = navigator::navigateUp
                 )
             }
         }


### PR DESCRIPTION
## Related issue 🛠
- closed #84 

## Work Description ✏️
- `홈 -> 일기 상세`랑 `일기 상세 > 사진 보기` 화면 연결했어요

## Screenshot 📸
https://github.com/user-attachments/assets/1c8b626b-d78c-426d-9fee-c3aad3ecef93


## Uncompleted Tasks 😅
- [ ] `일기 작성`에서의 화면 이동 (`피드백 보러가기` 버튼 클릭 시)
- [ ] 사진 확인 `sharedTransition` 적용 - API 붙이고 시간 나면 해볼게요

## To Reviewers 📢
- [#76](https://github.com/Hi-lingual/Hilingual-Android/pull/85) PR 머지되면 남은 화면 이동 플로우 이어서 구현할게요!!
기본 화면 이동 코드 위주로 봐주세요:)
- 사진 보기 화면은 navGraph로 관리하는 게 아니라 DiaryFeedbackScreen에서 별도로 띄워주게끔 했어요!