### PR TITLE
[FEAT/#356] 피드 프로필 유저 액션 관련 api 연결

### DIFF
--- a/presentation/feedprofile/build.gradle.kts
+++ b/presentation/feedprofile/build.gradle.kts
@@ -26,4 +26,5 @@ android {
 dependencies {
     implementation(projects.data.feed)
     implementation(projects.data.user)
+    implementation(projects.data.diary)
 }

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/DiaryListScreen.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/DiaryListScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -23,7 +24,6 @@ import com.hilingual.presentation.feedprofile.profile.component.FeedEmptyCardTyp
 import com.hilingual.presentation.feedprofile.profile.model.FeedDiaryUIModel
 import kotlinx.collections.immutable.ImmutableList
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun DiaryListScreen(
     diaries: ImmutableList<FeedDiaryUIModel>,
@@ -37,10 +37,13 @@ internal fun DiaryListScreen(
     onScrollStateChanged: ((Boolean) -> Unit)? = null,
     isNestedScroll: Boolean = false,
     canParentScroll: Boolean = true,
-    isRefreshing: Boolean,
-    onRefresh: () -> Unit
+    onListStateCreated: ((LazyListState) -> Unit)? = null
 ) {
     val listState = rememberLazyListState()
+
+    LaunchedEffect(listState) {
+        onListStateCreated?.invoke(listState)
+    }
 
     LaunchedEffect(listState.layoutInfo, diaries.size) {
         val layoutInfo = listState.layoutInfo
@@ -55,60 +58,55 @@ internal fun DiaryListScreen(
 
         onScrollStateChanged?.invoke(canScrollDown || canScrollUp)
     }
-    PullToRefreshBox(
-        isRefreshing = isRefreshing,
-        onRefresh = onRefresh,
-        modifier = modifier.fillMaxSize()
-    ) {
-        LazyColumn(
-            state = listState,
-            contentPadding = PaddingValues(bottom = 48.dp),
-            userScrollEnabled = if (isNestedScroll) canParentScroll else true,
-            modifier = modifier
-                .fillMaxSize()
-                .background(HilingualTheme.colors.white)
-                .padding(horizontal = 16.dp)
-        ) {
-            if (diaries.isEmpty()) {
-                item {
-                    Column(
-                        modifier = Modifier.fillParentMaxSize()
-                    ) {
-                        Spacer(modifier = Modifier.weight(140f))
-                        FeedEmptyCard(type = emptyCardType)
-                        Spacer(modifier = Modifier.weight(243f))
-                    }
-                }
-            } else {
-                itemsIndexed(
-                    items = diaries,
-                    key = { _, diary -> diary.diaryId }
-                ) { index, diary ->
-                    with(diary) {
-                        FeedCard(
-                            profileUrl = authorProfileImageUrl,
-                            onProfileClick = { onProfileClick(authorUserId) },
-                            nickname = authorNickname,
-                            streak = authorStreak,
-                            sharedDateInMinutes = sharedDate,
-                            content = originalText,
-                            onContentDetailClick = { onContentDetailClick(diaryId) },
-                            imageUrl = diaryImageUrl,
-                            likeCount = likeCount,
-                            isLiked = isLiked,
-                            onLikeClick = { onLikeClick(diaryId, !isLiked) },
-                            isMine = isMine,
-                            onUnpublishClick = { onUnpublishClick(diaryId) },
-                            onReportClick = onReportClick
-                        )
-                    }
 
-                    if (index < diaries.lastIndex) {
-                        HorizontalDivider(
-                            thickness = 1.dp,
-                            color = HilingualTheme.colors.gray100
-                        )
-                    }
+    LazyColumn(
+        state = listState,
+        contentPadding = PaddingValues(bottom = 48.dp),
+        userScrollEnabled = if (isNestedScroll) canParentScroll else true,
+        modifier = modifier
+            .fillMaxSize()
+            .background(HilingualTheme.colors.white)
+            .padding(horizontal = 16.dp)
+    ) {
+        if (diaries.isEmpty()) {
+            item {
+                Column(
+                    modifier = Modifier.fillParentMaxSize()
+                ) {
+                    Spacer(modifier = Modifier.weight(140f))
+                    FeedEmptyCard(type = emptyCardType)
+                    Spacer(modifier = Modifier.weight(243f))
+                }
+            }
+        } else {
+            itemsIndexed(
+                items = diaries,
+                key = { _, diary -> diary.diaryId }
+            ) { index, diary ->
+                with(diary) {
+                    FeedCard(
+                        profileUrl = authorProfileImageUrl,
+                        onProfileClick = { onProfileClick(authorUserId) },
+                        nickname = authorNickname,
+                        streak = authorStreak,
+                        sharedDateInMinutes = sharedDate,
+                        content = originalText,
+                        onContentDetailClick = { onContentDetailClick(diaryId) },
+                        imageUrl = diaryImageUrl,
+                        likeCount = likeCount,
+                        isLiked = isLiked,
+                        onLikeClick = { onLikeClick(diaryId, !isLiked) },
+                        isMine = isMine,
+                        onUnpublishClick = { onUnpublishClick(diaryId) },
+                        onReportClick = onReportClick
+                    )
+                }
+
+                if (index < diaries.lastIndex) {
+                    HorizontalDivider(
+                        thickness = 1.dp,
+                        color = HilingualTheme.colors.gray100
+                    )
                 }
             }
         }

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/DiaryListScreen.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/DiaryListScreen.kt
@@ -9,7 +9,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
@@ -21,6 +23,7 @@ import com.hilingual.presentation.feedprofile.profile.component.FeedEmptyCardTyp
 import com.hilingual.presentation.feedprofile.profile.model.FeedDiaryUIModel
 import kotlinx.collections.immutable.ImmutableList
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun DiaryListScreen(
     diaries: ImmutableList<FeedDiaryUIModel>,
@@ -33,7 +36,9 @@ internal fun DiaryListScreen(
     modifier: Modifier = Modifier,
     onScrollStateChanged: ((Boolean) -> Unit)? = null,
     isNestedScroll: Boolean = false,
-    canParentScroll: Boolean = true
+    canParentScroll: Boolean = true,
+    isRefreshing: Boolean,
+    onRefresh: () -> Unit
 ) {
     val listState = rememberLazyListState()
 
@@ -50,55 +55,60 @@ internal fun DiaryListScreen(
 
         onScrollStateChanged?.invoke(canScrollDown || canScrollUp)
     }
-
-    LazyColumn(
-        state = listState,
-        contentPadding = PaddingValues(bottom = 48.dp),
-        userScrollEnabled = if (isNestedScroll) canParentScroll else true,
-        modifier = modifier
-            .fillMaxSize()
-            .background(HilingualTheme.colors.white)
-            .padding(horizontal = 16.dp)
+    PullToRefreshBox(
+        isRefreshing = isRefreshing,
+        onRefresh = onRefresh,
+        modifier = modifier.fillMaxSize()
     ) {
-        if (diaries.isEmpty()) {
-            item {
-                Column(
-                    modifier = Modifier.fillParentMaxSize()
-                ) {
-                    Spacer(modifier = Modifier.weight(140f))
-                    FeedEmptyCard(type = emptyCardType)
-                    Spacer(modifier = Modifier.weight(243f))
+        LazyColumn(
+            state = listState,
+            contentPadding = PaddingValues(bottom = 48.dp),
+            userScrollEnabled = if (isNestedScroll) canParentScroll else true,
+            modifier = modifier
+                .fillMaxSize()
+                .background(HilingualTheme.colors.white)
+                .padding(horizontal = 16.dp)
+        ) {
+            if (diaries.isEmpty()) {
+                item {
+                    Column(
+                        modifier = Modifier.fillParentMaxSize()
+                    ) {
+                        Spacer(modifier = Modifier.weight(140f))
+                        FeedEmptyCard(type = emptyCardType)
+                        Spacer(modifier = Modifier.weight(243f))
+                    }
                 }
-            }
-        } else {
-            itemsIndexed(
-                items = diaries,
-                key = { _, diary -> diary.diaryId }
-            ) { index, diary ->
-                with(diary) {
-                    FeedCard(
-                        profileUrl = authorProfileImageUrl,
-                        onProfileClick = { onProfileClick(authorUserId) },
-                        nickname = authorNickname,
-                        streak = authorStreak,
-                        sharedDateInMinutes = sharedDate,
-                        content = originalText,
-                        onContentDetailClick = { onContentDetailClick(diaryId) },
-                        imageUrl = diaryImageUrl,
-                        likeCount = likeCount,
-                        isLiked = isLiked,
-                        onLikeClick = { onLikeClick(diaryId, !isLiked) },
-                        isMine = isMine,
-                        onUnpublishClick = { onUnpublishClick(diaryId) },
-                        onReportClick = onReportClick
-                    )
-                }
+            } else {
+                itemsIndexed(
+                    items = diaries,
+                    key = { _, diary -> diary.diaryId }
+                ) { index, diary ->
+                    with(diary) {
+                        FeedCard(
+                            profileUrl = authorProfileImageUrl,
+                            onProfileClick = { onProfileClick(authorUserId) },
+                            nickname = authorNickname,
+                            streak = authorStreak,
+                            sharedDateInMinutes = sharedDate,
+                            content = originalText,
+                            onContentDetailClick = { onContentDetailClick(diaryId) },
+                            imageUrl = diaryImageUrl,
+                            likeCount = likeCount,
+                            isLiked = isLiked,
+                            onLikeClick = { onLikeClick(diaryId, !isLiked) },
+                            isMine = isMine,
+                            onUnpublishClick = { onUnpublishClick(diaryId) },
+                            onReportClick = onReportClick
+                        )
+                    }
 
-                if (index < diaries.lastIndex) {
-                    HorizontalDivider(
-                        thickness = 1.dp,
-                        color = HilingualTheme.colors.gray100
-                    )
+                    if (index < diaries.lastIndex) {
+                        HorizontalDivider(
+                            thickness = 1.dp,
+                            color = HilingualTheme.colors.gray100
+                        )
+                    }
                 }
             }
         }

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/DiaryListScreen.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/DiaryListScreen.kt
@@ -10,9 +10,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/DiaryListScreen.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/DiaryListScreen.kt
@@ -35,14 +35,8 @@ internal fun DiaryListScreen(
     onScrollStateChanged: ((Boolean) -> Unit)? = null,
     isNestedScroll: Boolean = false,
     canParentScroll: Boolean = true,
-    onListStateCreated: ((LazyListState) -> Unit)? = null
+    listState: LazyListState = rememberLazyListState()
 ) {
-    val listState = rememberLazyListState()
-
-    LaunchedEffect(listState) {
-        onListStateCreated?.invoke(listState)
-    }
-
     LaunchedEffect(listState.layoutInfo, diaries.size) {
         val layoutInfo = listState.layoutInfo
 

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileScreen.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileScreen.kt
@@ -161,6 +161,7 @@ private fun FeedProfileScreen(
         snapshotFlow { pagerState.currentPage }.distinctUntilChanged().collect {
             val tabType = if (it == 0) DiaryTabType.SHARED else DiaryTabType.LIKED
             onTabRefresh(tabType)
+            profileListState.animateScrollToItem(0)
         }
     }
 

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileScreen.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileScreen.kt
@@ -168,6 +168,21 @@ private fun FeedProfileScreen(
             .collect { pageIndex ->
                 val tabType = if (pageIndex == 0) DiaryTabType.SHARED else DiaryTabType.LIKED
                 onTabRefresh(tabType)
+                coroutineScope.launch {
+                    profileListState.animateScrollToItem(0)
+                    when {
+                        profile.isMine -> {
+                            val currentListState = when (pageIndex) {
+                                0 -> sharedDiaryListState
+                                else -> likedDiaryListState
+                            }
+                            currentListState?.animateScrollToItem(0)
+                        }
+                        profile.isBlock != true -> {
+                            othersDiaryListState?.animateScrollToItem(0)
+                        }
+                    }
+                }
             }
     }
 

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileScreen.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileScreen.kt
@@ -160,11 +160,12 @@ private fun FeedProfileScreen(
     }
 
     LaunchedEffect(pagerState) {
-        snapshotFlow { pagerState.currentPage }.distinctUntilChanged().collect {
-            val tabType = if (it == 0) DiaryTabType.SHARED else DiaryTabType.LIKED
-            onTabRefresh(tabType)
-            profileListState.animateScrollToItem(0)
-        }
+        snapshotFlow { pagerState.currentPage }
+            .distinctUntilChanged()
+            .collect { pageIndex ->
+                val tabType = if (pageIndex == 0) DiaryTabType.SHARED else DiaryTabType.LIKED
+                onTabRefresh(tabType)
+            }
     }
 
     Box(
@@ -229,7 +230,12 @@ private fun FeedProfileScreen(
                                 tabIndex = pagerState.currentPage,
                                 onTabSelected = { index ->
                                     coroutineScope.launch {
-                                        pagerState.animateScrollToPage(index)
+                                        val tabType = if (index == 0) DiaryTabType.SHARED else DiaryTabType.LIKED
+                                        if (index == pagerState.currentPage) {
+                                            onTabRefresh(tabType)
+                                        } else {
+                                            pagerState.animateScrollToPage(index)
+                                        }
                                     }
                                 },
                                 modifier = Modifier

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileScreen.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
@@ -51,8 +50,6 @@ import com.hilingual.presentation.feedprofile.profile.component.FeedProfileInfo
 import com.hilingual.presentation.feedprofile.profile.component.FeedProfileTabRow
 import com.hilingual.presentation.feedprofile.profile.component.ReportBlockBottomSheet
 import com.hilingual.presentation.feedprofile.profile.model.DiaryTabType
-import com.hilingual.presentation.feedprofile.profile.model.FeedDiaryUIModel
-import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileScreen.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileScreen.kt
@@ -143,7 +143,15 @@ private fun FeedProfileScreen(
 
     val sharedDiaryListState = rememberLazyListState()
     val likedDiaryListState = rememberLazyListState()
-    val othersDiaryListState = rememberLazyListState()
+
+    val currentListState by remember {
+        derivedStateOf {
+            when (pagerState.currentPage) {
+                0 -> sharedDiaryListState
+                else -> likedDiaryListState
+            }
+        }
+    }
 
     val canParentScrollForOthers by remember {
         derivedStateOf { profileListState.firstVisibleItemIndex >= 1 }
@@ -175,14 +183,10 @@ private fun FeedProfileScreen(
                     profileListState.animateScrollToItem(0)
                     when {
                         profile.isMine -> {
-                            val currentListState = when (pageIndex) {
-                                0 -> sharedDiaryListState
-                                else -> likedDiaryListState
-                            }
                             currentListState.animateScrollToItem(0)
                         }
                         profile.isBlock != true -> {
-                            othersDiaryListState.animateScrollToItem(0)
+                            sharedDiaryListState.animateScrollToItem(0)
                         }
                     }
                 }
@@ -270,25 +274,19 @@ private fun FeedProfileScreen(
                                 state = pagerState,
                                 modifier = Modifier.fillParentMaxSize()
                             ) { page ->
-                                val diaries: ImmutableList<FeedDiaryUIModel>
-                                val emptyCardType: FeedEmptyCardType
-                                val tabType: DiaryTabType
-                                val listState: LazyListState
 
-                                when (page) {
-                                    0 -> {
-                                        diaries = uiState.sharedDiaries
-                                        emptyCardType = FeedEmptyCardType.NOT_SHARED
-                                        tabType = DiaryTabType.SHARED
-                                        listState = sharedDiaryListState
-                                    }
-
-                                    else -> {
-                                        diaries = uiState.likedDiaries
-                                        emptyCardType = FeedEmptyCardType.NOT_LIKED
-                                        tabType = DiaryTabType.LIKED
-                                        listState = likedDiaryListState
-                                    }
+                                val tabType = DiaryTabType.entries[page]
+                                val (diaries, emptyCardType, listState) = when (tabType) {
+                                    DiaryTabType.SHARED -> Triple(
+                                        uiState.sharedDiaries,
+                                        FeedEmptyCardType.NOT_SHARED,
+                                        sharedDiaryListState
+                                    )
+                                    DiaryTabType.LIKED -> Triple(
+                                        uiState.likedDiaries,
+                                        FeedEmptyCardType.NOT_LIKED,
+                                        likedDiaryListState
+                                    )
                                 }
 
                                 DiaryListScreen(
@@ -369,14 +367,10 @@ private fun FeedProfileScreen(
                     profileListState.animateScrollToItem(0)
                     when {
                         profile.isMine -> {
-                            val currentListState = when (pagerState.currentPage) {
-                                0 -> sharedDiaryListState
-                                else -> likedDiaryListState
-                            }
                             currentListState.animateScrollToItem(0)
                         }
                         profile.isBlock != true -> {
-                            othersDiaryListState.animateScrollToItem(0)
+                            sharedDiaryListState.animateScrollToItem(0)
                         }
                     }
                 }

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileScreen.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileScreen.kt
@@ -103,7 +103,8 @@ internal fun FeedProfileRoute(
                 onBlockClick = { viewModel.updateBlockState(state.data.feedProfileInfo.isBlock ?: false) },
                 onReportDiaryClick = { context.launchCustomTabs(UrlConstant.FEEDBACK_REPORT) },
                 onUnpublishClick = viewModel::diaryUnpublish,
-                onTabRefresh = viewModel::refreshTab
+                onTabRefresh = viewModel::refreshTab,
+                onUserRefresh = viewModel::onUserRefresh
             )
         }
 
@@ -126,6 +127,7 @@ private fun FeedProfileScreen(
     onUnpublishClick: (diaryId: Long) -> Unit,
     onReportDiaryClick: () -> Unit,
     onTabRefresh: (DiaryTabType) -> Unit,
+    onUserRefresh: (DiaryTabType) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val pagerState = rememberPagerState(pageCount = { 2 })
@@ -255,10 +257,12 @@ private fun FeedProfileScreen(
                                     onUnpublishClick = onUnpublishClick,
                                     onReportClick = onReportDiaryClick,
                                     onScrollStateChanged = { isScrollable ->
-                                        shouldEnableScroll = isScrollable
+                                        shouldEnableScroll = !isScrollable
                                     },
                                     isNestedScroll = true,
-                                    canParentScroll = canParentScrollForMine,
+                                    canParentScroll = !canParentScrollForMine,
+                                    isRefreshing = if (tabType == DiaryTabType.SHARED) uiState.isSharedRefreshing else uiState.isLikedRefreshing,
+                                    onRefresh = { onUserRefresh(tabType) },
                                     modifier = Modifier.fillParentMaxSize()
                                 )
                             }
@@ -303,10 +307,12 @@ private fun FeedProfileScreen(
                                 onUnpublishClick = onUnpublishClick,
                                 onReportClick = onReportDiaryClick,
                                 onScrollStateChanged = { isScrollable ->
-                                    shouldEnableScroll = isScrollable
+                                    shouldEnableScroll = !isScrollable
                                 },
                                 isNestedScroll = true,
-                                canParentScroll = canParentScrollForOthers,
+                                canParentScroll = !canParentScrollForOthers,
+                                isRefreshing = uiState.isSharedRefreshing,
+                                onRefresh = { onTabRefresh(DiaryTabType.SHARED) },
                                 modifier = Modifier.fillParentMaxSize()
                             )
                         }
@@ -378,7 +384,8 @@ private fun FeedProfileScreenPreview() {
             onLikeClick = { _, _, _ -> },
             onUnpublishClick = {},
             onReportDiaryClick = {},
-            onTabRefresh = {}
+            onTabRefresh = {},
+            onUserRefresh = {}
         )
     }
 }

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileUiState.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileUiState.kt
@@ -10,9 +10,7 @@ import kotlinx.collections.immutable.persistentListOf
 data class FeedProfileUiState(
     val feedProfileInfo: FeedProfileInfoModel,
     val sharedDiaries: ImmutableList<FeedDiaryUIModel> = persistentListOf(),
-    val likedDiaries: ImmutableList<FeedDiaryUIModel> = persistentListOf(),
-    val isSharedRefreshing: Boolean = false,
-    val isLikedRefreshing: Boolean = false
+    val likedDiaries: ImmutableList<FeedDiaryUIModel> = persistentListOf()
 ) {
     companion object {
         val Fake = FeedProfileUiState(

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileUiState.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileUiState.kt
@@ -10,7 +10,9 @@ import kotlinx.collections.immutable.persistentListOf
 data class FeedProfileUiState(
     val feedProfileInfo: FeedProfileInfoModel,
     val sharedDiaries: ImmutableList<FeedDiaryUIModel> = persistentListOf(),
-    val likedDiaries: ImmutableList<FeedDiaryUIModel> = persistentListOf()
+    val likedDiaries: ImmutableList<FeedDiaryUIModel> = persistentListOf(),
+    val isSharedRefreshing: Boolean = false,
+    val isLikedRefreshing: Boolean = false
 ) {
     companion object {
         val Fake = FeedProfileUiState(

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileViewModel.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileViewModel.kt
@@ -124,12 +124,13 @@ internal class FeedProfileViewModel @Inject constructor(
     }
 
     fun refreshTab(tabType: DiaryTabType) {
-        val currentState = _uiState.value as? UiState.Success ?: return
-        val feedProfileModel = currentState.data.feedProfileInfo
-
-        when (tabType) {
-            DiaryTabType.SHARED -> { loadSharedDiaries(feedProfileModel) }
-            DiaryTabType.LIKED -> { loadLikedDiaries() }
+        _uiState.updateSuccess { currentState ->
+            val feedProfileModel = currentState.feedProfileInfo
+            when (tabType) {
+                DiaryTabType.SHARED -> loadSharedDiaries(feedProfileModel)
+                DiaryTabType.LIKED -> loadLikedDiaries()
+            }
+            currentState
         }
     }
 
@@ -155,6 +156,7 @@ internal class FeedProfileViewModel @Inject constructor(
                         }
                     }
                 }
+                .onLogFailure {  }
         }
     }
 
@@ -177,7 +179,6 @@ internal class FeedProfileViewModel @Inject constructor(
         viewModelScope.launch {
             diaryRepository.patchDiaryUnpublish(diaryId)
                 .onSuccess {
-                    _sideEffect.emit(FeedProfileSideEffect.ShowToast(message = "일기가 비공개 되었어요."))
                     _uiState.updateSuccess { currentState ->
 
                         val updatedSharedDiaries = currentState.sharedDiaries
@@ -186,6 +187,7 @@ internal class FeedProfileViewModel @Inject constructor(
 
                         currentState.copy(sharedDiaries = updatedSharedDiaries)
                     }
+                    _sideEffect.emit(FeedProfileSideEffect.ShowToast(message = "일기가 비공개 되었어요."))
                 }
                 .onLogFailure { }
         }

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileViewModel.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileViewModel.kt
@@ -84,12 +84,8 @@ internal class FeedProfileViewModel @Inject constructor(
         }
     }
 
-    private fun loadSharedDiaries(feedProfileInfoModel: FeedProfileInfoModel, isUserRefresh: Boolean = false) {
+    private fun loadSharedDiaries(feedProfileInfoModel: FeedProfileInfoModel) {
         viewModelScope.launch {
-            if (isUserRefresh) {
-                setRefreshing(DiaryTabType.SHARED, isRefreshing = true)
-            }
-
             feedRepository.getSharedDiaries(targetUserId)
                 .onSuccess { sharedDiariesModel ->
                     val sharedDiaryUIModels = sharedDiariesModel.diaryList.map { sharedDiary ->
@@ -106,19 +102,11 @@ internal class FeedProfileViewModel @Inject constructor(
                 .onLogFailure {
                     _sideEffect.emit(FeedProfileSideEffect.ShowRetryDialog { loadFeedProfile() })
                 }
-
-            if (isUserRefresh) {
-                setRefreshing(DiaryTabType.SHARED, isRefreshing = false)
-            }
         }
     }
 
-    private fun loadLikedDiaries(isUserRefresh: Boolean = false) {
+    private fun loadLikedDiaries() {
         viewModelScope.launch {
-            if (isUserRefresh) {
-                setRefreshing(DiaryTabType.LIKED, isRefreshing = true)
-            }
-
             feedRepository.getLikedDiaries(targetUserId)
                 .onSuccess { likedDiariesModel ->
                     val likedDiaryUIModels = likedDiariesModel.diaryList.map { likedDiaryItem ->
@@ -132,41 +120,16 @@ internal class FeedProfileViewModel @Inject constructor(
                 .onLogFailure {
                     _sideEffect.emit(FeedProfileSideEffect.ShowRetryDialog { loadFeedProfile() })
                 }
-
-            if (isUserRefresh) {
-                setRefreshing(DiaryTabType.LIKED, isRefreshing = false)
-            }
         }
     }
 
     fun refreshTab(tabType: DiaryTabType) {
-        loadTab(tabType, isUserRefresh = false)
-    }
-
-    fun onUserRefresh(tabType: DiaryTabType) {
-        loadTab(tabType, isUserRefresh = true)
-    }
-
-    private fun loadTab(tabType: DiaryTabType, isUserRefresh: Boolean) {
         val currentState = _uiState.value as? UiState.Success ?: return
         val feedProfileModel = currentState.data.feedProfileInfo
 
         when (tabType) {
-            DiaryTabType.SHARED -> {
-                loadSharedDiaries(feedProfileModel, isUserRefresh)
-            }
-            DiaryTabType.LIKED -> {
-                loadLikedDiaries(isUserRefresh)
-            }
-        }
-    }
-
-    private fun setRefreshing(tabType: DiaryTabType, isRefreshing: Boolean) {
-        _uiState.updateSuccess { currentState ->
-            when (tabType) {
-                DiaryTabType.SHARED -> currentState.copy(isSharedRefreshing = isRefreshing)
-                DiaryTabType.LIKED -> currentState.copy(isLikedRefreshing = isRefreshing)
-            }
+            DiaryTabType.SHARED -> { loadSharedDiaries(feedProfileModel) }
+            DiaryTabType.LIKED -> { loadLikedDiaries() }
         }
     }
 

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileViewModel.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileViewModel.kt
@@ -7,7 +7,9 @@ import androidx.navigation.toRoute
 import com.hilingual.core.common.extension.onLogFailure
 import com.hilingual.core.common.extension.updateSuccess
 import com.hilingual.core.common.util.UiState
+import com.hilingual.data.diary.repository.DiaryRepository
 import com.hilingual.data.feed.repository.FeedRepository
+import com.hilingual.data.user.repository.UserRepository
 import com.hilingual.presentation.feedprofile.profile.model.DiaryTabType
 import com.hilingual.presentation.feedprofile.profile.model.FeedDiaryUIModel
 import com.hilingual.presentation.feedprofile.profile.model.FeedProfileInfoModel
@@ -30,6 +32,8 @@ import javax.inject.Inject
 @HiltViewModel
 internal class FeedProfileViewModel @Inject constructor(
     private val feedRepository: FeedRepository,
+    private val userRepository: UserRepository,
+    private val diaryRepository: DiaryRepository,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
     private val targetUserId: Long = savedStateHandle.toRoute<FeedProfileGraph>().userId
@@ -42,7 +46,6 @@ internal class FeedProfileViewModel @Inject constructor(
 
     init {
         loadFeedProfile()
-        loadLikedDiaries()
     }
 
     private fun loadFeedProfile() {
@@ -122,21 +125,26 @@ internal class FeedProfileViewModel @Inject constructor(
 
     fun toggleIsLiked(diaryId: Long, isLiked: Boolean, type: DiaryTabType) {
         viewModelScope.launch {
-            _uiState.updateSuccess { currentState ->
-                when (type) {
-                    DiaryTabType.SHARED -> {
-                        currentState.copy(
-                            sharedDiaries = currentState.sharedDiaries.updateLikeState(diaryId, isLiked)
-                        )
-                    }
-
-                    DiaryTabType.LIKED -> {
-                        currentState.copy(
-                            likedDiaries = currentState.likedDiaries.updateLikeState(diaryId, isLiked)
-                        )
+            feedRepository.postIsLike(
+                diaryId = diaryId,
+                isLiked = isLiked
+            )
+                .onSuccess {
+                    _uiState.updateSuccess { currentState ->
+                        when (type) {
+                            DiaryTabType.SHARED -> {
+                                currentState.copy(
+                                    sharedDiaries = currentState.sharedDiaries.updateLikeState(diaryId, isLiked)
+                                )
+                            }
+                            DiaryTabType.LIKED -> {
+                                currentState.copy(
+                                    likedDiaries = currentState.likedDiaries.updateLikeState(diaryId, isLiked)
+                                )
+                            }
+                        }
                     }
                 }
-            }
         }
     }
 
@@ -157,9 +165,77 @@ internal class FeedProfileViewModel @Inject constructor(
 
     fun diaryUnpublish(diaryId: Long) {
         viewModelScope.launch {
-            _sideEffect.emit(FeedProfileSideEffect.ShowToast(message = "일기가 비공개 되었어요."))
+            diaryRepository.patchDiaryUnpublish(diaryId)
+                .onSuccess {
+                    _sideEffect.emit(FeedProfileSideEffect.ShowToast(message = "일기가 비공개 되었어요."))
+                    _uiState.updateSuccess { currentState ->
+
+
+                        val updatedSharedDiaries = currentState.sharedDiaries
+                            .filter { it.diaryId != diaryId }
+                            .toImmutableList()
+
+                        currentState.copy(sharedDiaries = updatedSharedDiaries)
+                    }
+                }
+                .onLogFailure {
+                    _sideEffect.emit(FeedProfileSideEffect.ShowToast("일기 비공개에 실패했습니다."))
+                }
         }
     }
+
+    fun updateFollowingState(isCurrentlyFollowing: Boolean) {
+        viewModelScope.launch {
+            //TODO: 팔로우 화면 머지 후 주석 삭제
+           /* val result = if (isCurrentlyFollowing) {
+                userRepository.deleteFollow(targetUserId)
+            } else {
+                userRepository.putFollow(targetUserId)
+            }
+            result.onSuccess {
+                _uiState.updateSuccess { currentState ->
+                    val currentProfile = currentState.feedProfileInfo
+
+                    val updatedProfile = currentProfile.copy(
+                        isFollowing = !isCurrentlyFollowing,
+                        follower = if (isCurrentlyFollowing) currentProfile.follower - 1 else currentProfile.follower + 1
+                    )
+
+                    currentState.copy(feedProfileInfo = updatedProfile)
+                }
+            }.onLogFailure {
+            }*/
+        }
+    }
+
+    fun updateBlockState(isCurrentlyBlocked: Boolean) {
+        viewModelScope.launch {
+            val result = if (isCurrentlyBlocked) {
+                userRepository.deleteBlockUser(targetUserId)
+            } else {
+                userRepository.putBlockUser(targetUserId)
+            }
+            result.onSuccess {
+                _uiState.updateSuccess { currentState ->
+                    val updatedProfile = currentState.feedProfileInfo.copy(
+                        isBlock = !isCurrentlyBlocked
+                    )
+                    currentState.copy(feedProfileInfo = updatedProfile)
+                }
+            }.onLogFailure {
+            }
+        }
+    }
+
+    fun refreshTab(tabType: DiaryTabType) {
+        val currentState = _uiState.value as? UiState.Success ?: return
+        val feedProfileModel = currentState.data.feedProfileInfo
+        when (tabType) {
+            DiaryTabType.SHARED -> loadSharedDiaries(feedProfileModel)
+            DiaryTabType.LIKED -> loadLikedDiaries()
+        }
+    }
+
 }
 
 sealed interface FeedProfileSideEffect {

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileViewModel.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileViewModel.kt
@@ -170,7 +170,6 @@ internal class FeedProfileViewModel @Inject constructor(
                     _sideEffect.emit(FeedProfileSideEffect.ShowToast(message = "일기가 비공개 되었어요."))
                     _uiState.updateSuccess { currentState ->
 
-
                         val updatedSharedDiaries = currentState.sharedDiaries
                             .filter { it.diaryId != diaryId }
                             .toImmutableList()
@@ -186,7 +185,7 @@ internal class FeedProfileViewModel @Inject constructor(
 
     fun updateFollowingState(isCurrentlyFollowing: Boolean) {
         viewModelScope.launch {
-            //TODO: 팔로우 화면 머지 후 주석 삭제
+            // TODO: 팔로우 화면 머지 후 주석 삭제
            /* val result = if (isCurrentlyFollowing) {
                 userRepository.deleteFollow(targetUserId)
             } else {
@@ -235,7 +234,6 @@ internal class FeedProfileViewModel @Inject constructor(
             DiaryTabType.LIKED -> loadLikedDiaries()
         }
     }
-
 }
 
 sealed interface FeedProfileSideEffect {

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileViewModel.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileViewModel.kt
@@ -156,7 +156,7 @@ internal class FeedProfileViewModel @Inject constructor(
                         }
                     }
                 }
-                .onLogFailure {  }
+                .onLogFailure { }
         }
     }
 

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/component/FeedProfileInfo.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/component/FeedProfileInfo.kt
@@ -151,7 +151,7 @@ internal fun FeedProfileInfo(
 
         if (!isMine) {
             FeedUserActionButton(
-                isFilled = isFollowing == false,
+                isFilled = isFollowing == false && isBlock != true,
                 buttonText = when {
                     isBlock == true -> "차단 해제"
                     isFollowing == true -> "팔로잉"

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/component/FeedProfileInfo.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/component/FeedProfileInfo.kt
@@ -151,7 +151,7 @@ internal fun FeedProfileInfo(
 
         if (!isMine) {
             FeedUserActionButton(
-                isFilled = isFollowing == false && isBlock != true,
+                isFilled = isFollowing == false && isBlock == false,
                 buttonText = when {
                     isBlock == true -> "차단 해제"
                     isFollowing == true -> "팔로잉"

--- a/presentation/voca/src/main/java/com/hilingual/presentation/voca/component/AddVocaButton.kt
+++ b/presentation/voca/src/main/java/com/hilingual/presentation/voca/component/AddVocaButton.kt
@@ -43,7 +43,7 @@ internal fun AddVocaButton(
             .clip(RoundedCornerShape(8.dp))
             .background(
                 shape = RoundedCornerShape(8.dp),
-                color = HilingualTheme.colors.black
+                color = HilingualTheme.colors.hilingualBlack
             )
             .width(IntrinsicSize.Max)
             .noRippleClickable(onClick = onClick)


### PR DESCRIPTION
## Related issue 🛠
- closed #356 

## Work Description ✏️
- 피드 좋아요 지정 / 해제 API를 연결했습니다.
- 일기 비공개 하기 API를 연결했습니다.
- 피드 프로필 내의 팔로우 등록 / 해제 API를 연결했습니다.
- 차단 / 차단 해제 API를 연결했습니다.

## Screenshot 📸  

| 좋아요 | 비공개 | 차단 | ~~PTR~~ |
|:--:|:--:|:--:|:--:|
| <video src="https://github.com/user-attachments/assets/96a30584-a3c1-4972-928d-16911539558b" width="300"/> | <video src="https://github.com/user-attachments/assets/9ead5cb9-ee8d-4a3a-91c5-196afbc9420a" width="300"/> | <video src="https://github.com/user-attachments/assets/30619b21-8e25-4711-aa6f-9bd33ddf1ca5" width="300"/> | <video src="https://github.com/user-attachments/assets/81406946-191b-4944-885a-4c88d01e1033" width="300"/> |


## Uncompleted Tasks 😅
- [ ] 팔로우 머지 후 주석 처리 삭제
- ~~[ ] Pull to Refresh~~

## To Reviewers 📢
- 기존 브랜치 충돌이 너무 많이 나서 새 브랜치에 작업 후 올립니다
- ~~중첩 스크롤 때문에 PTR을 추가하면 화면에 일기가 다 들어가는 상황에서도 스크롤이 되네요.. 어떻게 수정하면 좋을지 조언 구하고 싶습니다..~~
