### PR TITLE
[FEAT/#368] 피드 홈 ptr 적용 및 유저 관련 API 추가 연동

### DIFF
--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/content/FeedCard.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/content/FeedCard.kt
@@ -15,7 +15,6 @@
  */
 package com.hilingual.core.designsystem.component.content
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -41,7 +40,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -55,6 +53,7 @@ import com.hilingual.core.designsystem.component.dropdown.HilingualBasicDropdown
 import com.hilingual.core.designsystem.component.dropdown.HilingualDropdownMenuItem
 import com.hilingual.core.designsystem.component.image.ErrorImageSize
 import com.hilingual.core.designsystem.component.image.NetworkImage
+import com.hilingual.core.designsystem.component.image.ProfileImage
 import com.hilingual.core.designsystem.theme.HilingualTheme
 
 @Composable
@@ -83,28 +82,20 @@ fun FeedCard(
             .background(HilingualTheme.colors.white)
             .padding(vertical = 20.dp)
     ) {
-        val profileImageModifier = Modifier
-            .size(42.dp)
-            .clip(shape = CircleShape)
-            .border(
-                width = 1.dp,
-                color = HilingualTheme.colors.gray200,
-                shape = CircleShape
-            )
-            .noRippleClickable(onClick = onProfileClick)
+        ProfileImage(
+            imageUrl = profileUrl,
+            size = 42.dp,
+            modifier = Modifier
+                .size(42.dp)
+                .clip(shape = CircleShape)
+                .border(
+                    width = 1.dp,
+                    color = HilingualTheme.colors.gray200,
+                    shape = CircleShape
+                )
+                .noRippleClickable(onClick = onProfileClick)
+        )
 
-        if (profileUrl.isNullOrBlank()) {
-            Image(
-                painter = painterResource(R.drawable.img_default_image),
-                contentDescription = null,
-                modifier = profileImageModifier
-            )
-        } else {
-            NetworkImage(
-                imageUrl = profileUrl,
-                modifier = profileImageModifier
-            )
-        }
         Column {
             FeedHeader(
                 nickname = nickname,

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/content/FeedCard.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/content/FeedCard.kt
@@ -84,7 +84,6 @@ fun FeedCard(
     ) {
         ProfileImage(
             imageUrl = profileUrl,
-            size = 42.dp,
             modifier = Modifier
                 .size(42.dp)
                 .clip(shape = CircleShape)

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/content/UserActionItem.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/content/UserActionItem.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hilingual.core.common.extension.noRippleClickable
 import com.hilingual.core.designsystem.component.button.UserActionButton
-import com.hilingual.core.designsystem.component.image.NetworkImage
+import com.hilingual.core.designsystem.component.image.ProfileImage
 import com.hilingual.core.designsystem.theme.HilingualTheme
 
 @Composable
@@ -59,11 +59,10 @@ fun UserActionItem(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             modifier = Modifier.noRippleClickable(onClick = { onProfileClick(userId) })
         ) {
-            NetworkImage(
+            ProfileImage(
                 imageUrl = profileUrl,
-                shape = CircleShape,
+                size = 42.dp,
                 modifier = Modifier
-                    .size(42.dp)
                     .border(
                         width = 1.dp,
                         color = HilingualTheme.colors.gray200,

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/content/UserActionItem.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/content/UserActionItem.kt
@@ -61,8 +61,8 @@ fun UserActionItem(
         ) {
             ProfileImage(
                 imageUrl = profileUrl,
-                size = 42.dp,
                 modifier = Modifier
+                    .size(42.dp)
                     .border(
                         width = 1.dp,
                         color = HilingualTheme.colors.gray200,

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/image/ProfileImage.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/image/ProfileImage.kt
@@ -14,7 +14,7 @@ import com.hilingual.core.designsystem.R
 fun ProfileImage(
     imageUrl: String?,
     size: Dp,
-    modifier: Modifier = Modifier,
+    modifier: Modifier = Modifier
 ) {
     if (imageUrl.isNullOrBlank()) {
         Image(

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/image/ProfileImage.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/image/ProfileImage.kt
@@ -1,13 +1,11 @@
 package com.hilingual.core.designsystem.component.image
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.unit.Dp
 import com.hilingual.core.designsystem.R
 
 @Composable

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/image/ProfileImage.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/image/ProfileImage.kt
@@ -13,21 +13,18 @@ import com.hilingual.core.designsystem.R
 @Composable
 fun ProfileImage(
     imageUrl: String?,
-    size: Dp,
     modifier: Modifier = Modifier
 ) {
     if (imageUrl.isNullOrBlank()) {
         Image(
             painter = painterResource(R.drawable.img_default_image),
             contentDescription = null,
-            modifier = modifier
-                .size(size)
-                .clip(CircleShape)
+            modifier = modifier.clip(CircleShape)
         )
     } else {
         NetworkImage(
             imageUrl = imageUrl,
-            modifier = modifier.size(size)
+            modifier = modifier
         )
     }
 }

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/image/ProfileImage.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/image/ProfileImage.kt
@@ -1,0 +1,33 @@
+package com.hilingual.core.designsystem.component.image
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.Dp
+import com.hilingual.core.designsystem.R
+
+@Composable
+fun ProfileImage(
+    imageUrl: String?,
+    size: Dp,
+    modifier: Modifier = Modifier,
+) {
+    if (imageUrl.isNullOrBlank()) {
+        Image(
+            painter = painterResource(R.drawable.img_default_image),
+            contentDescription = null,
+            modifier = modifier
+                .size(size)
+                .clip(CircleShape)
+        )
+    } else {
+        NetworkImage(
+            imageUrl = imageUrl,
+            modifier = modifier.size(size)
+        )
+    }
+}

--- a/presentation/feed/build.gradle.kts
+++ b/presentation/feed/build.gradle.kts
@@ -26,4 +26,5 @@ android {
 dependencies {
     implementation(projects.data.feed)
     implementation(projects.data.diary)
+    implementation(projects.data.user)
 }

--- a/presentation/feed/src/main/java/com/hilingual/presentation/feed/FeedScreen.kt
+++ b/presentation/feed/src/main/java/com/hilingual/presentation/feed/FeedScreen.kt
@@ -82,7 +82,7 @@ internal fun FeedRoute(
     }
 
     LaunchedEffect(Unit) {
-        viewModel.loadFeedData()
+        viewModel.loadInitialFeedData()
     }
 
     with(uiState) {
@@ -91,6 +91,9 @@ internal fun FeedRoute(
             myProfileUrl = myProfileUrl,
             recommendFeedList = recommendFeedList,
             followingFeedList = followingFeedList,
+            recommendRefreshing = isRecommendRefreshing,
+            followingRefreshing = isFollowingRefreshing,
+            onFeedRefresh = viewModel::onFeedRefresh,
             hasFollowing = hasFollowing,
             onSearchClick = navigateToFeedSearch,
             onMyProfileClick = navigateToMyFeedProfile,
@@ -110,6 +113,8 @@ private fun FeedScreen(
     myProfileUrl: String,
     recommendFeedList: UiState<ImmutableList<FeedItemUiModel>>,
     followingFeedList: UiState<ImmutableList<FeedItemUiModel>>,
+    recommendRefreshing: Boolean,
+    followingRefreshing: Boolean,
     hasFollowing: Boolean,
     onMyProfileClick: () -> Unit,
     onSearchClick: () -> Unit,
@@ -119,6 +124,7 @@ private fun FeedScreen(
     onUnpublishClick: (Long) -> Unit,
     onReportClick: () -> Unit,
     readAllFeed: () -> Unit,
+    onFeedRefresh: (FeedTab) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val coroutineScope = rememberCoroutineScope()
@@ -205,10 +211,12 @@ private fun FeedScreen(
                 state = pagerState,
                 modifier = Modifier.fillMaxSize()
             ) { page ->
-                when (page) {
-                    0 -> FeedTabScreen(
+                when (val tab = FeedTab.entries[page]) {
+                    FeedTab.RECOMMEND -> FeedTabScreen(
                         listState = recommendListState,
                         feedListState = recommendFeedList,
+                        isRefreshing = recommendRefreshing,
+                        onRefresh = { onFeedRefresh(tab) },
                         onProfileClick = onFeedProfileClick,
                         onContentDetailClick = onContentDetailClick,
                         onLikeClick = onLikeClick,
@@ -216,9 +224,11 @@ private fun FeedScreen(
                         onUnpublishClick = onUnpublishClick,
                         onReportClick = onReportClick
                     )
-                    1 -> FeedTabScreen(
+                    FeedTab.FOLLOWING -> FeedTabScreen(
                         listState = followingsListState,
                         feedListState = followingFeedList,
+                        isRefreshing = followingRefreshing,
+                        onRefresh = { onFeedRefresh(tab) },
                         onProfileClick = onFeedProfileClick,
                         onContentDetailClick = onContentDetailClick,
                         onLikeClick = onLikeClick,
@@ -261,7 +271,10 @@ private fun FeedScreenPreview() {
             myProfileUrl = "",
             recommendFeedList = UiState.Success(persistentListOf()),
             followingFeedList = UiState.Success(persistentListOf()),
-            hasFollowing = false
+            hasFollowing = false,
+            recommendRefreshing = false,
+            followingRefreshing = false,
+            onFeedRefresh = {}
         )
     }
 }

--- a/presentation/feed/src/main/java/com/hilingual/presentation/feed/FeedTabScreen.kt
+++ b/presentation/feed/src/main/java/com/hilingual/presentation/feed/FeedTabScreen.kt
@@ -98,7 +98,7 @@ internal fun FeedTabScreen(
                         ) { index, feed ->
                             with(feed) {
                                 FeedCard(
-                                    profileUrl = profileUrl ?: "", // TODO: 이미지 null 처리 필요
+                                    profileUrl = profileUrl,
                                     onProfileClick = { onProfileClick(userId) },
                                     nickname = nickname,
                                     streak = streak,

--- a/presentation/feed/src/main/java/com/hilingual/presentation/feed/FeedTabScreen.kt
+++ b/presentation/feed/src/main/java/com/hilingual/presentation/feed/FeedTabScreen.kt
@@ -25,7 +25,9 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -44,10 +46,13 @@ import com.hilingual.presentation.feed.model.FeedItemUiModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun FeedTabScreen(
     listState: LazyListState,
     feedListState: UiState<ImmutableList<FeedItemUiModel>>,
+    isRefreshing: Boolean,
+    onRefresh: () -> Unit,
     onProfileClick: (Long) -> Unit,
     onContentDetailClick: (Long) -> Unit,
     onLikeClick: (Long, Boolean) -> Unit,
@@ -61,55 +66,61 @@ internal fun FeedTabScreen(
         is UiState.Success -> {
             val feedList = state.data
 
-            LazyColumn(
-                state = listState,
-                contentPadding = PaddingValues(bottom = 48.dp),
-                modifier = modifier
-                    .background(HilingualTheme.colors.white)
-                    .fillMaxSize()
-                    .padding(horizontal = 16.dp)
+            PullToRefreshBox(
+                isRefreshing = isRefreshing,
+                onRefresh = onRefresh,
+                modifier = modifier.fillMaxSize()
             ) {
-                if (feedList.isEmpty()) {
-                    item {
-                        Column(
-                            modifier = Modifier.fillParentMaxSize()
-                        ) {
-                            Spacer(Modifier.weight(16f))
-                            FeedEmptyCard(
-                                type = if (hasFollowing) FeedEmptyCardType.NOT_FEED else FeedEmptyCardType.NOT_FOLLOWING
-                            )
-                            Spacer(Modifier.weight(30f))
+                LazyColumn(
+                    state = listState,
+                    contentPadding = PaddingValues(bottom = 48.dp),
+                    modifier = Modifier
+                        .background(HilingualTheme.colors.white)
+                        .fillMaxSize()
+                        .padding(horizontal = 16.dp)
+                ) {
+                    if (feedList.isEmpty()) {
+                        item {
+                            Column(
+                                modifier = Modifier.fillParentMaxSize()
+                            ) {
+                                Spacer(Modifier.weight(16f))
+                                FeedEmptyCard(
+                                    type = if (hasFollowing) FeedEmptyCardType.NOT_FEED else FeedEmptyCardType.NOT_FOLLOWING
+                                )
+                                Spacer(Modifier.weight(30f))
+                            }
                         }
-                    }
-                } else {
-                    itemsIndexed(
-                        items = feedList,
-                        key = { _, feed -> feed.diaryId }
-                    ) { index, feed ->
-                        with(feed) {
-                            FeedCard(
-                                profileUrl = profileUrl ?: "", // TODO: 이미지 null 처리 필요
-                                onProfileClick = { onProfileClick(userId) },
-                                nickname = nickname,
-                                streak = streak,
-                                sharedDateInMinutes = sharedDateInMinutes,
-                                content = content,
-                                onContentDetailClick = { onContentDetailClick(diaryId) },
-                                imageUrl = imageUrl,
-                                likeCount = likeCount,
-                                isLiked = isLiked,
-                                onLikeClick = { onLikeClick(diaryId, !isLiked) },
-                                isMine = isMine,
-                                onUnpublishClick = { onUnpublishClick(diaryId) },
-                                onReportClick = onReportClick
-                            )
-                        }
+                    } else {
+                        itemsIndexed(
+                            items = feedList,
+                            key = { _, feed -> feed.diaryId }
+                        ) { index, feed ->
+                            with(feed) {
+                                FeedCard(
+                                    profileUrl = profileUrl ?: "", // TODO: 이미지 null 처리 필요
+                                    onProfileClick = { onProfileClick(userId) },
+                                    nickname = nickname,
+                                    streak = streak,
+                                    sharedDateInMinutes = sharedDateInMinutes,
+                                    content = content,
+                                    onContentDetailClick = { onContentDetailClick(diaryId) },
+                                    imageUrl = imageUrl,
+                                    likeCount = likeCount,
+                                    isLiked = isLiked,
+                                    onLikeClick = { onLikeClick(diaryId, !isLiked) },
+                                    isMine = isMine,
+                                    onUnpublishClick = { onUnpublishClick(diaryId) },
+                                    onReportClick = onReportClick
+                                )
+                            }
 
-                        if (index != feedList.lastIndex) {
-                            HorizontalDivider(
-                                color = HilingualTheme.colors.gray100,
-                                thickness = 1.dp
-                            )
+                            if (index != feedList.lastIndex) {
+                                HorizontalDivider(
+                                    color = HilingualTheme.colors.gray100,
+                                    thickness = 1.dp
+                                )
+                            }
                         }
                     }
                 }
@@ -159,6 +170,8 @@ private fun FeedTabScreenPreview() {
         FeedTabScreen(
             listState = rememberLazyListState(),
             feedListState = UiState.Success(sampleFeedList),
+            isRefreshing = false,
+            onRefresh = { },
             onProfileClick = { },
             onContentDetailClick = { },
             onLikeClick = { _, _ -> },

--- a/presentation/feed/src/main/java/com/hilingual/presentation/feed/FeedUiState.kt
+++ b/presentation/feed/src/main/java/com/hilingual/presentation/feed/FeedUiState.kt
@@ -23,9 +23,16 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 
+enum class FeedTab {
+    RECOMMEND,
+    FOLLOWING
+}
+
 @Immutable
 internal data class FeedUiState(
     val myProfileUrl: String = "",
+    val isRecommendRefreshing: Boolean = false,
+    val isFollowingRefreshing: Boolean = false,
     val recommendFeedList: UiState<ImmutableList<FeedItemUiModel>> = UiState.Loading,
     val followingFeedList: UiState<ImmutableList<FeedItemUiModel>> = UiState.Loading,
     val hasFollowing: Boolean = true

--- a/presentation/feed/src/main/java/com/hilingual/presentation/feed/FeedViewModel.kt
+++ b/presentation/feed/src/main/java/com/hilingual/presentation/feed/FeedViewModel.kt
@@ -70,23 +70,25 @@ internal class FeedViewModel @Inject constructor(
 
     private fun getMyProfile() {
         viewModelScope.launch {
-            userRepository.getUserLoginInfo().onSuccess { myInfo ->
-                _uiState.update {
-                    it.copy(
-                        myProfileUrl = myInfo.profileImg
-                    )
-                }
-            }.onLogFailure { }
+            userRepository.getUserLoginInfo()
+                .onSuccess { myInfo ->
+                    _uiState.update {
+                        it.copy(
+                            myProfileUrl = myInfo.profileImg
+                        )
+                    }
+                }.onLogFailure { }
         }
     }
 
     private fun getRecommendFeeds() {
         viewModelScope.launch {
+            _uiState.update { it.copy(isRecommendRefreshing = true) }
+
             feedRepository.getRecommendFeeds()
                 .onSuccess { feedResult ->
                     _uiState.update {
                         it.copy(
-                            isRecommendRefreshing = false,
                             recommendFeedList = UiState.Success(feedResult.toState())
                         )
                     }
@@ -94,11 +96,15 @@ internal class FeedViewModel @Inject constructor(
                 .onLogFailure {
                     emitRetrySideEffect { getRecommendFeeds() }
                 }
+
+            _uiState.update { it.copy(isRecommendRefreshing = false) }
         }
     }
 
     private fun getFollowingFeeds() {
         viewModelScope.launch {
+            _uiState.update { it.copy(isFollowingRefreshing = true) }
+
             feedRepository.getFollowingFeeds()
                 .onSuccess { feedResult ->
                     _uiState.update {
@@ -112,6 +118,8 @@ internal class FeedViewModel @Inject constructor(
                 .onLogFailure {
                     emitRetrySideEffect { getFollowingFeeds() }
                 }
+
+            _uiState.update { it.copy(isFollowingRefreshing = false) }
         }
     }
 

--- a/presentation/feed/src/main/java/com/hilingual/presentation/feed/FeedViewModel.kt
+++ b/presentation/feed/src/main/java/com/hilingual/presentation/feed/FeedViewModel.kt
@@ -49,10 +49,17 @@ internal class FeedViewModel @Inject constructor(
     private val _sideEffect = MutableSharedFlow<FeedSideEffect>()
     val sideEffect: SharedFlow<FeedSideEffect> = _sideEffect.asSharedFlow()
 
-    fun loadFeedData() {
+    fun loadInitialFeedData() {
         getMyProfile()
         getRecommendFeeds()
         getFollowingFeeds()
+    }
+
+    fun onFeedRefresh(tab: FeedTab) {
+        when (tab) {
+            FeedTab.RECOMMEND -> getRecommendFeeds()
+            FeedTab.FOLLOWING -> getFollowingFeeds()
+        }
     }
 
     fun readAllFeed() {
@@ -79,6 +86,7 @@ internal class FeedViewModel @Inject constructor(
                 .onSuccess { feedResult ->
                     _uiState.update {
                         it.copy(
+                            isRecommendRefreshing = false,
                             recommendFeedList = UiState.Success(feedResult.toState())
                         )
                     }
@@ -95,6 +103,7 @@ internal class FeedViewModel @Inject constructor(
                 .onSuccess { feedResult ->
                     _uiState.update {
                         it.copy(
+                            isFollowingRefreshing = false,
                             followingFeedList = UiState.Success(feedResult.toState()),
                             hasFollowing = feedResult.hasFollowing
                         )

--- a/presentation/feed/src/main/java/com/hilingual/presentation/feed/FeedViewModel.kt
+++ b/presentation/feed/src/main/java/com/hilingual/presentation/feed/FeedViewModel.kt
@@ -21,6 +21,7 @@ import com.hilingual.core.common.extension.onLogFailure
 import com.hilingual.core.common.util.UiState
 import com.hilingual.data.diary.repository.DiaryRepository
 import com.hilingual.data.feed.repository.FeedRepository
+import com.hilingual.data.user.repository.UserRepository
 import com.hilingual.presentation.feed.model.FeedItemUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.ImmutableList
@@ -39,7 +40,8 @@ import javax.inject.Inject
 @HiltViewModel
 internal class FeedViewModel @Inject constructor(
     private val feedRepository: FeedRepository,
-    private val diaryRepository: DiaryRepository
+    private val diaryRepository: DiaryRepository,
+    private val userRepository: UserRepository
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(FeedUiState())
     val uiState: StateFlow<FeedUiState> = _uiState.asStateFlow()
@@ -48,6 +50,7 @@ internal class FeedViewModel @Inject constructor(
     val sideEffect: SharedFlow<FeedSideEffect> = _sideEffect.asSharedFlow()
 
     fun loadFeedData() {
+        getMyProfile()
         getRecommendFeeds()
         getFollowingFeeds()
     }
@@ -55,6 +58,18 @@ internal class FeedViewModel @Inject constructor(
     fun readAllFeed() {
         viewModelScope.launch {
             emitToastSideEffect("피드의 일기를 모두 확인했어요.")
+        }
+    }
+
+    private fun getMyProfile() {
+        viewModelScope.launch {
+            userRepository.getUserLoginInfo().onSuccess { myInfo ->
+                _uiState.update {
+                    it.copy(
+                        myProfileUrl = myInfo.profileImg
+                    )
+                }
+            }.onLogFailure { }
         }
     }
 

--- a/presentation/feed/src/main/java/com/hilingual/presentation/feed/component/FeedTopAppBar.kt
+++ b/presentation/feed/src/main/java/com/hilingual/presentation/feed/component/FeedTopAppBar.kt
@@ -72,9 +72,9 @@ internal fun FeedTopAppBar(
 
         ProfileImage(
             imageUrl = profileImageUrl,
-            size = 36.dp,
             modifier = Modifier
                 .noRippleClickable(onClick = onProfileClick)
+                .size(36.dp)
                 .border(
                     width = 1.dp,
                     color = HilingualTheme.colors.gray400,

--- a/presentation/feed/src/main/java/com/hilingual/presentation/feed/component/FeedTopAppBar.kt
+++ b/presentation/feed/src/main/java/com/hilingual/presentation/feed/component/FeedTopAppBar.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hilingual.core.common.extension.noRippleClickable
 import com.hilingual.core.designsystem.R
-import com.hilingual.core.designsystem.component.image.NetworkImage
+import com.hilingual.core.designsystem.component.image.ProfileImage
 import com.hilingual.core.designsystem.theme.HilingualTheme
 
 @Composable
@@ -70,12 +70,11 @@ internal fun FeedTopAppBar(
 
         Spacer(Modifier.width(8.dp))
 
-        NetworkImage(
+        ProfileImage(
             imageUrl = profileImageUrl,
-            contentDescription = null,
+            size = 36.dp,
             modifier = Modifier
                 .noRippleClickable(onClick = onProfileClick)
-                .size(36.dp)
                 .border(
                     width = 1.dp,
                     color = HilingualTheme.colors.gray400,

--- a/presentation/feeddiary/build.gradle.kts
+++ b/presentation/feeddiary/build.gradle.kts
@@ -26,4 +26,5 @@ android {
 dependencies {
     implementation(projects.data.diary)
     implementation(projects.data.feed)
+    implementation(projects.data.user)
 }

--- a/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/FeedDiaryScreen.kt
+++ b/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/FeedDiaryScreen.kt
@@ -77,6 +77,8 @@ internal fun FeedDiaryRoute(
         when (it) {
             is FeedDiarySideEffect.NavigateToUp -> navigateUp()
 
+            is FeedDiarySideEffect.NavigateToFeedProfile -> navigateToFeedProfile(it.userId)
+
             is FeedDiarySideEffect.ShowVocaOverflowSnackbar -> {
                 snackbarTrigger(
                     SnackbarRequest(
@@ -129,7 +131,7 @@ private fun FeedDiaryScreen(
     onLikeClick: (Boolean) -> Unit,
     onPrivateClick: () -> Unit,
     onReportClick: () -> Unit,
-    onBlockClick: () -> Unit,
+    onBlockClick: (Long) -> Unit,
     isImageDetailVisible: Boolean,
     onChangeImageDetailVisible: () -> Unit,
     onToggleBookmark: (Long, Boolean) -> Unit
@@ -181,22 +183,22 @@ private fun FeedDiaryScreen(
             title = "피드"
         )
 
-        with(uiState.profileContent) {
+        with(uiState) {
             FeedDiaryProfile(
-                profileUrl = profileUrl,
-                nickname = nickname,
-                streak = streak,
-                isLiked = isLiked,
-                likeCount = likeCount,
-                sharedDateInMinutes = sharedDateInMinutes,
+                profileUrl = profileContent.profileUrl,
+                nickname = profileContent.nickname,
+                streak = profileContent.streak,
+                isLiked = profileContent.isLiked,
+                likeCount = profileContent.likeCount,
+                sharedDateInMinutes = profileContent.sharedDateInMinutes,
                 onProfileClick = {
-                    if (uiState.isMine) {
+                    if (isMine) {
                         onMyProfileClick()
                     } else {
-                        onProfileClick(userId)
+                        onProfileClick(profileContent.userId)
                     }
                 },
-                onLikeClick = { onLikeClick(!isLiked) }
+                onLikeClick = { onLikeClick(!profileContent.isLiked) }
             )
         }
 
@@ -301,7 +303,7 @@ private fun FeedDiaryScreen(
         onDismiss = { isBlockConfirmBottomSheetVisible = false },
         onBlockButtonClick = {
             isBlockConfirmBottomSheetVisible = false
-            onBlockClick()
+            onBlockClick(uiState.profileContent.userId)
         }
     )
 

--- a/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/FeedDiaryViewModel.kt
+++ b/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/FeedDiaryViewModel.kt
@@ -69,12 +69,14 @@ internal class FeedDiaryViewModel @Inject constructor(
                     val profileDeferred = async { feedRepository.getFeedDiaryProfile(diaryId) }
                     val contentDeferred = async { diaryRepository.getDiaryContent(diaryId) }
                     val feedbacksDeferred = async { diaryRepository.getDiaryFeedbacks(diaryId) }
-                    val recommendExpressionsDeferred = async { diaryRepository.getDiaryRecommendExpressions(diaryId) }
+                    val recommendExpressionsDeferred =
+                        async { diaryRepository.getDiaryRecommendExpressions(diaryId) }
 
                     val profileResult = profileDeferred.await().getOrThrow()
                     val contentResult = contentDeferred.await().getOrThrow()
                     val feedbacksResult = feedbacksDeferred.await().getOrThrow()
-                    val recommendExpressionsResult = recommendExpressionsDeferred.await().getOrThrow()
+                    val recommendExpressionsResult =
+                        recommendExpressionsDeferred.await().getOrThrow()
 
                     FeedDiaryUiState(
                         isMine = profileResult.isMine,
@@ -102,7 +104,8 @@ internal class FeedDiaryViewModel @Inject constructor(
                         it.copy(
                             profileContent = it.profileContent.copy(
                                 isLiked = isLiked,
-                                likeCount = (it.profileContent.likeCount + if (isLiked) 1 else -1).coerceAtLeast(0)
+                                likeCount = (it.profileContent.likeCount + if (isLiked) 1 else -1)
+                                    .coerceAtLeast(0)
                             )
                         )
                     }
@@ -113,9 +116,10 @@ internal class FeedDiaryViewModel @Inject constructor(
 
     fun blockUser(userId: Long) {
         viewModelScope.launch {
-            userRepository.putBlockUser(userId).onSuccess {
-                _sideEffect.emit(FeedDiarySideEffect.NavigateToFeedProfile(userId))
-            }.onLogFailure { }
+            userRepository.putBlockUser(userId)
+                .onSuccess {
+                    _sideEffect.emit(FeedDiarySideEffect.NavigateToFeedProfile(userId))
+                }.onLogFailure { }
         }
     }
 
@@ -171,7 +175,12 @@ internal class FeedDiaryViewModel @Inject constructor(
     }
 
     private suspend fun showVocaOverflowSnackbar() {
-        _sideEffect.emit(FeedDiarySideEffect.ShowVocaOverflowSnackbar(message = "단어장이 모두 찼어요!", actionLabel = "비우러가기"))
+        _sideEffect.emit(
+            FeedDiarySideEffect.ShowVocaOverflowSnackbar(
+                message = "단어장이 모두 찼어요!",
+                actionLabel = "비우러가기"
+            )
+        )
     }
 }
 
@@ -179,6 +188,8 @@ sealed interface FeedDiarySideEffect {
     data object NavigateToUp : FeedDiarySideEffect
     data class NavigateToFeedProfile(val userId: Long) : FeedDiarySideEffect
     data class ShowRetryDialog(val onRetry: () -> Unit) : FeedDiarySideEffect
-    data class ShowVocaOverflowSnackbar(val message: String, val actionLabel: String) : FeedDiarySideEffect
+    data class ShowVocaOverflowSnackbar(val message: String, val actionLabel: String) :
+        FeedDiarySideEffect
+
     data class ShowToast(val message: String) : FeedDiarySideEffect
 }

--- a/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/component/FeedDiaryProfile.kt
+++ b/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/component/FeedDiaryProfile.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
@@ -24,7 +25,7 @@ import androidx.compose.ui.unit.dp
 import com.hilingual.core.common.extension.noRippleClickable
 import com.hilingual.core.common.util.formatRelativeTime
 import com.hilingual.core.designsystem.R
-import com.hilingual.core.designsystem.component.image.NetworkImage
+import com.hilingual.core.designsystem.component.image.ProfileImage
 import com.hilingual.core.designsystem.theme.HilingualTheme
 
 @Composable
@@ -47,16 +48,18 @@ internal fun FeedDiaryProfile(
             .fillMaxWidth()
             .padding(vertical = 10.dp, horizontal = 20.dp)
     ) {
-        NetworkImage(
+        ProfileImage(
             imageUrl = profileUrl,
+            size = 42.dp,
             modifier = Modifier
-                .noRippleClickable(onClick = onProfileClick)
                 .size(42.dp)
+                .clip(shape = CircleShape)
                 .border(
                     width = 1.dp,
                     color = HilingualTheme.colors.gray200,
                     shape = CircleShape
                 )
+                .noRippleClickable(onClick = onProfileClick)
         )
 
         Spacer(Modifier.width(10.dp))

--- a/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/component/FeedDiaryProfile.kt
+++ b/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/component/FeedDiaryProfile.kt
@@ -16,7 +16,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
@@ -52,7 +51,6 @@ internal fun FeedDiaryProfile(
             imageUrl = profileUrl,
             modifier = Modifier
                 .size(42.dp)
-                .clip(shape = CircleShape)
                 .border(
                     width = 1.dp,
                     color = HilingualTheme.colors.gray200,

--- a/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/component/FeedDiaryProfile.kt
+++ b/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/component/FeedDiaryProfile.kt
@@ -50,7 +50,6 @@ internal fun FeedDiaryProfile(
     ) {
         ProfileImage(
             imageUrl = profileUrl,
-            size = 42.dp,
             modifier = Modifier
                 .size(42.dp)
                 .clip(shape = CircleShape)

--- a/presentation/main/src/main/java/com/hilingual/presentation/main/state/MainAppState.kt
+++ b/presentation/main/src/main/java/com/hilingual/presentation/main/state/MainAppState.kt
@@ -109,7 +109,7 @@ internal class MainAppState(
             }
         }
 
-        val vocaNavOptions = navOptions {
+        val refreshNavOptions = navOptions {
             popUpTo(0) {
                 inclusive = true
             }
@@ -118,8 +118,8 @@ internal class MainAppState(
 
         when (tab) {
             MainTab.HOME -> navController.navigateToHome(navOptions = navOptions)
-            MainTab.VOCA -> navController.navigateToVoca(navOptions = vocaNavOptions)
-            MainTab.FEED -> navController.navigateToFeed(navOptions = navOptions)
+            MainTab.VOCA -> navController.navigateToVoca(navOptions = refreshNavOptions)
+            MainTab.FEED -> navController.navigateToFeed(navOptions = refreshNavOptions)
             MainTab.MY -> navController.navigateToMyPage(navOptions = navOptions)
         }
     }
@@ -175,7 +175,6 @@ internal class MainAppState(
         navController.navigateToNotification(navOptions)
     }
 
-    // TODO: 추후 마이페이지의 스택관리로 변경해주세요 to.지영
     fun navigateToNotificationSetting(
         navOptions: NavOptions = navOptions {
             launchSingleTop = true

--- a/presentation/main/src/main/java/com/hilingual/presentation/main/state/MainAppState.kt
+++ b/presentation/main/src/main/java/com/hilingual/presentation/main/state/MainAppState.kt
@@ -143,7 +143,7 @@ internal class MainAppState(
         navController.navigateToHome(navOptions)
     }
 
-    fun navigateToVoca(navOptions: NavOptions? = null) {
+    fun navigateToVoca(navOptions: NavOptions? = clearStackNavOptions) {
         navController.navigateToVoca(navOptions)
     }
 


### PR DESCRIPTION
## Related issue 🛠
- closed #368 

## Work Description ✏️
- 피드 API들 작업 시에 연동 못했던 '내 정보 API(피드 홈)', '유저 차단 API(피드 일기)' 추가 연동
- ProfileImage 컴포넌트 생성 + 전체적으로 기본 이미지 적용 (isNullOrBlank)
- 피드 Pull To Refresh 구현

## Screenshot 📸
| 기존 | PTR 오류 수정본 |
|:--:|:--:|
<video width=375 src="https://github.com/user-attachments/assets/67501a33-36e9-4c5e-b3e0-cfcf21be08e1"> | <video width=375 src="https://github.com/user-attachments/assets/e7f0dddc-2cef-4d6d-90ff-5e43769c4341">




## Uncompleted Tasks 😅
- [x] PTR 인디케이터 오류 수정

## To Reviewers 📢
- 풀 땡기고 나서도 PTR 인디케이터가 사라지지 않고 계속 남아있는 오류가 있는데.. 뭐 때문일까요? 일단 일어나서 다시 봐보겠습니다.. 리프레시는 잘 됩니다.
- 피드 홈에서 '내 정보 API' 불러와서 profileImage 표시해주는데.. 이미지 하나 표시해주려고도 API 호출을 따로 해야하는 거겠죠?..