### PR TITLE
[FIX/#325] 일기 작성, 피드백 요청 로딩, 마이페이지 디자인 QA 이슈 반영

### DIFF
--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/TitleLeftAlignedTopAppBar.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/topappbar/TitleLeftAlignedTopAppBar.kt
@@ -41,7 +41,7 @@ fun TitleLeftAlignedTopAppBar(
         textAlign = TextAlign.Start,
         text = title,
         color = textColor,
-        style = HilingualTheme.typography.headM18
+        style = HilingualTheme.typography.headB18
     )
 }
 

--- a/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/DiaryFeedbackStatusScreen.kt
+++ b/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/DiaryFeedbackStatusScreen.kt
@@ -132,8 +132,8 @@ private fun DiaryFeedbackCompleteStatusScreenPreview() {
         DiaryFeedbackStatusScreen(
             paddingValues = PaddingValues(0.dp),
             uiData = FeedbackUIData(
-                title = "AI 피드백 완료!",
-                description = "틀린 부분을 고치고,\n더 나은 표현으로 수정했어요!",
+                title = "일기 저장 완료!",
+                description = "펜펜이가 틀린 부분을 고치고,\n더 나은 표현으로 수정했어요!",
                 media = FeedbackMedia.Lottie(
                     resId = R.raw.lottie_feedback_complete,
                     heightDp = 180.dp

--- a/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/component/DiaryWriteCancelDialog.kt
+++ b/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/component/DiaryWriteCancelDialog.kt
@@ -30,7 +30,7 @@ internal fun DiaryWriteCancelDialog(
         title = "일기 작성을 취소하시겠어요?",
         description = "지금 나가면 작성한 내용이 모두 사라져요!",
         cancelText = "아니요",
-        confirmText = "네, 취소할게요",
+        confirmText = "취소하기",
         onNegative = onNoClick,
         onPositive = onCancelClick,
         onDismiss = onDismiss

--- a/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/component/MyInfoBox.kt
+++ b/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/component/MyInfoBox.kt
@@ -2,7 +2,6 @@ package com.hilingual.presentation.mypage.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -57,11 +56,13 @@ internal fun MyInfoBox(
                         color = HilingualTheme.colors.gray200,
                         shape = CircleShape
                     )
+                    .noRippleClickable(onClick = onEditButtonClick)
             )
 
             Spacer(modifier = Modifier.width(10.dp))
 
             Text(
+                modifier = Modifier.noRippleClickable(onClick = onEditButtonClick),
                 text = profileNickname,
                 color = HilingualTheme.colors.gray850,
                 style = HilingualTheme.typography.headB18
@@ -72,7 +73,7 @@ internal fun MyInfoBox(
             Icon(
                 modifier = Modifier
                     .size(32.dp)
-                    .clickable(onClick = onEditButtonClick)
+                    .noRippleClickable(onClick = onEditButtonClick)
                     .padding(4.dp),
                 imageVector = ImageVector.vectorResource(R.drawable.ic_pen_24),
                 contentDescription = null,


### PR DESCRIPTION
## Related issue 🛠
- closed #325 

## Work Description ✏️
아래의 디자인 QA 이슈를 반영해 수정했습니다
- 일기 작성 - 취소모달 (바디 텍스트 크기 다름, 라이팅 다름, 딤 컬러 다름)
    - 바디 텍스트랑 딤 컬러는 큰나가 #324 에서 작업해줬길래 라이팅만 수정했습니다! 큰나 고마웡
- 피드백 요청 로딩 - '일기 저장 완료' 노출 문구 변경
- 마이페이지 - 헤더 (폰트 굵기 다름)
- 마이페이지 - 프로필카드 (프로필/닉네임 클릭해도 이동이 안됨)

## Screenshot 📸
| 일기 작성 취소 모달 - 수정 전 | 일기 작성 취소 모달 - 수정 후 |
|--|--|
| <img width="508" height="322" alt="스크린샷 2025-09-02 오전 10 04 18" src="https://github.com/user-attachments/assets/9ae440bb-46e3-42d3-b8b9-2fdd92e17332" /> | <img width="508" height="322" alt="스크린샷 2025-09-03 오전 2 15 32" src="https://github.com/user-attachments/assets/46dd35c0-7827-4c39-a5a9-ae1d9b4d21d9" /> |

| 피드백 요청 로딩 - 수정 전 | 피드백 요청 로딩 - 수정 후 |
|--|--|
| <img width="1080" height="2400" alt="Screenshot_20250903_020844" src="https://github.com/user-attachments/assets/e60dac69-74e9-4476-a53b-484c2c205ae4" /> | <img width="1080" height="2400" alt="Screenshot_20250903_020912" src="https://github.com/user-attachments/assets/7ba5ee8f-7824-4c69-9ba7-602e582b8dc6" /> |

| 마이페이지 헤더 - 수정 전 | 마이페이지 헤더 - 수정 후 |
|--|--|
| <img width="372" height="50" alt="TitleLeftAlignedTopAppBar_before" src="https://github.com/user-attachments/assets/ae934779-d1b4-451d-af15-3d92b87d89b3" /> | <img width="372" height="50" alt="TitleLeftAlignedTopAppBar_after" src="https://github.com/user-attachments/assets/1041ba7c-8054-4749-b8f5-617b97e62be2" /> |

https://github.com/user-attachments/assets/e6d3396d-d721-4e44-9417-aac6494300a8

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
- TitleLeftAlignedTopAppBar 글꼴 변경하면서 해당 컴포넌트를 사용 중인 큰나의 단어장 탑앱바 글꼴도 같이 변경되었는데, 얘두 원래는 디자인 QA에서 걸렸어야 하는 부분이었더라구요..?? (탑앱바 컴포넌트 작업할 때 내가 꼼꼼하게 못했나봐 엉엉) 그래두 글꼴은 같길래 그냥 내부에서 폰트만 바꿔줬습니당!
- 클릭 범위 수정하면서 리플도 없애버렸어용
