### PR TITLE
[REF/#382] Coil2 -> Coil3 마이그레이션

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -106,6 +106,9 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.credentials.play.services.auth)
     implementation(libs.jakewharton.process.phoenix)
+
+    implementation(platform(libs.coil.bom))
+    implementation(libs.bundles.coil)
 }
 
 ktlint {

--- a/app/src/main/java/com/hilingual/App.kt
+++ b/app/src/main/java/com/hilingual/App.kt
@@ -16,18 +16,29 @@
 package com.hilingual
 
 import android.app.Application
+import android.content.Context
 import androidx.appcompat.app.AppCompatDelegate
+import coil3.ImageLoader
+import coil3.SingletonImageLoader
+import dagger.Lazy
 import dagger.hilt.android.HiltAndroidApp
+import javax.inject.Inject
 import timber.log.Timber
 
 @HiltAndroidApp
-class App : Application() {
+class App : Application(), SingletonImageLoader.Factory {
+    @Inject
+    lateinit var imageLoader: Lazy<ImageLoader>
+
     override fun onCreate() {
         super.onCreate()
+        SingletonImageLoader.setSafe { imageLoader.get() }
 
         setDayMode()
         initTimber()
     }
+
+    override fun newImageLoader(context: Context): ImageLoader = imageLoader.get()
 
     private fun setDayMode() {
         AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)

--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -32,7 +32,8 @@ dependencies {
     implementation(libs.bundles.androidx)
 
     // others
-    implementation(libs.coil.compose)
+    implementation(platform(libs.coil.bom))
+    implementation(libs.bundles.coil)
     implementation(libs.kotlinx.immutable)
     implementation(libs.lottie)
     implementation(libs.pebble)

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/image/NetworkImage.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/image/NetworkImage.kt
@@ -26,13 +26,11 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
+import coil3.compose.AsyncImage
 import com.hilingual.core.designsystem.R
 import com.hilingual.core.designsystem.theme.HilingualTheme
 
@@ -67,10 +65,7 @@ fun NetworkImage(
         )
     } else {
         AsyncImage(
-            model = ImageRequest.Builder(LocalContext.current)
-                .data(imageUrl)
-                .crossfade(true)
-                .build(),
+            model = imageUrl,
             contentDescription = contentDescription,
             contentScale = contentScale,
             error = painterResource(errorImage),

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -57,9 +57,9 @@ dependencies {
     // others
     implementation(platform(libs.okhttp.bom))
     implementation(libs.bundles.okhttp)
-
     implementation(libs.bundles.retrofit)
-
+    implementation(platform(libs.coil.bom))
+    implementation(libs.bundles.coil)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.timber)
 }

--- a/core/network/src/main/java/com/hilingual/core/network/di/ImageLoaderModule.kt
+++ b/core/network/src/main/java/com/hilingual/core/network/di/ImageLoaderModule.kt
@@ -1,18 +1,3 @@
-/*
- * Copyright 2025 The Hilingual Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hilingual.core.network.di
 
 import android.content.Context

--- a/core/network/src/main/java/com/hilingual/core/network/di/ImageLoaderModule.kt
+++ b/core/network/src/main/java/com/hilingual/core/network/di/ImageLoaderModule.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 The Hilingual Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hilingual.core.network.di
+
+import android.content.Context
+import coil3.ImageLoader
+import coil3.disk.DiskCache
+import coil3.disk.directory
+import coil3.memory.MemoryCache
+import coil3.network.okhttp.OkHttpNetworkFetcherFactory
+import coil3.request.allowRgb565
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object ImageLoaderModule {
+
+    @Provides
+    @Singleton
+    fun provideImageLoader(
+        @ApplicationContext context: Context,
+        okHttpClient: OkHttpClient
+    ): ImageLoader = ImageLoader.Builder(context)
+        .components {
+            add(OkHttpNetworkFetcherFactory(callFactory = okHttpClient))
+        }
+        .memoryCache {
+            MemoryCache.Builder()
+                .maxSizePercent(context, 0.25)
+                .strongReferencesEnabled(true)
+                .build()
+        }
+        .diskCache {
+            DiskCache.Builder()
+                .directory(context.cacheDir.resolve("image_cache"))
+                .maxSizeBytes(100L * 1024 * 1024)
+                .build()
+        }
+        .allowRgb565(true)
+        .build()
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,7 +49,7 @@ retrofit = "3.0.0"
 kotlinxSerializationJson = "1.9.0"
 daggerHilt = "2.57.1"
 hiltNavigationCompose = "1.2.0"
-coil = "2.7.0"
+coil = "3.3.0"
 timber = "5.0.1"
 lottieCompose = "6.6.7"
 coroutine = "1.10.2"
@@ -134,7 +134,9 @@ hilt-android-gradle-plugin = { group = "com.google.dagger", name = "hilt-android
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
 
 # UI & Animation
-coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
+coil-bom = { group = "io.coil-kt.coil3", name = "coil-bom", version.ref = "coil" }
+coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose" }
+coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp" }
 lottie = { group = "com.airbnb.android", name = "lottie-compose", version.ref = "lottieCompose" }
 balloon-compose = { group = "com.github.skydoves", name = "balloon-compose", version.ref = "balloonCompose" }
 
@@ -193,6 +195,8 @@ androidx = [
     "androidx-security",
     "androidx-appcompat"
 ]
+
+coil = ["coil-compose", "coil-network-okhttp"]
 
 test = [
     "androidx-junit",


### PR DESCRIPTION
## Related issue 🛠
- closed #382

## Work Description ✏️
- **Coil 3 마이그레이션**: 프로젝트의 이미지 로딩 라이브러리를 Coil 2에서 3으로 마이그레이션
- **의존성 업데이트**: `libs.versions.toml`에 Coil 3 BOM 및 관련 의존성을 설정하고, `app`, `core:designsystem`, `core:network` 모듈에 이를 적용
- **Hilt 모듈 도입**: `core:network` 모듈에 `ImageLoaderModule`을 추가하여, 앱 전역에서 사용될 싱글톤 `ImageLoader`를 Hilt를 통해 제공하도록 개선
- **`Application` 클래스 수정**: `App.kt`에서 Hilt를 통해 주입받은 `ImageLoader`를 싱글톤으로 설정하도록 수정
- **캐시 설정 최적화**: 다음과 같이 `ImageLoader`의 캐시 설정을 최적화
    - 디스크 캐시: 100MB 고정 크기 할당
    - 메모리 캐시: Strong-reference 활성화
    - 메모리 최적화: `allowRgb565(true)` 옵션 활성화
- **`NetworkImage` 컴포저블 리팩토링**: Coil 3 API에 맞게 `ImageRequest.Builder`를 제거하여 코드 감소

## To Reviewers 📢
- Coil 2에서 3으로 마이그레이션을 진행했습니다. Hilt 모듈을 통해 앱 전역에서 사용될 싱글톤 `ImageLoader`를 제공하도록 아키텍처를 개선하고, 캐시 설정을 최적화하여 성능 개선을 시도했습니다.
