### PR TITLE
[FIX/#195] 스크린샷 이미지 대응

### DIFF
--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/ModalImage.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/ModalImage.kt
@@ -41,11 +41,6 @@ internal fun ModalImage(
             .fillMaxSize()
             .background(HilingualTheme.colors.black)
     ) {
-        CloseOnlyTopAppBar(
-            onCloseClicked = onBackClick,
-            modifier = Modifier.align(Alignment.TopCenter)
-        )
-
         NetworkImage(
             imageUrl = imageUrl,
             shape = RectangleShape,
@@ -53,6 +48,13 @@ internal fun ModalImage(
             modifier = Modifier
                 .fillMaxWidth()
                 .align(Alignment.Center)
+        )
+
+        CloseOnlyTopAppBar(
+            onCloseClicked = onBackClick,
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .background(HilingualTheme.colors.black)
         )
     }
 }

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/ModalImage.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/ModalImage.kt
@@ -20,15 +20,12 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import com.hilingual.core.designsystem.component.image.NetworkImage
 import com.hilingual.core.designsystem.component.topappbar.CloseOnlyTopAppBar
 import com.hilingual.core.designsystem.theme.HilingualTheme
@@ -69,7 +66,7 @@ internal fun ModalImage(
 private fun PhotoDetailPreview() {
     HilingualTheme {
         ModalImage(
-            imageUrl = "https://avatars.githubusercontent.com/u/101113025?v=4",
+            imageUrl = "",
             onBackClick = {}
         )
     }

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/ModalImage.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/ModalImage.kt
@@ -17,14 +17,18 @@ package com.hilingual.presentation.diaryfeedback
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.hilingual.core.designsystem.component.image.NetworkImage
 import com.hilingual.core.designsystem.component.topappbar.CloseOnlyTopAppBar
 import com.hilingual.core.designsystem.theme.HilingualTheme
@@ -47,6 +51,7 @@ internal fun ModalImage(
             contentScale = ContentScale.FillWidth,
             modifier = Modifier
                 .fillMaxWidth()
+                .aspectRatio(9f / 16f)
                 .align(Alignment.Center)
         )
 
@@ -64,7 +69,7 @@ internal fun ModalImage(
 private fun PhotoDetailPreview() {
     HilingualTheme {
         ModalImage(
-            imageUrl = "",
+            imageUrl = "https://avatars.githubusercontent.com/u/101113025?v=4",
             onBackClick = {}
         )
     }


### PR DESCRIPTION
## Related issue 🛠
- closed #195 

## Work Description ✏️
- 기존 화면에서 흰색의 풀스크린 이미지가 들어가는 경우 상단의 x 버튼이 잘 보이지 않는 문제가 있어, 해당 상황에 대응했습니다.

## Screenshot 📸
| 수정 전 | 수정 후|
|:--:|:--:|
<img width="1080" height="2220" alt="image" src="https://github.com/user-attachments/assets/3fb90e5c-24fa-4faa-98ff-11250b6598f1" /> | <img width="1080" height="2220" alt="image" src="https://github.com/user-attachments/assets/72a94baf-0483-4550-bcf0-5eaf36674fcc" />

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
- 이전에 파일명을 `ModalImage`로 지었는데 뭔가 더 좋은 이름이 없을까?.. 싶은 생각에 고민이 계속되네요.
- 만약 이번에 사진 상세보기가 '다른 사람이 쓴 일기에서도 가능하다.'라고 한다면, 이 `ModalImage`는 디자인시스템으로 가야 할까요?.. 아니면 Screen으로 네이밍을 바꾸고 모듈을 따로 만들어야 할까요?