### PR TITLE
[FEAT/#142] 일기 상세 조회 실패 시 재요청 기능 추가

### DIFF
--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
@@ -34,6 +34,7 @@ import com.hilingual.core.common.provider.LocalSystemBarsColor
 import com.hilingual.core.common.util.UiState
 import com.hilingual.core.designsystem.component.button.HilingualFloatingButton
 import com.hilingual.core.designsystem.component.topappbar.BackAndMoreTopAppBar
+import com.hilingual.core.designsystem.event.LocalDialogController
 import com.hilingual.core.designsystem.theme.HilingualTheme
 import com.hilingual.core.designsystem.theme.white
 import com.hilingual.presentation.diaryfeedback.component.DiaryFeedbackTabRow
@@ -57,6 +58,7 @@ internal fun DiaryFeedbackRoute(
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val localSystemBarsColor = LocalSystemBarsColor.current
     var isImageDetailVisible by remember { mutableStateOf(false) }
+    val dialogController = LocalDialogController.current
 
     BackHandler {
         if (isImageDetailVisible) {
@@ -72,10 +74,22 @@ internal fun DiaryFeedbackRoute(
         )
     }
 
+    LaunchedEffect(viewModel.sideEffect) {
+        viewModel.sideEffect.collect { event ->
+            when (event) {
+                is DiaryFeedbackSideEffect.ShowRetryDialog -> {
+                    dialogController.show(event.onRetry)
+                }
+            }
+        }
+    }
+
     when (state) {
         is UiState.Loading -> {
             Box(
-                modifier = Modifier.fillMaxSize(),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(HilingualTheme.colors.white),
                 contentAlignment = Alignment.Center
             ) {
                 CircularProgressIndicator()

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackViewModel.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackViewModel.kt
@@ -13,11 +13,16 @@ import com.hilingual.presentation.diaryfeedback.navigation.DiaryFeedback
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -30,42 +35,53 @@ internal class DiaryFeedbackViewModel @Inject constructor(
 
     val diaryId = savedStateHandle.toRoute<DiaryFeedback>().diaryId
 
+    private val _sideEffect = MutableSharedFlow<DiaryFeedbackSideEffect>()
+    val sideEffect: SharedFlow<DiaryFeedbackSideEffect> = _sideEffect.asSharedFlow()
+
     init {
         loadInitialData()
     }
 
+    private suspend fun requestDiaryFeedbackData() = coroutineScope {
+        val contentDeferred = async { diaryRepository.getDiaryContent(diaryId) }
+        val feedbacksDeferred = async { diaryRepository.getDiaryFeedbacks(diaryId) }
+        val recommendExpressionsDeferred = async { diaryRepository.getDiaryRecommendExpressions(diaryId) }
+
+        val contentResult = contentDeferred.await()
+        val feedbacksResult = feedbacksDeferred.await()
+        val recommendExpressionsResult = recommendExpressionsDeferred.await()
+
+        if (
+            contentResult.isSuccess &&
+            feedbacksResult.isSuccess &&
+            recommendExpressionsResult.isSuccess
+        ) {
+            val diaryResult = contentResult.getOrThrow()
+            val feedbacks = feedbacksResult.getOrThrow()
+            val recommendExpressions = recommendExpressionsResult.getOrThrow()
+
+            val newUiState = DiaryFeedbackUiState(
+                writtenDate = diaryResult.writtenDate,
+                diaryContent = diaryResult.toState(),
+                feedbackList = feedbacks.map { it.toState() }.toImmutableList(),
+                recommendExpressionList = recommendExpressions.map { it.toState() }.toImmutableList()
+            )
+            _uiState.value = UiState.Success(newUiState)
+        } else {
+            throw Exception("API error")
+        }
+    }
+
     private fun loadInitialData() {
         viewModelScope.launch {
-            val contentDeferred = async { diaryRepository.getDiaryContent(diaryId) }
-            val feedbacksDeferred = async { diaryRepository.getDiaryFeedbacks(diaryId) }
-            val recommendExpressionsDeferred = async { diaryRepository.getDiaryRecommendExpressions(diaryId) }
-
-            val contentResult = contentDeferred.await()
-            val feedbacksResult = feedbacksDeferred.await()
-            val recommendExpressionsResult = recommendExpressionsDeferred.await()
-
-            if (
-                contentResult.isSuccess &&
-                feedbacksResult.isSuccess &&
-                recommendExpressionsResult.isSuccess
-            ) {
-                val diaryResult = contentResult.getOrThrow()
-                val feedbacks = feedbacksResult.getOrThrow()
-                val recommendExpressions = recommendExpressionsResult.getOrThrow()
-
-                val newUiState = DiaryFeedbackUiState(
-                    writtenDate = diaryResult.writtenDate,
-                    diaryContent = diaryResult.toState(),
-                    feedbackList = feedbacks.map {
-                        it.toState()
-                    }.toImmutableList(),
-                    recommendExpressionList = recommendExpressions.map {
-                        it.toState()
-                    }.toImmutableList()
-                )
-                _uiState.value = UiState.Success(newUiState)
-            } else {
+            runCatching {
+                requestDiaryFeedbackData()
+            }.onFailure { e ->
+                Timber.d("일기 상세 조회 실패: $e")
                 _uiState.value = UiState.Failure
+                _sideEffect.emit(
+                    DiaryFeedbackSideEffect.ShowRetryDialog { loadInitialData() }
+                )
             }
         }
     }
@@ -98,4 +114,8 @@ internal class DiaryFeedbackViewModel @Inject constructor(
                 .onLogFailure { }
         }
     }
+}
+
+sealed interface DiaryFeedbackSideEffect {
+    data class ShowRetryDialog(val onRetry: () -> Unit) : DiaryFeedbackSideEffect
 }

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackViewModel.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackViewModel.kt
@@ -42,14 +42,14 @@ internal class DiaryFeedbackViewModel @Inject constructor(
         loadInitialData()
     }
 
-    private suspend fun requestDiaryFeedbackData() = coroutineScope {
-        val contentDeferred = async { diaryRepository.getDiaryContent(diaryId) }
-        val feedbacksDeferred = async { diaryRepository.getDiaryFeedbacks(diaryId) }
-        val recommendExpressionsDeferred = async { diaryRepository.getDiaryRecommendExpressions(diaryId) }
+    private suspend fun requestDiaryFeedbackData() {
+        val (contentResult, feedbacksResult, recommendExpressionsResult) = coroutineScope {
+            val contentDeferred = async { diaryRepository.getDiaryContent(diaryId) }
+            val feedbacksDeferred = async { diaryRepository.getDiaryFeedbacks(diaryId) }
+            val recommendExpressionsDeferred = async { diaryRepository.getDiaryRecommendExpressions(diaryId) }
 
-        val contentResult = contentDeferred.await()
-        val feedbacksResult = feedbacksDeferred.await()
-        val recommendExpressionsResult = recommendExpressionsDeferred.await()
+            Triple(contentDeferred.await(), feedbacksDeferred.await(), recommendExpressionsDeferred.await())
+        }
 
         if (
             contentResult.isSuccess &&
@@ -68,7 +68,7 @@ internal class DiaryFeedbackViewModel @Inject constructor(
             )
             _uiState.value = UiState.Success(newUiState)
         } else {
-            throw Exception("API error")
+            throw Exception()
         }
     }
 


### PR DESCRIPTION
## Related issue 🛠
- closed #142 

## Work Description ✏️
- 요청 실패 시 다이얼로그 노출
- 확인 버튼 클릭 시 재요청

## Screenshot 📸
https://github.com/user-attachments/assets/b26f3d2a-a5a0-4951-9fef-30c8b3782ee7


## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
- API 3개 요청 if-else로 throw하기 대신 RunCatching로 묶어주기 실패.. 뭔가 3개 중 하나라도 실패 시 셋 다 재요청하는 거 말고 하나 실패했을 때 그것만 재요청하게끔 해주고 싶은데.. 감자 이슈로 좀 더 고민해볼게요ㅠㅠ Result 너무 어렵다....