### PR TITLE
[MOD/#330] 로그인 서버 연결

### DIFF
--- a/core/localstorage/src/main/java/com/hilingual/core/localstorage/TokenManager.kt
+++ b/core/localstorage/src/main/java/com/hilingual/core/localstorage/TokenManager.kt
@@ -18,10 +18,8 @@ package com.hilingual.core.localstorage
 interface TokenManager {
     suspend fun saveAccessToken(token: String)
     suspend fun saveRefreshToken(token: String)
-    suspend fun saveTokens(accessToken: String, refreshToken: String, isProfileCompleted: Boolean)
+    suspend fun saveTokens(accessToken: String, refreshToken: String)
     suspend fun getAccessToken(): String?
     suspend fun getRefreshToken(): String?
-    suspend fun isProfileCompleted(): Boolean
     suspend fun clearTokens()
-    suspend fun completeOnboarding()
 }

--- a/core/localstorage/src/main/java/com/hilingual/core/localstorage/TokenManagerImpl.kt
+++ b/core/localstorage/src/main/java/com/hilingual/core/localstorage/TokenManagerImpl.kt
@@ -16,7 +16,6 @@
 package com.hilingual.core.localstorage
 
 import android.content.Context
-import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
@@ -38,7 +37,6 @@ class TokenManagerImpl @Inject constructor(
     private object PreferencesKeys {
         val ACCESS_TOKEN = stringPreferencesKey("access_token")
         val REFRESH_TOKEN = stringPreferencesKey("refresh_token")
-        val IS_PROFILE_COMPLETED = booleanPreferencesKey("is_profile_completed")
     }
 
     override suspend fun saveAccessToken(token: String) {
@@ -54,12 +52,11 @@ class TokenManagerImpl @Inject constructor(
         }
     }
 
-    override suspend fun saveTokens(accessToken: String, refreshToken: String, isProfileCompleted: Boolean) {
+    override suspend fun saveTokens(accessToken: String, refreshToken: String) {
         cachedAccessToken = accessToken
         context.dataStore.edit {
             it[PreferencesKeys.ACCESS_TOKEN] = accessToken
             it[PreferencesKeys.REFRESH_TOKEN] = refreshToken
-            it[PreferencesKeys.IS_PROFILE_COMPLETED] = isProfileCompleted
         }
     }
 
@@ -73,22 +70,11 @@ class TokenManagerImpl @Inject constructor(
         return context.dataStore.data.first()[PreferencesKeys.REFRESH_TOKEN]
     }
 
-    override suspend fun isProfileCompleted(): Boolean {
-        return context.dataStore.data.first()[PreferencesKeys.IS_PROFILE_COMPLETED] ?: false
-    }
-
     override suspend fun clearTokens() {
         cachedAccessToken = null
         context.dataStore.edit { preferences ->
             preferences.remove(PreferencesKeys.ACCESS_TOKEN)
             preferences.remove(PreferencesKeys.REFRESH_TOKEN)
-            preferences.remove(PreferencesKeys.IS_PROFILE_COMPLETED)
-        }
-    }
-
-    override suspend fun completeOnboarding() {
-        context.dataStore.edit {
-            it[PreferencesKeys.IS_PROFILE_COMPLETED] = true
         }
     }
 }

--- a/core/localstorage/src/main/java/com/hilingual/core/localstorage/UserInfoManager.kt
+++ b/core/localstorage/src/main/java/com/hilingual/core/localstorage/UserInfoManager.kt
@@ -1,0 +1,9 @@
+package com.hilingual.core.localstorage
+
+interface UserInfoManager {
+    suspend fun saveRegisterStatus(isCompleted: Boolean)
+    suspend fun getRegisterStatus(): Boolean
+    suspend fun saveOtpVerified(isVerified: Boolean)
+    suspend fun isOtpVerified(): Boolean
+    suspend fun clear()
+}

--- a/core/localstorage/src/main/java/com/hilingual/core/localstorage/UserInfoManagerImpl.kt
+++ b/core/localstorage/src/main/java/com/hilingual/core/localstorage/UserInfoManagerImpl.kt
@@ -1,0 +1,49 @@
+package com.hilingual.core.localstorage
+
+import android.content.Context
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.first
+import javax.inject.Inject
+import javax.inject.Singleton
+
+val Context.userInfoDataStore by preferencesDataStore(name = "hilingual_user_info_prefs")
+
+@Singleton
+class UserInfoManagerImpl @Inject constructor(
+    @ApplicationContext private val context: Context
+) : UserInfoManager {
+
+    private object PreferencesKeys {
+        val IS_REGISTER_COMPLETED = booleanPreferencesKey("is_register_completed")
+        val IS_OTP_VERIFIED = booleanPreferencesKey("is_otp_verified")
+    }
+
+    override suspend fun saveRegisterStatus(isCompleted: Boolean) {
+        context.userInfoDataStore.edit { preferences ->
+            preferences[PreferencesKeys.IS_REGISTER_COMPLETED] = isCompleted
+        }
+    }
+
+    override suspend fun getRegisterStatus(): Boolean {
+        return context.userInfoDataStore.data.first()[PreferencesKeys.IS_REGISTER_COMPLETED] ?: false
+    }
+
+    override suspend fun saveOtpVerified(isVerified: Boolean) {
+        context.userInfoDataStore.edit { preferences ->
+            preferences[PreferencesKeys.IS_OTP_VERIFIED] = isVerified
+        }
+    }
+
+    override suspend fun isOtpVerified(): Boolean {
+        return context.userInfoDataStore.data.first()[PreferencesKeys.IS_OTP_VERIFIED] ?: false
+    }
+
+    override suspend fun clear() {
+        context.userInfoDataStore.edit { preferences ->
+            preferences.clear()
+        }
+    }
+}

--- a/core/localstorage/src/main/java/com/hilingual/core/localstorage/di/LocalStorageModule.kt
+++ b/core/localstorage/src/main/java/com/hilingual/core/localstorage/di/LocalStorageModule.kt
@@ -17,6 +17,8 @@ package com.hilingual.core.localstorage.di
 
 import com.hilingual.core.localstorage.TokenManager
 import com.hilingual.core.localstorage.TokenManagerImpl
+import com.hilingual.core.localstorage.UserInfoManager
+import com.hilingual.core.localstorage.UserInfoManagerImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -30,4 +32,8 @@ abstract class LocalStorageModule {
     @Binds
     @Singleton
     abstract fun bindTokenManager(tokenManagerImpl: TokenManagerImpl): TokenManager
+
+    @Binds
+    @Singleton
+    abstract fun bindUserInfoManager(userInfoManagerImpl: UserInfoManagerImpl): UserInfoManager
 }

--- a/core/network/src/main/java/com/hilingual/core/network/TokenAuthenticator.kt
+++ b/core/network/src/main/java/com/hilingual/core/network/TokenAuthenticator.kt
@@ -71,8 +71,7 @@ class TokenAuthenticator @Inject constructor(
 
         return if (result.isSuccess) {
             val (newAccessToken, newRefreshToken) = result.getOrThrow()
-            val isProfileCompleted = tokenManager.isProfileCompleted()
-            tokenManager.saveTokens(newAccessToken, newRefreshToken, isProfileCompleted)
+            tokenManager.saveTokens(newAccessToken, newRefreshToken)
             Timber.d("토큰 재발급 성공. 요청 재시도.")
             response.request.newBuilder()
                 .header(AUTHORIZATION, "$BEARER $newAccessToken")

--- a/data/auth/build.gradle.kts
+++ b/data/auth/build.gradle.kts
@@ -41,9 +41,6 @@ android {
 }
 
 dependencies {
-    implementation(project(":core:common"))
-    implementation(project(":core:network"))
-
     // Google Auth
     api(libs.androidx.credentials)
     api(libs.googleid)

--- a/data/auth/src/main/java/com/hilingual/data/auth/datasource/AuthRemoteDataSource.kt
+++ b/data/auth/src/main/java/com/hilingual/data/auth/datasource/AuthRemoteDataSource.kt
@@ -16,8 +16,9 @@
 package com.hilingual.data.auth.datasource
 
 import com.hilingual.core.network.BaseResponse
+import com.hilingual.data.auth.dto.request.LoginRequestDto
 import com.hilingual.data.auth.dto.response.LoginResponseDto
 
 interface AuthRemoteDataSource {
-    suspend fun login(providerToken: String, provider: String): BaseResponse<LoginResponseDto>
+    suspend fun login(providerToken: String, loginRequestDto: LoginRequestDto): BaseResponse<LoginResponseDto>
 }

--- a/data/auth/src/main/java/com/hilingual/data/auth/datasourceimpl/AuthRemoteDataSourceImpl.kt
+++ b/data/auth/src/main/java/com/hilingual/data/auth/datasourceimpl/AuthRemoteDataSourceImpl.kt
@@ -25,6 +25,9 @@ import javax.inject.Inject
 internal class AuthRemoteDataSourceImpl @Inject constructor(
     private val loginService: LoginService
 ) : AuthRemoteDataSource {
-    override suspend fun login(providerToken: String, provider: String): BaseResponse<LoginResponseDto> =
-        loginService.login(providerToken, LoginRequestDto(provider))
+    override suspend fun login(
+        providerToken: String,
+        loginRequestDto: LoginRequestDto
+    ): BaseResponse<LoginResponseDto> =
+        loginService.login(providerToken, loginRequestDto)
 }

--- a/data/auth/src/main/java/com/hilingual/data/auth/dto/request/LoginRequestDto.kt
+++ b/data/auth/src/main/java/com/hilingual/data/auth/dto/request/LoginRequestDto.kt
@@ -21,5 +21,17 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class LoginRequestDto(
     @SerialName("provider")
-    val provider: String
+    val provider: String,
+    @SerialName("role")
+    val role: String,
+    @SerialName("deviceName")
+    val deviceName: String,
+    @SerialName("deviceType")
+    val deviceType: String,
+    @SerialName("osType")
+    val osType: String,
+    @SerialName("osVersion")
+    val osVersion: String,
+    @SerialName("appVersion")
+    val appVersion: String
 )

--- a/data/auth/src/main/java/com/hilingual/data/auth/dto/response/LoginResponseDto.kt
+++ b/data/auth/src/main/java/com/hilingual/data/auth/dto/response/LoginResponseDto.kt
@@ -24,6 +24,6 @@ data class LoginResponseDto(
     val accessToken: String,
     @SerialName("refreshToken")
     val refreshToken: String,
-    @SerialName("isProfileCompleted")
-    val isProfileCompleted: Boolean
+    @SerialName("registerStatus")
+    val registerStatus: Boolean
 )

--- a/data/auth/src/main/java/com/hilingual/data/auth/model/LoginModel.kt
+++ b/data/auth/src/main/java/com/hilingual/data/auth/model/LoginModel.kt
@@ -16,5 +16,5 @@
 package com.hilingual.data.auth.model
 
 data class LoginModel(
-    val isProfileCompleted: Boolean
+    val registerStatus: Boolean
 )

--- a/data/auth/src/main/java/com/hilingual/data/auth/repository/AuthRepository.kt
+++ b/data/auth/src/main/java/com/hilingual/data/auth/repository/AuthRepository.kt
@@ -20,5 +20,7 @@ import com.hilingual.data.auth.model.LoginModel
 
 interface AuthRepository {
     suspend fun signInWithGoogle(context: Context): Result<String>
-    suspend fun login(providerToken: String, provider: String): Result<LoginModel>
+    suspend fun login(providerToken: String): Result<LoginModel>
+    suspend fun getAccessToken(): String?
+    suspend fun getRefreshToken(): String?
 }

--- a/data/auth/src/main/java/com/hilingual/data/auth/repositoryimpl/AuthRepositoryImpl.kt
+++ b/data/auth/src/main/java/com/hilingual/data/auth/repositoryimpl/AuthRepositoryImpl.kt
@@ -16,25 +16,47 @@
 package com.hilingual.data.auth.repositoryimpl
 
 import android.content.Context
+import android.os.Build
 import com.hilingual.core.common.util.suspendRunCatching
 import com.hilingual.core.localstorage.TokenManager
+import com.hilingual.core.localstorage.UserInfoManager
 import com.hilingual.data.auth.datasource.AuthRemoteDataSource
 import com.hilingual.data.auth.datasource.GoogleAuthDataSource
+import com.hilingual.data.auth.dto.request.LoginRequestDto
 import com.hilingual.data.auth.model.LoginModel
 import com.hilingual.data.auth.repository.AuthRepository
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
 internal class AuthRepositoryImpl @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val authRemoteDataSource: AuthRemoteDataSource,
     private val googleAuthDataSource: GoogleAuthDataSource,
-    private val tokenManager: TokenManager
+    private val tokenManager: TokenManager,
+    private val userInfoManager: UserInfoManager
 ) : AuthRepository {
     override suspend fun signInWithGoogle(context: Context): Result<String> =
         googleAuthDataSource.signIn(context).map { it.idToken }
 
-    override suspend fun login(providerToken: String, provider: String): Result<LoginModel> = suspendRunCatching {
-        val loginResponse = authRemoteDataSource.login(providerToken, provider).data!!
-        tokenManager.saveTokens(loginResponse.accessToken, loginResponse.refreshToken, loginResponse.isProfileCompleted)
-        LoginModel(loginResponse.isProfileCompleted)
+    override suspend fun login(providerToken: String): Result<LoginModel> = suspendRunCatching {
+        val loginRequestDto = LoginRequestDto(
+            provider = "GOOGLE",
+            role = "USER",
+            deviceName = Build.MODEL,
+            deviceType = "PHONE",
+            osType = "Android",
+            osVersion = Build.VERSION.RELEASE,
+            appVersion = context.packageManager.getPackageInfo(context.packageName, 0).versionName ?: ""
+        )
+        val loginResponse = authRemoteDataSource.login(providerToken, loginRequestDto).data!!
+
+        tokenManager.saveTokens(loginResponse.accessToken, loginResponse.refreshToken)
+        userInfoManager.saveRegisterStatus(loginResponse.registerStatus)
+
+        LoginModel(loginResponse.registerStatus)
     }
+
+    override suspend fun getAccessToken(): String? = tokenManager.getAccessToken()
+
+    override suspend fun getRefreshToken(): String? = tokenManager.getRefreshToken()
 }

--- a/data/auth/src/main/java/com/hilingual/data/auth/service/TokenRefreshServiceImpl.kt
+++ b/data/auth/src/main/java/com/hilingual/data/auth/service/TokenRefreshServiceImpl.kt
@@ -28,7 +28,7 @@ internal class TokenRefreshServiceImpl @Inject constructor(
     override suspend fun refreshToken(refreshToken: String): Result<Pair<String, String>> = suspendRunCatching {
         val response = reissueService.reissueToken("$BEARER $refreshToken")
         val data = response.data!!
-        tokenManager.saveTokens(data.accessToken, data.refreshToken, tokenManager.isProfileCompleted())
+        tokenManager.saveTokens(data.accessToken, data.refreshToken)
         Pair(data.accessToken, data.refreshToken)
     }
 }

--- a/data/user/src/main/java/com/hilingual/data/user/repository/UserRepository.kt
+++ b/data/user/src/main/java/com/hilingual/data/user/repository/UserRepository.kt
@@ -29,4 +29,12 @@ interface UserRepository {
     ): Result<Unit>
 
     suspend fun getUserInfo(): Result<UserInfoModel>
+
+    suspend fun saveRegisterStatus(isCompleted: Boolean)
+
+    suspend fun getRegisterStatus(): Boolean
+
+    suspend fun saveOtpVerified(isVerified: Boolean)
+
+    suspend fun isOtpVerified(): Boolean
 }

--- a/data/user/src/main/java/com/hilingual/data/user/repositoryimpl/UserRepositoryImpl.kt
+++ b/data/user/src/main/java/com/hilingual/data/user/repositoryimpl/UserRepositoryImpl.kt
@@ -16,6 +16,7 @@
 package com.hilingual.data.user.repositoryimpl
 
 import com.hilingual.core.common.util.suspendRunCatching
+import com.hilingual.core.localstorage.UserInfoManager
 import com.hilingual.data.user.datasource.UserRemoteDataSource
 import com.hilingual.data.user.model.NicknameValidationResult
 import com.hilingual.data.user.model.UserInfoModel
@@ -26,7 +27,8 @@ import com.hilingual.data.user.repository.UserRepository
 import jakarta.inject.Inject
 
 internal class UserRepositoryImpl @Inject constructor(
-    private val userRemoteDataSource: UserRemoteDataSource
+    private val userRemoteDataSource: UserRemoteDataSource,
+    private val userInfoManager: UserInfoManager
 ) : UserRepository {
     override suspend fun getNicknameAvailability(nickname: String): Result<NicknameValidationResult> =
         suspendRunCatching {
@@ -48,4 +50,20 @@ internal class UserRepositoryImpl @Inject constructor(
         suspendRunCatching {
             userRemoteDataSource.getUserInfo().data!!.toModel()
         }
+
+    override suspend fun saveRegisterStatus(isCompleted: Boolean) {
+        userInfoManager.saveRegisterStatus(isCompleted)
+    }
+
+    override suspend fun getRegisterStatus(): Boolean {
+        return userInfoManager.getRegisterStatus()
+    }
+
+    override suspend fun saveOtpVerified(isVerified: Boolean) {
+        userInfoManager.saveOtpVerified(isVerified)
+    }
+
+    override suspend fun isOtpVerified(): Boolean {
+        return userInfoManager.isOtpVerified()
+    }
 }

--- a/presentation/auth/build.gradle.kts
+++ b/presentation/auth/build.gradle.kts
@@ -25,4 +25,5 @@ android {
 
 dependencies {
     implementation(projects.data.auth)
+    implementation(projects.data.user)
 }

--- a/presentation/onboarding/build.gradle.kts
+++ b/presentation/onboarding/build.gradle.kts
@@ -25,5 +25,4 @@ android {
 
 dependencies {
     implementation(projects.data.user)
-    implementation(projects.core.localstorage)
 }

--- a/presentation/onboarding/src/main/java/com/hilingual/presentation/onboarding/OnboardingViewModel.kt
+++ b/presentation/onboarding/src/main/java/com/hilingual/presentation/onboarding/OnboardingViewModel.kt
@@ -19,7 +19,6 @@ import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hilingual.core.common.extension.onLogFailure
-import com.hilingual.core.localstorage.TokenManager
 import com.hilingual.data.user.model.NicknameValidationResult
 import com.hilingual.data.user.model.UserProfileModel
 import com.hilingual.data.user.repository.UserRepository
@@ -44,8 +43,7 @@ private val specialCharRegex = Regex("[^a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣ]")
 
 @HiltViewModel
 internal class OnboardingViewModel @Inject constructor(
-    private val userRepository: UserRepository,
-    private val tokenManager: TokenManager
+    private val userRepository: UserRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(OnboardingUiState())
@@ -82,7 +80,7 @@ internal class OnboardingViewModel @Inject constructor(
         viewModelScope.launch {
             userRepository.postUserProfile(UserProfileModel(profileImg = "", nickname = nickname))
                 .onSuccess {
-                    tokenManager.completeOnboarding()
+                    userRepository.saveRegisterStatus(true)
                     _sideEffect.emit(OnboardingSideEffect.NavigateToHome)
                 }
                 .onLogFailure {

--- a/presentation/splash/build.gradle.kts
+++ b/presentation/splash/build.gradle.kts
@@ -24,5 +24,6 @@ android {
 }
 
 dependencies {
-    implementation(projects.core.localstorage)
+    implementation(projects.data.auth)
+    implementation(projects.data.user)
 }

--- a/presentation/splash/src/main/java/com/hilingual/presentation/splash/SplashViewModel.kt
+++ b/presentation/splash/src/main/java/com/hilingual/presentation/splash/SplashViewModel.kt
@@ -17,7 +17,8 @@ package com.hilingual.presentation.splash
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.hilingual.core.localstorage.TokenManager
+import com.hilingual.data.auth.repository.AuthRepository
+import com.hilingual.data.user.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.delay
@@ -28,7 +29,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 internal class SplashViewModel @Inject constructor(
-    private val tokenManager: TokenManager
+    private val authRepository: AuthRepository,
+    private val userRepository: UserRepository
 ) : ViewModel() {
 
     private val _sideEffect = MutableSharedFlow<SplashSideEffect>(
@@ -44,11 +46,11 @@ internal class SplashViewModel @Inject constructor(
 
     private fun checkLoginStatus() {
         viewModelScope.launch {
-            val accessToken = tokenManager.getAccessToken()
-            val refreshToken = tokenManager.getRefreshToken()
-            val isProfileCompleted = tokenManager.isProfileCompleted()
+            val accessToken = authRepository.getAccessToken()
+            val refreshToken = authRepository.getRefreshToken()
+            val isRegistered = userRepository.getRegisterStatus()
 
-            val isLoggedIn = !accessToken.isNullOrEmpty() && !refreshToken.isNullOrEmpty() && isProfileCompleted
+            val isLoggedIn = !accessToken.isNullOrEmpty() && !refreshToken.isNullOrEmpty() && isRegistered
             val effect = if (isLoggedIn) SplashSideEffect.NavigateToHome else SplashSideEffect.NavigateToAuth
 
             delay(1400L)


### PR DESCRIPTION
## Related issue 🛠
- closed #330

## Work Description ✏️
- 토큰매니저, 유저정보매니저 책임분리
- presentation에서 core localStorage 직접 의존제거
- 로그인 DTO 변경 대응
- 온보딩,스플래시,로그인에서 Manager의존 제거

## Screenshot 📸

https://github.com/user-attachments/assets/da34b5ee-d09a-4af6-9b1d-00ed99967ac7


## Uncompleted Tasks 😅
- [ ] 서버가 안대서 테스트 못했어요.

## To Reviewers 📢
소셜 로그인(구글, 애플) API 작업하면서 TokenManager에 붙어있던 isProfileComplite로직을 제거했습니다. 되게 거슬렸는데 드디어 작업하네요ㅎㅎ 그와 별개로 Manager의 책임분리로 인한 Splash,Onboarding,Auth의 뷰모델도 수정했습니다.
`core:localstorage`는 `presentation`에서 접근해도 문제는 없습니다만, repository를 통해서 데이터를 조작하도록 추상화를 했습니다. 생각을 좀 했었는데 이미 `core:localstorage`라는 데이터 소스에서 값을 얻어오는거라 `datasource`로 추상화는 안했습니다.

다음으로는 OTP 작업하고 온보딩 작업하겠습니다. 빠르게 인증쪽 작업을 마쳐야 여러분들이 편하게 테스트 하실테니..!