### PR TITLE
[FEAT/#343] 스프린트 ver 일기 API 연동

### DIFF
--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/model/DiaryContent.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/model/DiaryContent.kt
@@ -24,5 +24,6 @@ data class DiaryContent(
     val originalText: String = "",
     val aiText: String = "",
     val diffRanges: ImmutableList<Pair<Int, Int>> = persistentListOf(),
-    val imageUrl: String? = null
+    val imageUrl: String? = null,
+    val isPublished: Boolean = false
 )

--- a/data/diary/src/main/java/com/hilingual/data/diary/datasource/DiaryRemoteDataSource.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/datasource/DiaryRemoteDataSource.kt
@@ -55,4 +55,8 @@ interface DiaryRemoteDataSource {
     suspend fun patchDiaryUnpublish(
         diaryId: Long
     ): BaseResponse<Unit>
+
+    suspend fun deleteDiary(
+        diaryId: Long
+    ): BaseResponse<Unit>
 }

--- a/data/diary/src/main/java/com/hilingual/data/diary/datasource/DiaryRemoteDataSource.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/datasource/DiaryRemoteDataSource.kt
@@ -47,4 +47,12 @@ interface DiaryRemoteDataSource {
         date: RequestBody,
         imageFile: MultipartBody.Part? = null
     ): BaseResponse<DiaryFeedbackCreateResponseDto>
+
+    suspend fun patchDiaryPublish(
+        diaryId: Long
+    ): BaseResponse<Unit>
+
+    suspend fun patchDiaryUnpublish(
+        diaryId: Long
+    ): BaseResponse<Unit>
 }

--- a/data/diary/src/main/java/com/hilingual/data/diary/datasourceimpl/DiaryRemoteDataSourceImpl.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/datasourceimpl/DiaryRemoteDataSourceImpl.kt
@@ -58,4 +58,10 @@ internal class DiaryRemoteDataSourceImpl @Inject constructor(
             date = date,
             imageFile = imageFile
         )
+
+    override suspend fun patchDiaryPublish(diaryId: Long): BaseResponse<Unit> =
+        diaryService.patchDiaryPublish(diaryId)
+
+    override suspend fun patchDiaryUnpublish(diaryId: Long): BaseResponse<Unit> =
+        diaryService.patchDiaryUnpublish(diaryId)
 }

--- a/data/diary/src/main/java/com/hilingual/data/diary/datasourceimpl/DiaryRemoteDataSourceImpl.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/datasourceimpl/DiaryRemoteDataSourceImpl.kt
@@ -64,4 +64,7 @@ internal class DiaryRemoteDataSourceImpl @Inject constructor(
 
     override suspend fun patchDiaryUnpublish(diaryId: Long): BaseResponse<Unit> =
         diaryService.patchDiaryUnpublish(diaryId)
+
+    override suspend fun deleteDiary(diaryId: Long): BaseResponse<Unit> =
+        diaryService.deleteDiary(diaryId)
 }

--- a/data/diary/src/main/java/com/hilingual/data/diary/dto/response/DiaryContentResponseDto.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/dto/response/DiaryContentResponseDto.kt
@@ -29,7 +29,9 @@ data class DiaryContentResponseDto(
     @SerialName("diffRanges")
     val diffRanges: List<DiaryContentDiffRange>,
     @SerialName("imageUrl")
-    val imageUrl: String?
+    val imageUrl: String?,
+    @SerialName("isPublished")
+    val isPublished: Boolean
 )
 
 @Serializable

--- a/data/diary/src/main/java/com/hilingual/data/diary/model/BookmarkResult.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/model/BookmarkResult.kt
@@ -6,6 +6,6 @@ enum class BookmarkResult(val code: Int) {
     OVERCAPACITY(40301);
 
     companion object {
-        fun getErrorResult(code: Int) = entries.find { it.code == code } ?: DEFAULT
+        fun getOrError(code: Int) = entries.find { it.code == code } ?: DEFAULT
     }
 }

