### PR TITLE
[FIX/#372] 일기 작성, 피드백 요청 로딩, 마이페이지 수정사항 반영

### DIFF
--- a/data/diary/build.gradle.kts
+++ b/data/diary/build.gradle.kts
@@ -22,3 +22,7 @@ plugins {
 android {
     setNamespace("data.diary")
 }
+
+dependencies {
+    implementation(projects.data.presigned)
+}

--- a/data/diary/src/main/java/com/hilingual/data/diary/datasource/DiaryRemoteDataSource.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/datasource/DiaryRemoteDataSource.kt
@@ -21,8 +21,6 @@ import com.hilingual.data.diary.dto.response.DiaryContentResponseDto
 import com.hilingual.data.diary.dto.response.DiaryFeedbackCreateResponseDto
 import com.hilingual.data.diary.dto.response.DiaryFeedbackResponseDto
 import com.hilingual.data.diary.dto.response.DiaryRecommendExpressionResponseDto
-import okhttp3.MultipartBody
-import okhttp3.RequestBody
 
 interface DiaryRemoteDataSource {
     suspend fun getDiaryContent(
@@ -43,9 +41,9 @@ interface DiaryRemoteDataSource {
     ): BaseResponse<Unit>
 
     suspend fun postDiaryFeedbackCreate(
-        originalText: RequestBody,
-        date: RequestBody,
-        imageFile: MultipartBody.Part? = null
+        originalText: String,
+        date: String,
+        fileKey: String?
     ): BaseResponse<DiaryFeedbackCreateResponseDto>
 
     suspend fun patchDiaryPublish(

--- a/data/diary/src/main/java/com/hilingual/data/diary/datasourceimpl/DiaryRemoteDataSourceImpl.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/datasourceimpl/DiaryRemoteDataSourceImpl.kt
@@ -18,13 +18,13 @@ package com.hilingual.data.diary.datasourceimpl
 import com.hilingual.core.network.BaseResponse
 import com.hilingual.data.diary.datasource.DiaryRemoteDataSource
 import com.hilingual.data.diary.dto.request.BookmarkRequestDto
+import com.hilingual.data.diary.dto.request.DiaryFeedbackCreateRequestDto
+import com.hilingual.data.diary.dto.request.ImageRequestDto
 import com.hilingual.data.diary.dto.response.DiaryContentResponseDto
 import com.hilingual.data.diary.dto.response.DiaryFeedbackCreateResponseDto
 import com.hilingual.data.diary.dto.response.DiaryFeedbackResponseDto
 import com.hilingual.data.diary.dto.response.DiaryRecommendExpressionResponseDto
 import com.hilingual.data.diary.service.DiaryService
-import okhttp3.MultipartBody
-import okhttp3.RequestBody
 import javax.inject.Inject
 
 internal class DiaryRemoteDataSourceImpl @Inject constructor(
@@ -49,15 +49,27 @@ internal class DiaryRemoteDataSourceImpl @Inject constructor(
         )
 
     override suspend fun postDiaryFeedbackCreate(
-        originalText: RequestBody,
-        date: RequestBody,
-        imageFile: MultipartBody.Part?
-    ): BaseResponse<DiaryFeedbackCreateResponseDto> =
-        diaryService.postDiaryFeedbackCreate(
-            originalText = originalText,
-            date = date,
-            imageFile = imageFile
+        originalText: String,
+        date: String,
+        fileKey: String?
+    ): BaseResponse<DiaryFeedbackCreateResponseDto> {
+        val imageRequest = if (fileKey != null) {
+            ImageRequestDto(
+                fileKey = fileKey,
+                purpose = "DIARY_IMAGE"
+            )
+        } else {
+            null
+        }
+
+        return diaryService.postDiaryFeedbackCreate(
+            diaryFeedbackCreateRequestDto = DiaryFeedbackCreateRequestDto(
+                originalText = originalText,
+                date = date,
+                image = imageRequest
+            )
         )
+    }
 
     override suspend fun patchDiaryPublish(diaryId: Long): BaseResponse<Unit> =
         diaryService.patchDiaryPublish(diaryId)

--- a/data/diary/src/main/java/com/hilingual/data/diary/dto/request/DiaryFeedbackCreateRequestDto.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/dto/request/DiaryFeedbackCreateRequestDto.kt
@@ -1,0 +1,14 @@
+package com.hilingual.data.diary.dto.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DiaryFeedbackCreateRequestDto(
+    @SerialName("originalText")
+    val originalText: String,
+    @SerialName("date")
+    val date: String,
+    @SerialName("image")
+    val image: ImageRequestDto? = null
+)

--- a/data/diary/src/main/java/com/hilingual/data/diary/dto/request/ImageRequestDto.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/dto/request/ImageRequestDto.kt
@@ -1,0 +1,12 @@
+package com.hilingual.data.diary.dto.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ImageRequestDto(
+    @SerialName("fileKey")
+    val fileKey: String,
+    @SerialName("purpose")
+    val purpose: String
+)

--- a/data/diary/src/main/java/com/hilingual/data/diary/repositoryimpl/DiaryRepositoryImpl.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/repositoryimpl/DiaryRepositoryImpl.kt
@@ -15,7 +15,6 @@
  */
 package com.hilingual.data.diary.repositoryimpl
 
-import android.content.Context
 import android.net.Uri
 import com.hilingual.core.common.util.suspendRunCatching
 import com.hilingual.data.diary.datasource.DiaryRemoteDataSource
@@ -29,13 +28,13 @@ import com.hilingual.data.diary.model.toDto
 import com.hilingual.data.diary.model.toModel
 import com.hilingual.data.diary.repository.DiaryRepository
 import com.hilingual.data.presigned.repository.FileUploaderRepository
-import dagger.hilt.android.qualifiers.ApplicationContext
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
+private val DATE_FORMATTER: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE
+
 internal class DiaryRepositoryImpl @Inject constructor(
-    @ApplicationContext private val context: Context,
     private val diaryRemoteDataSource: DiaryRemoteDataSource,
     private val fileUploaderRepository: FileUploaderRepository
 ) : DiaryRepository {
@@ -102,11 +101,4 @@ internal class DiaryRepositoryImpl @Inject constructor(
         suspendRunCatching {
             diaryRemoteDataSource.deleteDiary(diaryId)
         }
-
-    companion object {
-        const val APPLICATION_JSON = "application/json"
-        const val IMAGE_FILE_NAME = "imageFile"
-
-        val DATE_FORMATTER: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE
-    }
 }

--- a/data/diary/src/main/java/com/hilingual/data/diary/service/DiaryService.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/service/DiaryService.kt
@@ -17,19 +17,16 @@ package com.hilingual.data.diary.service
 
 import com.hilingual.core.network.BaseResponse
 import com.hilingual.data.diary.dto.request.BookmarkRequestDto
+import com.hilingual.data.diary.dto.request.DiaryFeedbackCreateRequestDto
 import com.hilingual.data.diary.dto.response.DiaryContentResponseDto
 import com.hilingual.data.diary.dto.response.DiaryFeedbackCreateResponseDto
 import com.hilingual.data.diary.dto.response.DiaryFeedbackResponseDto
 import com.hilingual.data.diary.dto.response.DiaryRecommendExpressionResponseDto
-import okhttp3.MultipartBody
-import okhttp3.RequestBody
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
-import retrofit2.http.Multipart
 import retrofit2.http.PATCH
 import retrofit2.http.POST
-import retrofit2.http.Part
 import retrofit2.http.Path
 
 internal interface DiaryService {
@@ -54,12 +51,9 @@ internal interface DiaryService {
         @Body bookmarkRequestDto: BookmarkRequestDto
     ): BaseResponse<Unit>
 
-    @Multipart
     @POST("/api/v1/diaries")
     suspend fun postDiaryFeedbackCreate(
-        @Part("originalText") originalText: RequestBody,
-        @Part("date") date: RequestBody,
-        @Part imageFile: MultipartBody.Part? = null
+        @Body diaryFeedbackCreateRequestDto: DiaryFeedbackCreateRequestDto
     ): BaseResponse<DiaryFeedbackCreateResponseDto>
 
     @PATCH("/api/v1/diaries/{diaryId}/publish")

--- a/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/DiaryFeedbackStatusScreen.kt
+++ b/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/DiaryFeedbackStatusScreen.kt
@@ -133,7 +133,7 @@ private fun DiaryFeedbackCompleteStatusScreenPreview() {
             paddingValues = PaddingValues(0.dp),
             uiData = FeedbackUIData(
                 title = "일기 저장 완료!",
-                description = "펜펜이가 틀린 부분을 고치고,\n더 나은 표현으로 수정했어요!",
+                description = "틀린 부분을 고치고,\n더 나은 표현으로 수정했어요!",
                 media = FeedbackMedia.Lottie(
                     resId = R.raw.lottie_feedback_complete,
                     heightDp = 180.dp

--- a/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/component/MyInfoBox.kt
+++ b/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/component/MyInfoBox.kt
@@ -1,5 +1,6 @@
 package com.hilingual.presentation.mypage.component
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -19,6 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -47,17 +49,28 @@ internal fun MyInfoBox(
         Row(
             verticalAlignment = Alignment.CenterVertically
         ) {
-            NetworkImage(
-                imageUrl = profileUrl,
-                modifier = Modifier
-                    .size(60.dp)
-                    .border(
-                        width = 1.dp,
-                        color = HilingualTheme.colors.gray200,
-                        shape = CircleShape
-                    )
-                    .noRippleClickable(onClick = onEditButtonClick)
-            )
+            val imageModifier = Modifier
+                .size(60.dp)
+                .clip(shape = CircleShape)
+                .border(
+                    width = 1.dp,
+                    color = HilingualTheme.colors.gray200,
+                    shape = CircleShape
+                )
+                .noRippleClickable(onClick = onEditButtonClick)
+
+            if (profileUrl.isNullOrBlank()) {
+                Image(
+                    painter = painterResource(R.drawable.img_default_image),
+                    contentDescription = null,
+                    modifier = imageModifier
+                )
+            } else {
+                NetworkImage(
+                    imageUrl = profileUrl,
+                    modifier = imageModifier
+                )
+            }
 
             Spacer(modifier = Modifier.width(10.dp))
 


### PR DESCRIPTION
## Related issue 🛠
- closed #372 

## Work Description ✏️
- 일기 작성 - 일기 피드백 요청 POST API 수정사항 반영
- 피드백 요청 로딩 - 텍스트 수정사항 반영
- 마이페이지 - 사진 관련 분기처리

## Screenshot 📸
| 피드백 요청 로딩 - 수정 전 | 피드백 요청 로딩 - 수정 후 |
|-----|-----|
| <img width="1080" height="2400" alt="issue_372_loading_before" src="https://github.com/user-attachments/assets/949bc32d-f4d3-45bf-83d6-55cfd514b48f" /> | <img width="1080" height="2400" alt="issue_372_loading_after" src="https://github.com/user-attachments/assets/8fd60dca-2d5f-4300-8649-9259569f1ed0" /> |

## Uncompleted Tasks 😅
- [ ] 새 계정 생성 후 한번 더 테스트 진행 (To Reviewers 참고)

## To Reviewers 📢
- 해당 플로우로 테스트를 진행했습니다.
    - (1) 기존에 등록해뒀던 일기 2개 삭제
    - (2) POST API 수정사항 반영 후 새로운 일기 등록(일기 피드백 요청 POST API 잘 작동하는 것 확인함)
    - (3) 다만 (일기 삭제하기 DELETE API를 통해 일기를 2개 삭제했음에도 불구하고) 월별 조회 API에서는 일기가 삭제됐었던 건지를 파악하지 못해 피드백 요청 로딩뷰에서는 성공 처리로 뜨지 않음
- 위의 플로우에서 발생한 API 싱크 이슈로 인해 새로운 계정 생성 후 한번 더 테스트할 예정입니다.