### PR TITLE
[FIX/#312] 피드 프로필 및 팔로우 화면 엠티뷰 수정

### DIFF
--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/follow/FollowListScreen.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/follow/FollowListScreen.kt
@@ -21,6 +21,7 @@ import com.hilingual.core.designsystem.component.topappbar.BackTopAppBar
 import com.hilingual.core.designsystem.theme.HilingualTheme
 import com.hilingual.presentation.feedprofile.follow.component.FollowTabRow
 import com.hilingual.presentation.feedprofile.follow.model.FollowItemModel
+import com.hilingual.presentation.feedprofile.profile.component.FeedEmptyCardType
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.launch
@@ -28,6 +29,8 @@ import kotlinx.coroutines.launch
 @Composable
 internal fun FollowListRoute(
     paddingValues: PaddingValues,
+    navigateUp: () -> Unit,
+    navigateToFeedProfile: (Long) -> Unit,
     viewModel: FollowListViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -36,9 +39,10 @@ internal fun FollowListRoute(
         paddingValues = paddingValues,
         followers = uiState.followerList,
         followings = uiState.followingList,
-        onBackClick = { },
-        onProfileClick = { },
-        onActionButtonClick = { _, _ -> }
+        onBackClick = navigateUp,
+        onProfileClick = navigateToFeedProfile,
+        onActionButtonClick = { userId, isFollowing ->
+        }
     )
 }
 
@@ -77,9 +81,9 @@ private fun FollowListScreen(
             state = pagerState,
             modifier = Modifier.fillMaxSize()
         ) { page ->
-            val followState = when (page) {
-                0 -> followers
-                else -> followings
+            val (followState, emptyCardType) = when (page) {
+                0 -> followers to FeedEmptyCardType.NO_FOLLOWER
+                else -> followings to FeedEmptyCardType.NO_FOLLOWING
             }
 
             when (followState) {
@@ -87,10 +91,12 @@ private fun FollowListScreen(
                 is UiState.Success -> {
                     FollowScreen(
                         follows = followState.data,
+                        emptyCardType = emptyCardType,
                         onProfileClick = onProfileClick,
                         onActionButtonClick = onActionButtonClick
                     )
                 }
+
                 else -> {}
             }
         }

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/follow/FollowListScreen.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/follow/FollowListScreen.kt
@@ -29,8 +29,6 @@ import kotlinx.coroutines.launch
 @Composable
 internal fun FollowListRoute(
     paddingValues: PaddingValues,
-    navigateUp: () -> Unit,
-    navigateToFeedProfile: (Long) -> Unit,
     viewModel: FollowListViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -39,10 +37,9 @@ internal fun FollowListRoute(
         paddingValues = paddingValues,
         followers = uiState.followerList,
         followings = uiState.followingList,
-        onBackClick = navigateUp,
-        onProfileClick = navigateToFeedProfile,
-        onActionButtonClick = { userId, isFollowing ->
-        }
+        onBackClick = { },
+        onProfileClick = { },
+        onActionButtonClick = { _, _ -> }
     )
 }
 

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/follow/FollowScreen.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/follow/FollowScreen.kt
@@ -3,6 +3,7 @@ package com.hilingual.presentation.feedprofile.follow
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -38,10 +39,8 @@ internal fun FollowScreen(
                 Column(
                     modifier = Modifier.fillParentMaxSize()
                 ) {
-                    FeedEmptyCard(
-                        type = emptyCardType,
-                        modifier = Modifier.padding(top = 140.dp)
-                    )
+                    Spacer(Modifier.weight(16f))
+                    FeedEmptyCard(type = emptyCardType)
                 }
             }
         } else {

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/follow/FollowScreen.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/follow/FollowScreen.kt
@@ -1,7 +1,9 @@
 package com.hilingual.presentation.feedprofile.follow
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -9,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.hilingual.core.designsystem.component.content.UserActionItem
+import com.hilingual.core.designsystem.theme.HilingualTheme
 import com.hilingual.presentation.feedprofile.follow.model.FollowItemModel
 import com.hilingual.presentation.feedprofile.follow.model.FollowState
 import com.hilingual.presentation.feedprofile.profile.component.FeedEmptyCard
@@ -18,21 +21,30 @@ import kotlinx.collections.immutable.ImmutableList
 @Composable
 internal fun FollowScreen(
     follows: ImmutableList<FollowItemModel>,
+    emptyCardType: FeedEmptyCardType,
     onProfileClick: (Long) -> Unit,
     onActionButtonClick: (Long, Boolean) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    if (follows.isEmpty()) {
-        FeedEmptyCard(
-            type = FeedEmptyCardType.NO_FOLLOWER,
-            modifier = modifier.fillMaxWidth()
-        )
-    } else {
-        LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(horizontal = 16.dp)
-        ) {
+    LazyColumn(
+        contentPadding = PaddingValues(bottom = 48.dp),
+        modifier = modifier
+            .fillMaxSize()
+            .background(HilingualTheme.colors.white)
+            .padding(horizontal = 16.dp)
+    ) {
+        if (follows.isEmpty()) {
+            item {
+                Column(
+                    modifier = Modifier.fillParentMaxSize()
+                ) {
+                    FeedEmptyCard(
+                        type = emptyCardType,
+                        modifier = Modifier.padding(top = 140.dp)
+                    )
+                }
+            }
+        } else {
             items(
                 items = follows,
                 key = { it.userId }

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/DiaryListScreen.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/DiaryListScreen.kt
@@ -3,6 +3,7 @@ package com.hilingual.presentation.feedprofile.profile
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -42,10 +43,8 @@ internal fun DiaryListScreen(
                 Column(
                     modifier = Modifier.fillParentMaxSize()
                 ) {
-                    FeedEmptyCard(
-                        type = emptyCardType,
-                        modifier = Modifier.padding(top = 140.dp)
-                    )
+                    Spacer(Modifier.weight(14f))
+                    FeedEmptyCard(type = emptyCardType)
                 }
             }
         } else {

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/DiaryListScreen.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/DiaryListScreen.kt
@@ -1,5 +1,7 @@
 package com.hilingual.presentation.feedprofile.profile
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -28,15 +30,25 @@ internal fun DiaryListScreen(
     onMenuClick: (diaryId: Long) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    if (diaries.isEmpty()) {
-        FeedEmptyCard(type = emptyCardType)
-    } else {
-        LazyColumn(
-            contentPadding = PaddingValues(bottom = 48.dp),
-            modifier = modifier
-                .fillMaxSize()
-                .padding(horizontal = 16.dp)
-        ) {
+    LazyColumn(
+        contentPadding = PaddingValues(bottom = 48.dp),
+        modifier = modifier
+            .fillMaxSize()
+            .background(HilingualTheme.colors.white)
+            .padding(horizontal = 16.dp)
+    ) {
+        if (diaries.isEmpty()) {
+            item {
+                Column(
+                    modifier = Modifier.fillParentMaxSize()
+                ) {
+                    FeedEmptyCard(
+                        type = emptyCardType,
+                        modifier = Modifier.padding(top = 140.dp)
+                    )
+                }
+            }
+        } else {
             itemsIndexed(
                 items = diaries,
                 key = { _, diary -> diary.diaryId }


### PR DESCRIPTION
## Related issue 🛠
- closed #312 

## Work Description ✏️
- 피드 프로필 스와이프 시 이상한 위치에 있는 엠티뷰를 조정했습니다
- 팔로잉, 팔로워 엠티뷰를 수정했습니다.

## Screenshot 📸
| BEFORE | AFTER |
|--|--|
| ![BEFORE](https://github.com/user-attachments/assets/8fa21210-a5ed-4e16-b9af-dc674bf670d3) | ![AFTER](https://github.com/user-attachments/assets/bb3853ed-812b-416b-98d9-f1206a0e8e17) |



<img width="208" height="460" alt="스크린샷 2025-08-28 오후 10 26 10" src="https://github.com/user-attachments/assets/0def6da1-91d1-4d74-8a95-c4862604cb7e" />
<img width="208" height="460" alt="스크린샷 2025-08-28 오후 10 26 20" src="https://github.com/user-attachments/assets/9291d7d9-de4f-4a32-87bf-19c5b644aa67" />

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
네비 연결 확인하다 엠티뷰 이상한 점들을 발견햇어요..,,, 빠르게 수정해서 pr 올립니다!