--- a/data/diary/src/main/java/com/hilingual/data/diary/model/BookmarkResult.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/model/BookmarkResult.kt
@@ -1,0 +1,16 @@
+package com.hilingual.data.diary.model
+
+// sealed interface BookmarkResult {
+//    data object isSuccess : BookmarkResult
+//    data class isError(val errorType: BookmarkErrorCode) : BookmarkResult
+// }
+
+enum class BookmarkResult(val code: Int) {
+    DEFAULT(-1),
+    SUCCESS(20000),
+    OVERCAPACITY(40301);
+
+    companion object {
+        fun getErrorResult(code: Int) = entries.find { it.code == code } ?: DEFAULT
+    }
+}

--- a/data/diary/src/main/java/com/hilingual/data/diary/model/BookmarkResult.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/model/BookmarkResult.kt
@@ -1,10 +1,5 @@
 package com.hilingual.data.diary.model
 
-// sealed interface BookmarkResult {
-//    data object isSuccess : BookmarkResult
-//    data class isError(val errorType: BookmarkErrorCode) : BookmarkResult
-// }
-
 enum class BookmarkResult(val code: Int) {
     DEFAULT(-1),
     SUCCESS(20000),

--- a/data/diary/src/main/java/com/hilingual/data/diary/model/DiaryModel.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/model/DiaryModel.kt
@@ -22,7 +22,8 @@ data class DiaryContentModel(
     val originalText: String,
     val rewriteText: String,
     val diffRanges: List<DiaryContentFeedback>,
-    val imageUrl: String?
+    val imageUrl: String?,
+    val isPublished: Boolean
 )
 
 data class DiaryContentFeedback(
@@ -38,5 +39,6 @@ internal fun DiaryContentResponseDto.toModel() = DiaryContentModel(
         DiaryContentFeedback(
             Pair(it.start, it.end)
         )
-    }
+    },
+    isPublished = this.isPublished
 )

--- a/data/diary/src/main/java/com/hilingual/data/diary/repository/DiaryRepository.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/repository/DiaryRepository.kt
@@ -16,6 +16,7 @@
 package com.hilingual.data.diary.repository
 
 import android.net.Uri
+import com.hilingual.data.diary.model.BookmarkResult
 import com.hilingual.data.diary.model.DiaryContentModel
 import com.hilingual.data.diary.model.DiaryFeedbackCreateModel
 import com.hilingual.data.diary.model.DiaryFeedbackModel
@@ -33,7 +34,7 @@ interface DiaryRepository {
     suspend fun patchPhraseBookmark(
         phraseId: Long,
         bookmarkModel: PhraseBookmarkModel
-    ): Result<Unit>
+    ): Result<BookmarkResult>
 
     suspend fun postDiaryFeedbackCreate(
         originalText: String,

--- a/data/diary/src/main/java/com/hilingual/data/diary/repository/DiaryRepository.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/repository/DiaryRepository.kt
@@ -48,4 +48,8 @@ interface DiaryRepository {
     suspend fun patchDiaryUnpublish(
         diaryId: Long
     ): Result<Unit>
+
+    suspend fun deleteDiary(
+        diaryId: Long
+    ): Result<Unit>
 }

--- a/data/diary/src/main/java/com/hilingual/data/diary/repository/DiaryRepository.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/repository/DiaryRepository.kt
@@ -40,4 +40,12 @@ interface DiaryRepository {
         date: LocalDate,
         imageFileUri: Uri? = null
     ): Result<DiaryFeedbackCreateModel>
+
+    suspend fun patchDiaryPublish(
+        diaryId: Long
+    ): Result<Unit>
+
+    suspend fun patchDiaryUnpublish(
+        diaryId: Long
+    ): Result<Unit>
 }

--- a/data/diary/src/main/java/com/hilingual/data/diary/repositoryimpl/DiaryRepositoryImpl.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/repositoryimpl/DiaryRepositoryImpl.kt
@@ -67,7 +67,7 @@ internal class DiaryRepositoryImpl @Inject constructor(
                 bookmarkRequestDto = bookmarkModel.toDto()
             )
 
