### PR TITLE
[FEAT/#125] 개인정보 처리방침 및 신고폼 url 이동 구현

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ security = "1.1.0-beta01"
 datastorePreferences = "1.1.7"
 material = "1.10.0"
 desugarJdkLibs = "2.1.4"
+browser="1.8.0"
 
 # Room
 room = "2.7.2"
@@ -103,6 +104,7 @@ androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-navigation = { module = "androidx.navigation:navigation-compose", version.ref = "composeNavigation" }
+androidx-browser = { group = "androidx.browser", name = "browser", version.ref = "browser"}
 
 # Coroutines
 coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutine" }

--- a/presentation/auth/build.gradle.kts
+++ b/presentation/auth/build.gradle.kts
@@ -12,4 +12,5 @@ dependencies {
     implementation(project(":core:common"))
     implementation(project(":core:designsystem"))
     implementation(project(":data:auth"))
+    implementation(libs.androidx.browser)
 }

--- a/presentation/auth/src/main/java/com/hilingual/presentation/auth/AuthScreen.kt
+++ b/presentation/auth/src/main/java/com/hilingual/presentation/auth/AuthScreen.kt
@@ -1,5 +1,7 @@
 package com.hilingual.presentation.auth
 
+import android.content.Context
+import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
@@ -27,6 +29,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.hilingual.core.common.extension.noRippleClickable
 import com.hilingual.core.common.provider.LocalSystemBarsColor
@@ -35,6 +38,8 @@ import com.hilingual.core.designsystem.theme.hilingualOrange
 import com.hilingual.presentation.auth.component.GoogleSignButton
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
+
+private const val POLICY_URL = "https://hilingual.notion.site/230829677ebf8104b52ce74c65c27607?pvs=74"
 
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
@@ -67,7 +72,7 @@ internal fun AuthRoute(
     AuthScreen(
         paddingValues = paddingValues,
         onGoogleSignClick = { viewModel.onGoogleSignClick(context) },
-        onPrivacyPolicyClick = { },
+        onPrivacyPolicyClick = { navigateToPolicyWebView(context) },
         sharedTransitionScope = sharedTransitionScope,
         animatedVisibilityScope = animatedVisibilityScope
     )
@@ -144,4 +149,8 @@ private fun AuthScreen(
             )
         }
     }
+}
+
+private fun navigateToPolicyWebView(context: Context) {
+    CustomTabsIntent.Builder().build().launchUrl(context, POLICY_URL.toUri())
 }

--- a/presentation/diaryfeedback/build.gradle.kts
+++ b/presentation/diaryfeedback/build.gradle.kts
@@ -10,4 +10,5 @@ android {
 
 dependencies {
     implementation(project(":data:diary"))
+    implementation(libs.androidx.browser)
 }

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
@@ -1,6 +1,8 @@
 package com.hilingual.presentation.diaryfeedback
 
+import android.content.Context
 import androidx.activity.compose.BackHandler
+import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -22,8 +24,10 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hilingual.core.common.provider.LocalSystemBarsColor
@@ -40,12 +44,16 @@ import com.hilingual.presentation.diaryfeedback.tab.RecommendExpressionScreen
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.launch
 
+private const val REPORT_URL = "https://hilingual.notion.site/230829677ebf801c965be24b0ef444e9"
+
 @Composable
 internal fun DiaryFeedbackRoute(
     paddingValues: PaddingValues,
     navigateUp: () -> Unit,
     viewModel: DiaryFeedbackViewModel = hiltViewModel()
 ) {
+    val context = LocalContext.current
+
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val localSystemBarsColor = LocalSystemBarsColor.current
     var isImageDetailVisible by remember { mutableStateOf(false) }
@@ -79,6 +87,7 @@ internal fun DiaryFeedbackRoute(
                 paddingValues = paddingValues,
                 uiState = (state as UiState.Success<DiaryFeedbackUiState>).data,
                 onBackClick = navigateUp,
+                onReportClick = { navigateToReportWebView(context) },
                 isImageDetailVisible = isImageDetailVisible,
                 onChangeImageDetailVisible = { isImageDetailVisible = !isImageDetailVisible },
                 onToggleBookmark = viewModel::toggleBookmark
@@ -94,6 +103,7 @@ private fun DiaryFeedbackScreen(
     paddingValues: PaddingValues,
     uiState: DiaryFeedbackUiState,
     onBackClick: () -> Unit,
+    onReportClick: () -> Unit,
     isImageDetailVisible: Boolean,
     onChangeImageDetailVisible: () -> Unit,
     onToggleBookmark: (Long, Boolean) -> Unit,
@@ -136,9 +146,7 @@ private fun DiaryFeedbackScreen(
     if (isReportDialogVisible) {
         FeedbackReportDialog(
             onDismiss = { isReportDialogVisible = false },
-            onReportClick = {
-                // TODO: 구글폼으로 이동
-            }
+            onReportClick = onReportClick
         )
     }
 
@@ -217,6 +225,10 @@ private fun DiaryFeedbackScreen(
     }
 }
 
+private fun navigateToReportWebView(context: Context) {
+    CustomTabsIntent.Builder().build().launchUrl(context, REPORT_URL.toUri())
+}
+
 @Preview(showBackground = true)
 @Composable
 private fun DiaryFeedbackScreenPreview() {
@@ -231,6 +243,7 @@ private fun DiaryFeedbackScreenPreview() {
             isImageDetailVisible = false,
             onChangeImageDetailVisible = {},
             onBackClick = {},
+            onReportClick = {},
             onToggleBookmark = { _, _ -> {} }
         )
     }


### PR DESCRIPTION
## Related issue 🛠
- closed #125 

## Work Description ✏️
- 로그인 화면에서의 개인정보 처리방침 및 일기 상세 화면에서 신고하기 url 링크 연결했어요

## Screenshot 📸
개인정보 처리방침 | 신고폼
|:--:|:--:|
<video src="https://github.com/user-attachments/assets/13b1a00b-8f56-496a-86c9-fedaa3795a53"> | <video src="https://github.com/user-attachments/assets/433b586e-90d9-4ca6-afd4-f79466643937">

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
- 원래 웹뷰로 띄우려다 기디쌤 문의 결과 해당 방식이 채택돼서 크롬 인앱으로 띄우게 되었어용!! 레퍼런스 3개 세팅해서 폰 빌려준 효비 언니 너무 사랑합니다🫶🏻
- Screen 파일에서 URL이랑 화면 이동 메소드 private으로 구현했는데 이 구조 괜찮은지 확인해주시면 좋을 것 같아요!