### PR TITLE
[MOD/#353] 단어장 뷰 api 변경 대응

### DIFF
--- a/data/voca/src/main/java/com/hilingual/data/voca/dto/response/VocaDetailResponseDto.kt
+++ b/data/voca/src/main/java/com/hilingual/data/voca/dto/response/VocaDetailResponseDto.kt
@@ -28,8 +28,8 @@ data class VocaDetailResponseDto(
     val phraseType: List<String>,
     @SerialName("explanation")
     val explanation: String,
-    @SerialName("writtenDate")
-    val writtenDate: String,
+    @SerialName("writtenFrom")
+    val writtenFrom: String,
     @SerialName("isBookmarked")
     val isBookmarked: Boolean
 )

--- a/data/voca/src/main/java/com/hilingual/data/voca/model/VocaDetailModel.kt
+++ b/data/voca/src/main/java/com/hilingual/data/voca/model/VocaDetailModel.kt
@@ -22,7 +22,7 @@ data class VocaDetailModel(
     val phrase: String,
     val phraseType: List<String>,
     val explanation: String,
-    val writtenDate: String,
+    val writtenFrom: String,
     val isBookmarked: Boolean
 )
 
@@ -32,6 +32,6 @@ internal fun VocaDetailResponseDto.toModel(): VocaDetailModel =
         phrase = this.phrase,
         phraseType = this.phraseType,
         explanation = this.explanation,
-        writtenDate = this.writtenDate,
+        writtenFrom = this.writtenFrom,
         isBookmarked = this.isBookmarked
     )

--- a/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaScreen.kt
+++ b/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaScreen.kt
@@ -127,7 +127,7 @@ internal fun VocaRoute(
                 phrase = vocaDetail.phrase,
                 phraseType = vocaDetail.phraseType.toPersistentList(),
                 explanation = vocaDetail.explanation,
-                writtenDate = vocaDetail.writtenDate,
+                writtenDate = vocaDetail.writtenFrom,
                 isBookmarked = vocaDetail.isBookmarked,
                 onBookmarkClick = { phraseId, isMarked ->
                     viewModel.toggleBookmark(phraseId = phraseId, isMarked = isMarked)

--- a/presentation/voca/src/main/java/com/hilingual/presentation/voca/component/VocaDialog.kt
+++ b/presentation/voca/src/main/java/com/hilingual/presentation/voca/component/VocaDialog.kt
@@ -134,7 +134,7 @@ internal fun VocaDialog(
             )
 
             Text(
-                text = "$writtenDate 일기에서 저장됨",
+                text = writtenDate,
                 style = HilingualTheme.typography.captionM12,
                 color = HilingualTheme.colors.gray400,
                 modifier = Modifier.align(Alignment.BottomEnd)


### PR DESCRIPTION
## Related issue 🛠
- closed #353 

## Work Description ✏️
- 특정 단어 세부 조회 api의 writtenDate를 writtenFrom으로 변경 대응 했습니다.

## Screenshot 📸
| 피드 | 내 일기 |
| ------ | ----- |
| <img width="1080" height="2400" alt="Screenshot_20250906_151428" src="https://github.com/user-attachments/assets/1a77a332-19da-49e3-b134-5b58728257f4" /> | <img width="1080" height="2400" alt="Screenshot_20250906_151441" src="https://github.com/user-attachments/assets/0d4937ee-d91e-4084-ba3e-57f85f7fc1a9" /> |

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