-            BookmarkResult.getErrorResult(response.code)
+            BookmarkResult.getOrError(response.code)
         }
 
     override suspend fun postDiaryFeedbackCreate(

--- a/data/diary/src/main/java/com/hilingual/data/diary/repositoryimpl/DiaryRepositoryImpl.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/repositoryimpl/DiaryRepositoryImpl.kt
@@ -92,6 +92,16 @@ internal class DiaryRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun patchDiaryPublish(diaryId: Long): Result<Unit> =
+        suspendRunCatching {
+            diaryRemoteDataSource.patchDiaryPublish(diaryId)
+        }
+
+    override suspend fun patchDiaryUnpublish(diaryId: Long): Result<Unit> =
+        suspendRunCatching {
+            diaryRemoteDataSource.patchDiaryUnpublish(diaryId)
+        }
+
     companion object {
         const val APPLICATION_JSON = "application/json"
         const val IMAGE_FILE_NAME = "imageFile"

--- a/data/diary/src/main/java/com/hilingual/data/diary/repositoryimpl/DiaryRepositoryImpl.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/repositoryimpl/DiaryRepositoryImpl.kt
@@ -20,6 +20,7 @@ import android.net.Uri
 import com.hilingual.core.common.util.suspendRunCatching
 import com.hilingual.core.network.ContentUriRequestBody
 import com.hilingual.data.diary.datasource.DiaryRemoteDataSource
+import com.hilingual.data.diary.model.BookmarkResult
 import com.hilingual.data.diary.model.DiaryContentModel
 import com.hilingual.data.diary.model.DiaryFeedbackCreateModel
 import com.hilingual.data.diary.model.DiaryFeedbackModel
@@ -59,12 +60,14 @@ internal class DiaryRepositoryImpl @Inject constructor(
     override suspend fun patchPhraseBookmark(
         phraseId: Long,
         bookmarkModel: PhraseBookmarkModel
-    ): Result<Unit> =
+    ): Result<BookmarkResult> =
         suspendRunCatching {
-            diaryRemoteDataSource.patchPhraseBookmark(
+            val response = diaryRemoteDataSource.patchPhraseBookmark(
                 phraseId = phraseId,
                 bookmarkRequestDto = bookmarkModel.toDto()
             )
+
+            BookmarkResult.getErrorResult(response.code)
         }
 
     override suspend fun postDiaryFeedbackCreate(

--- a/data/diary/src/main/java/com/hilingual/data/diary/repositoryimpl/DiaryRepositoryImpl.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/repositoryimpl/DiaryRepositoryImpl.kt
@@ -102,6 +102,11 @@ internal class DiaryRepositoryImpl @Inject constructor(
             diaryRemoteDataSource.patchDiaryUnpublish(diaryId)
         }
 
+    override suspend fun deleteDiary(diaryId: Long): Result<Unit> =
+        suspendRunCatching {
+            diaryRemoteDataSource.deleteDiary(diaryId)
+        }
+
     companion object {
         const val APPLICATION_JSON = "application/json"
         const val IMAGE_FILE_NAME = "imageFile"

--- a/data/diary/src/main/java/com/hilingual/data/diary/service/DiaryService.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/service/DiaryService.kt
@@ -24,6 +24,7 @@ import com.hilingual.data.diary.dto.response.DiaryRecommendExpressionResponseDto
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Multipart
 import retrofit2.http.PATCH
@@ -68,6 +69,11 @@ internal interface DiaryService {
 
     @PATCH("/api/v1/diaries/{diaryId}/unpublish")
     suspend fun patchDiaryUnpublish(
+        @Path("diaryId") diaryId: Long
+    ): BaseResponse<Unit>
+
+    @DELETE("/api/v1/diaries/{diaryId}")
+    suspend fun deleteDiary(
         @Path("diaryId") diaryId: Long
     ): BaseResponse<Unit>
 }

--- a/data/diary/src/main/java/com/hilingual/data/diary/service/DiaryService.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/service/DiaryService.kt
@@ -60,4 +60,14 @@ internal interface DiaryService {
         @Part("date") date: RequestBody,
         @Part imageFile: MultipartBody.Part? = null
     ): BaseResponse<DiaryFeedbackCreateResponseDto>
+
+    @PATCH("/api/v1/diaries/{diaryId}/publish")
+    suspend fun patchDiaryPublish(
+        @Path("diaryId") diaryId: Long
+    ): BaseResponse<Unit>
+
+    @PATCH("/api/v1/diaries/{diaryId}/unpublish")
+    suspend fun patchDiaryUnpublish(
+        @Path("diaryId") diaryId: Long
+    ): BaseResponse<Unit>
 }

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
@@ -70,6 +70,7 @@ internal fun DiaryFeedbackRoute(
     navigateUp: () -> Unit,
     navigateToHome: () -> Unit,
     navigateToFeed: () -> Unit,
+    navigateToVoca: () -> Unit,
     viewModel: DiaryFeedbackViewModel = hiltViewModel()
 ) {
     val context = LocalContext.current
@@ -93,12 +94,22 @@ internal fun DiaryFeedbackRoute(
         when (it) {
             is DiaryFeedbackSideEffect.ShowRetryDialog -> dialogTrigger.show(it.onRetry)
 
-            is DiaryFeedbackSideEffect.ShowSnackbar -> {
+            is DiaryFeedbackSideEffect.ShowDiaryPublishSnackbar -> {
                 snackbarTrigger(
                     SnackbarRequest(
                         message = it.message,
                         buttonText = it.actionLabel,
                         onClick = navigateToFeed
+                    )
+                )
+            }
+
+            is DiaryFeedbackSideEffect.ShowVocaOverflowSnackbar -> {
+                snackbarTrigger(
+                    SnackbarRequest(
+                        message = it.message,
+                        buttonText = it.actionLabel,
+                        onClick = navigateToVoca
                     )
                 )
             }

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackUiState.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackUiState.kt
@@ -86,7 +86,8 @@ internal fun DiaryContentModel.toState() = DiaryContent(
     diffRanges = this.diffRanges.map {
         it.diffRange.first to it.diffRange.second
     }.toImmutableList(),
-    imageUrl = this.imageUrl
+    imageUrl = this.imageUrl,
+    isPublished = this.isPublished
 )
 
 internal fun DiaryFeedbackModel.toState() = FeedbackContent(

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackViewModel.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackViewModel.kt
@@ -122,7 +122,7 @@ internal class DiaryFeedbackViewModel @Inject constructor(
                 } else {
                     showToast("일기가 비공개되었어요!")
                 }
-            }.onFailure { exception ->
+            }.onLogFailure { exception ->
                 _uiState.value = UiState.Failure
                 _sideEffect.emit(
                     DiaryFeedbackSideEffect.ShowRetryDialog { loadInitialData() }
@@ -133,9 +133,7 @@ internal class DiaryFeedbackViewModel @Inject constructor(
 
     fun deleteDiary() {
         viewModelScope.launch {
-            diaryRepository.deleteDiary(
-                diaryId = diaryId
-            ).onSuccess {
+            diaryRepository.deleteDiary(diaryId = diaryId).onSuccess {
                 showToast("삭제가 완료되었어요.")
                 _sideEffect.emit(DiaryFeedbackSideEffect.NavigateToHome)
             }

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackViewModel.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackViewModel.kt
@@ -133,10 +133,13 @@ internal class DiaryFeedbackViewModel @Inject constructor(
 
 
     fun deleteDiary() {
-        // TODO: API 호출 성공 후 표시
         viewModelScope.launch {
-            showToast("삭제가 완료되었어요.")
-            _sideEffect.emit(DiaryFeedbackSideEffect.NavigateToHome)
+            diaryRepository.deleteDiary(
+                diaryId = diaryId
+            ).onSuccess {
+                showToast("삭제가 완료되었어요.")
+                _sideEffect.emit(DiaryFeedbackSideEffect.NavigateToHome)
+            }
         }
     }
 

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackViewModel.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackViewModel.kt
@@ -172,16 +172,12 @@ internal class DiaryFeedbackViewModel @Inject constructor(
         }
     }
 
-    private fun showPublishSnackbar() {
-        viewModelScope.launch {
-            _sideEffect.emit(DiaryFeedbackSideEffect.ShowSnackbar(message = "일기가 게시되었어요!", actionLabel = "보러가기"))
-        }
+    private suspend fun showPublishSnackbar() {
+        _sideEffect.emit(DiaryFeedbackSideEffect.ShowSnackbar(message = "일기가 게시되었어요!", actionLabel = "보러가기"))
     }
 
-    private fun showToast(message: String) {
-        viewModelScope.launch {
-            _sideEffect.emit(DiaryFeedbackSideEffect.ShowToast(message = message))
-        }
+    private suspend fun showToast(message: String) {
+        _sideEffect.emit(DiaryFeedbackSideEffect.ShowToast(message = message))
     }
 }
 

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackViewModel.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackViewModel.kt
@@ -75,6 +75,7 @@ internal class DiaryFeedbackViewModel @Inject constructor(
             val recommendExpressions = recommendExpressionsResult.getOrThrow()
 
             val newUiState = DiaryFeedbackUiState(
+                isPublished = diaryResult.isPublished,
                 writtenDate = diaryResult.writtenDate,
                 diaryContent = diaryResult.toState(),
                 feedbackList = feedbacks.map { it.toState() }.toImmutableList(),

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/navigation/DiaryFeedbackNavigation.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/navigation/DiaryFeedbackNavigation.kt
@@ -45,7 +45,8 @@ fun NavGraphBuilder.diaryFeedbackNavGraph(
     paddingValues: PaddingValues,
     navigateUp: () -> Unit,
     navigateToHome: () -> Unit,
-    navigateToFeed: () -> Unit
+    navigateToFeed: () -> Unit,
+    navigateToVoca: () -> Unit
 ) {
     composable<DiaryFeedback>(
         enterTransition = {
@@ -59,7 +60,8 @@ fun NavGraphBuilder.diaryFeedbackNavGraph(
             paddingValues = paddingValues,
             navigateUp = navigateUp,
             navigateToHome = navigateToHome,
-            navigateToFeed = navigateToFeed
+            navigateToFeed = navigateToFeed,
+            navigateToVoca = navigateToVoca
         )
     }
 }

--- a/presentation/main/src/main/java/com/hilingual/presentation/main/MainScreen.kt
+++ b/presentation/main/src/main/java/com/hilingual/presentation/main/MainScreen.kt
@@ -223,7 +223,8 @@ internal fun MainScreen(
                     paddingValues = innerPadding,
                     navigateUp = appState::navigateUp,
                     navigateToHome = appState::navigateToHome,
-                    navigateToFeed = appState::navigateToFeed
+                    navigateToFeed = appState::navigateToFeed,
+                    navigateToVoca = appState::navigateToVoca
                 )
 
                 feedNavGraph(

--- a/presentation/main/src/main/java/com/hilingual/presentation/main/state/MainAppState.kt
+++ b/presentation/main/src/main/java/com/hilingual/presentation/main/state/MainAppState.kt
@@ -143,6 +143,10 @@ internal class MainAppState(
         navController.navigateToHome(navOptions)
     }
 
+    fun navigateToVoca(navOptions: NavOptions? = clearStackNavOptions) {
+        navController.navigateToVoca(navOptions)
+    }
+
     fun navigateToOnboarding(navOptions: NavOptions? = clearStackNavOptions) {
         navController.navigateToOnboarding(navOptions)
     }


### PR DESCRIPTION
## Related issue 🛠
- closed #343 

## Work Description ✏️
- 피드 기능 추가에 따른 API 추가/변동사항에 대응합니다. (게시, 비공개, 삭제)
- UiState 캐스팅 로직 변경
- 토스트 중복 scope 삭제
- 단어 저장 개수 초과 에러 처리

## Screenshot 📸
<image width=375 src="https://github.com/user-attachments/assets/4e1c052d-995d-4c68-9afe-15de96f6bb6e">


## Uncompleted Tasks 😅
- [x] 단어 저장 개수 초과 에러 핸들링

## To Reviewers 📢
- 일기 게시/비공개 로직을 뷰모델 단에서 합쳐봤는데 괜찮을까요? (함수 하나 내에서 toggle 형태로 처리)
- 단어 저장 시 오류처리 할 때, 닉네임 쪽 로직 참고를 해봤는데요. enum에 code를 같이 저장하는 방식을 사용해봤습니다. 레포지토리에서 코드에 따라 에러 매칭해주는 게 더 나을지 고민이 좀 되는데, 이 부분 코멘트 남겨주시면 감사하겠습니다!