### PR TITLE
[REF/#180] Use collectSideEffect extension for side effect handling

### DIFF
--- a/core/common/src/main/java/com/hilingual/core/common/extension/FlowExt.kt
+++ b/core/common/src/main/java/com/hilingual/core/common/extension/FlowExt.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 The Hilingual Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hilingual.core.common.extension
 
 import androidx.compose.runtime.Composable

--- a/core/common/src/main/java/com/hilingual/core/common/extension/FlowExt.kt
+++ b/core/common/src/main/java/com/hilingual/core/common/extension/FlowExt.kt
@@ -1,0 +1,33 @@
+package com.hilingual.core.common.extension
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.flowWithLifecycle
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collectLatest
+
+@Composable
+fun <T> Flow<T>.collectSideEffect(
+    key: Any? = Unit,
+    collector: suspend (T) -> Unit
+) {
+    val lifecycle = LocalLifecycleOwner.current.lifecycle
+    LaunchedEffect(key) {
+        flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
+            .collect(collector)
+    }
+}
+
+@Composable
+fun <T> Flow<T>.collectLatestSideEffect(
+    key: Any? = Unit,
+    collector: suspend (T) -> Unit
+) {
+    val lifecycle = LocalLifecycleOwner.current.lifecycle
+    LaunchedEffect(key) {
+        flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
+            .collectLatest(collector)
+    }
+}

--- a/presentation/auth/src/main/java/com/hilingual/presentation/auth/AuthScreen.kt
+++ b/presentation/auth/src/main/java/com/hilingual/presentation/auth/AuthScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.hilingual.core.common.extension.collectLatestSideEffect
 import com.hilingual.core.common.extension.noRippleClickable
 import com.hilingual.core.common.provider.LocalSystemBarsColor
 import com.hilingual.core.designsystem.event.LocalSharedTransitionScope
@@ -52,9 +53,9 @@ import com.hilingual.core.designsystem.theme.HilingualTheme
 import com.hilingual.core.designsystem.theme.hilingualOrange
 import com.hilingual.presentation.auth.component.GoogleSignButton
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.collectLatest
 
-private const val POLICY_URL = "https://hilingual.notion.site/230829677ebf8104b52ce74c65c27607?pvs=74"
+private const val POLICY_URL =
+    "https://hilingual.notion.site/230829677ebf8104b52ce74c65c27607?pvs=74"
 
 @Composable
 internal fun AuthRoute(
@@ -73,12 +74,10 @@ internal fun AuthRoute(
         )
     }
 
-    LaunchedEffect(Unit) {
-        viewModel.navigationEvent.collectLatest { event ->
-            when (event) {
-                is AuthSideEffect.NavigateToHome -> navigateToHome()
-                is AuthSideEffect.NavigateToOnboarding -> navigateToOnboarding()
-            }
+    viewModel.navigationEvent.collectLatestSideEffect { event ->
+        when (event) {
+            is AuthSideEffect.NavigateToHome -> navigateToHome()
+            is AuthSideEffect.NavigateToOnboarding -> navigateToOnboarding()
         }
     }
 

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hilingual.core.common.extension.collectSideEffect
 import com.hilingual.core.common.provider.LocalSystemBarsColor
 import com.hilingual.core.common.util.UiState
 import com.hilingual.core.designsystem.component.button.HilingualFloatingButton
@@ -89,12 +90,10 @@ internal fun DiaryFeedbackRoute(
         )
     }
 
-    LaunchedEffect(viewModel.sideEffect) {
-        viewModel.sideEffect.collect { event ->
-            when (event) {
-                is DiaryFeedbackSideEffect.ShowRetryDialog -> {
-                    dialogController.show(event.onRetry)
-                }
+    viewModel.sideEffect.collectSideEffect {
+        when (it) {
+            is DiaryFeedbackSideEffect.ShowRetryDialog -> {
+                dialogController.show(it.onRetry)
             }
         }
     }

--- a/presentation/home/src/main/java/com/hilingual/presentation/home/HomeScreen.kt
+++ b/presentation/home/src/main/java/com/hilingual/presentation/home/HomeScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hilingual.core.common.extension.collectSideEffect
 import com.hilingual.core.common.provider.LocalSystemBarsColor
 import com.hilingual.core.common.util.UiState
 import com.hilingual.core.designsystem.event.LocalDialogController
@@ -69,15 +70,14 @@ internal fun HomeRoute(
     val localSystemBarsColor = LocalSystemBarsColor.current
     val dialogController = LocalDialogController.current
 
-    LaunchedEffect(viewModel.sideEffect) {
-        viewModel.sideEffect.collect { event ->
-            when (event) {
-                is HomeSideEffect.ShowRetryDialog -> {
-                    dialogController.show(event.onRetry)
-                }
+    viewModel.sideEffect.collectSideEffect {
+        when(it) {
+            is HomeSideEffect.ShowRetryDialog -> {
+                dialogController.show(it.onRetry)
             }
         }
     }
+
 
     LaunchedEffect(Unit) {
         viewModel.loadInitialData()

--- a/presentation/home/src/main/java/com/hilingual/presentation/home/HomeScreen.kt
+++ b/presentation/home/src/main/java/com/hilingual/presentation/home/HomeScreen.kt
@@ -71,13 +71,12 @@ internal fun HomeRoute(
     val dialogController = LocalDialogController.current
 
     viewModel.sideEffect.collectSideEffect {
-        when(it) {
+        when (it) {
             is HomeSideEffect.ShowRetryDialog -> {
                 dialogController.show(it.onRetry)
             }
         }
     }
-
 
     LaunchedEffect(Unit) {
         viewModel.loadInitialData()

--- a/presentation/main/src/main/java/com/hilingual/presentation/main/MainNavigator.kt
+++ b/presentation/main/src/main/java/com/hilingual/presentation/main/MainNavigator.kt
@@ -28,7 +28,6 @@ import com.hilingual.presentation.auth.navigation.navigateToAuth
 import com.hilingual.presentation.community.navigateToCommunity
 import com.hilingual.presentation.diaryfeedback.navigation.navigateToDiaryFeedback
 import com.hilingual.presentation.diarywrite.navigation.navigateToDiaryWrite
-import com.hilingual.presentation.home.navigation.Home
 import com.hilingual.presentation.home.navigation.navigateToHome
 import com.hilingual.presentation.mypage.navigateToMyPage
 import com.hilingual.presentation.onboarding.navigation.navigateToOnboarding
@@ -43,7 +42,7 @@ internal class MainNavigator(
         @Composable get() = navController
             .currentBackStackEntryAsState().value?.destination
 
-    val startDestination = Home
+    val startDestination = Splash
 
     val currentTab: MainTab?
         @Composable get() = MainTab.find { tab ->

--- a/presentation/main/src/main/java/com/hilingual/presentation/main/MainNavigator.kt
+++ b/presentation/main/src/main/java/com/hilingual/presentation/main/MainNavigator.kt
@@ -28,6 +28,7 @@ import com.hilingual.presentation.auth.navigation.navigateToAuth
 import com.hilingual.presentation.community.navigateToCommunity
 import com.hilingual.presentation.diaryfeedback.navigation.navigateToDiaryFeedback
 import com.hilingual.presentation.diarywrite.navigation.navigateToDiaryWrite
+import com.hilingual.presentation.home.navigation.Home
 import com.hilingual.presentation.home.navigation.navigateToHome
 import com.hilingual.presentation.mypage.navigateToMyPage
 import com.hilingual.presentation.onboarding.navigation.navigateToOnboarding
@@ -42,7 +43,7 @@ internal class MainNavigator(
         @Composable get() = navController
             .currentBackStackEntryAsState().value?.destination
 
-    val startDestination = Splash
+    val startDestination = Home
 
     val currentTab: MainTab?
         @Composable get() = MainTab.find { tab ->

--- a/presentation/main/src/main/java/com/hilingual/presentation/main/MainScreen.kt
+++ b/presentation/main/src/main/java/com/hilingual/presentation/main/MainScreen.kt
@@ -92,7 +92,7 @@ internal fun MainScreen(
 
     LaunchedEffect(isOffline, dialogController.isVisible) {
         if (isOffline && !dialogController.isVisible) {
-            dialogController.show { navigator.navigateToHome() }
+            dialogController.show { dialogController.dismiss() }
         }
     }
 

--- a/presentation/onboarding/src/main/java/com/hilingual/presentation/onboarding/OnboardingScreen.kt
+++ b/presentation/onboarding/src/main/java/com/hilingual/presentation/onboarding/OnboardingScreen.kt
@@ -82,7 +82,7 @@ internal fun OnboardingRoute(
     }
 
     viewModel.sideEffect.collectSideEffect {
-        when(it) {
+        when (it) {
             is OnboardingSideEffect.NavigateToHome -> navigateToHome()
             is OnboardingSideEffect.ShowRetryDialog -> {
                 dialogController.show(it.onRetry)

--- a/presentation/onboarding/src/main/java/com/hilingual/presentation/onboarding/OnboardingScreen.kt
+++ b/presentation/onboarding/src/main/java/com/hilingual/presentation/onboarding/OnboardingScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hilingual.core.common.extension.addFocusCleaner
+import com.hilingual.core.common.extension.collectSideEffect
 import com.hilingual.core.common.provider.LocalSystemBarsColor
 import com.hilingual.core.designsystem.component.button.HilingualButton
 import com.hilingual.core.designsystem.component.textfield.HilingualShortTextField
@@ -80,13 +81,11 @@ internal fun OnboardingRoute(
         }
     }
 
-    LaunchedEffect(viewModel.sideEffect) {
-        viewModel.sideEffect.collect { event ->
-            when (event) {
-                is OnboardingSideEffect.NavigateToHome -> navigateToHome()
-                is OnboardingSideEffect.ShowRetryDialog -> {
-                    dialogController.show(event.onRetry)
-                }
+    viewModel.sideEffect.collectSideEffect {
+        when(it) {
+            is OnboardingSideEffect.NavigateToHome -> navigateToHome()
+            is OnboardingSideEffect.ShowRetryDialog -> {
+                dialogController.show(it.onRetry)
             }
         }
     }

--- a/presentation/splash/src/main/java/com/hilingual/presentation/splash/SplashScreen.kt
+++ b/presentation/splash/src/main/java/com/hilingual/presentation/splash/SplashScreen.kt
@@ -54,7 +54,7 @@ internal fun SplashRoute(
         )
     }
 
-    LaunchedEffect(uiState) {
+    LaunchedEffect(Unit) {
         delay(1400)
         when (uiState) {
             SplashUiState.LoggedIn -> navigateToHome()

--- a/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaScreen.kt
+++ b/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hilingual.core.common.extension.addFocusCleaner
+import com.hilingual.core.common.extension.collectSideEffect
 import com.hilingual.core.common.provider.LocalSystemBarsColor
 import com.hilingual.core.common.util.UiState
 import com.hilingual.core.designsystem.component.button.HilingualFloatingButton
@@ -97,12 +98,10 @@ internal fun VocaRoute(
         viewModel.fetchWords(uiState.sortType)
     }
 
-    LaunchedEffect(viewModel.sideEffect) {
-        viewModel.sideEffect.collect { event ->
-            when (event) {
-                is VocaSideEffect.ShowRetryDialog -> {
-                    dialogController.show { dialogController.dismiss() }
-                }
+    viewModel.sideEffect.collectSideEffect {
+        when (it) {
+            is VocaSideEffect.ShowRetryDialog -> {
+                dialogController.show { dialogController.dismiss() }
             }
         }
     }


### PR DESCRIPTION
## Related issue 🛠
- closed #180

## Work Description ✏️
- `FlowExt.kt` 확장 함수 구현
- 각 Screen에 해당 확장 함수 적용

## To Reviewers 📢
이번 PR은 추후 아티클로도 정리할 예정입니다.
적용 배경은 `LaunchedEffect`의 생명주기가 `Activity`가 아니라 `Composable`이라는 점에 있습니다. 이로 인해 백그라운드 상태에서 `Flow` 기반 이벤트 수집 시 **이벤트 유실 및 미소비** 문제가 발생할 수 있습니다.

### 예시 시나리오

1. 사용자가 로그인 버튼을 클릭해 네트워크 요청을 시작함
2. 응답이 도착하기 전에 홈 버튼을 눌러 앱이 백그라운드로 전환됨
3. 하지만 `LaunchedEffect`는 `Composable`의 생명주기를 따르기 때문에, 코루틴은 취소되지 않고 계속 실행됨
4. 백그라운드 상태에서도 네트워크 응답이 수신되어 사이드 이펙트 Flow가 값을 방출함
5. 그러나 `Composable`이 inactive 상태이므로 UI에 해당 값이 반영되지 않음
6. 이후 앱을 다시 열었을 때 Flow는 이미 소비된 상태이고, 앱 UI와 상태 간 불일치가 발생 → 흐름 꼬임

이러한 문제를 방지하고자 **lifecycle-aware한 Flow 수집 방식**으로 개선했습니다.