### PR TITLE
[FIX/#387] 1차 기능 QA 수정 사항 반영

### DIFF
--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/component/FeedbackReportDialog.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/component/FeedbackReportDialog.kt
@@ -34,6 +34,7 @@ internal fun FeedbackReportDialog(
             cancelText = "아니요",
             confirmText = "신고하기",
             properties = DialogProperties(
+                dismissOnClickOutside = false,
                 usePlatformDefaultWidth = false,
                 decorFitsSystemWindows = false
             ),

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/component/FeedbackReportDialog.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/component/FeedbackReportDialog.kt
@@ -30,10 +30,13 @@ internal fun FeedbackReportDialog(
     if (isVisible) {
         TwoButtonDialog(
             title = "AI 피드백을 신고하시겠어요?",
-            description = "신고된 AI 피드백은 확인 후 \n서비스의 운영원칙에 따라 처리됩니다.",
+            description = "신고된 AI 피드백은 확인 후 \n서비스의 운영원칙에 따라 처리돼요.",
             cancelText = "아니요",
-            confirmText = "네, 신고할게요",
-            properties = DialogProperties(dismissOnClickOutside = false),
+            confirmText = "신고하기",
+            properties = DialogProperties(
+                usePlatformDefaultWidth = false,
+                decorFitsSystemWindows = false
+            ),
             onNegative = onDismiss,
             onPositive = {
                 onReportClick()

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/DiaryListScreen.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/DiaryListScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.hilingual.core.designsystem.component.content.FeedCard

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/DiaryListScreen.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/DiaryListScreen.kt
@@ -32,29 +32,11 @@ internal fun DiaryListScreen(
     onUnpublishClick: (diaryId: Long) -> Unit,
     onReportClick: () -> Unit,
     modifier: Modifier = Modifier,
-    onScrollStateChanged: ((Boolean) -> Unit)? = null,
-    isNestedScroll: Boolean = false,
-    canParentScroll: Boolean = true,
     listState: LazyListState = rememberLazyListState()
 ) {
-    LaunchedEffect(listState.layoutInfo, diaries.size) {
-        val layoutInfo = listState.layoutInfo
-
-        if (diaries.isEmpty() || layoutInfo.visibleItemsInfo.isEmpty()) {
-            onScrollStateChanged?.invoke(false)
-            return@LaunchedEffect
-        }
-
-        val canScrollDown = listState.canScrollForward
-        val canScrollUp = listState.canScrollBackward
-
-        onScrollStateChanged?.invoke(canScrollDown || canScrollUp)
-    }
-
     LazyColumn(
         state = listState,
         contentPadding = PaddingValues(bottom = 48.dp),
-        userScrollEnabled = if (isNestedScroll) canParentScroll else true,
         modifier = modifier
             .fillMaxSize()
             .background(HilingualTheme.colors.white)

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileScreen.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileScreen.kt
@@ -51,6 +51,7 @@ import com.hilingual.presentation.feedprofile.profile.component.FeedProfileTabRo
 import com.hilingual.presentation.feedprofile.profile.component.ReportBlockBottomSheet
 import com.hilingual.presentation.feedprofile.profile.model.DiaryTabType
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
 
 @Composable
@@ -66,6 +67,10 @@ internal fun FeedProfileRoute(
     val context = LocalContext.current
     val toastTrigger = LocalToastTrigger.current
     val dialogTrigger = LocalDialogTrigger.current
+
+    LaunchedEffect(Unit) {
+        viewModel.loadFeedProfile()
+    }
 
     viewModel.sideEffect.collectSideEffect {
         when (it) {
@@ -173,6 +178,7 @@ private fun FeedProfileScreen(
     LaunchedEffect(pagerState) {
         snapshotFlow { pagerState.currentPage }
             .distinctUntilChanged()
+            .drop(1)
             .collect { pageIndex ->
                 val tabType = if (pageIndex == 0) DiaryTabType.SHARED else DiaryTabType.LIKED
                 onTabRefresh(tabType)

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileScreen.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileScreen.kt
@@ -1,5 +1,6 @@
 package com.hilingual.presentation.feedprofile.profile
 
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -10,15 +11,17 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -26,6 +29,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -140,8 +147,7 @@ private fun FeedProfileScreen(
     var isBlockBottomSheetVisible by remember { mutableStateOf(false) }
     var isReportUserDialogVisible by remember { mutableStateOf(false) }
 
-    val profileListState = rememberLazyListState()
-    var shouldEnableScroll by remember { mutableStateOf(true) }
+    val scrollState = rememberScrollState()
 
     val sharedDiaryListState = rememberLazyListState()
     val likedDiaryListState = rememberLazyListState()
@@ -155,23 +161,11 @@ private fun FeedProfileScreen(
         }
     }
 
-    val canParentScrollForOthers by remember {
-        derivedStateOf { profileListState.firstVisibleItemIndex >= 1 }
-    }
-
-    val canParentScrollForMine by remember {
-        derivedStateOf { profileListState.firstVisibleItemIndex >= 2 }
-    }
-
     val profile = uiState.feedProfileInfo
-    val finalScrollEnabled = if (profile.isBlock == true) false else shouldEnableScroll
 
     val isFabVisible by remember {
         derivedStateOf {
-            finalScrollEnabled && (
-                profileListState.firstVisibleItemIndex > 0 ||
-                    profileListState.firstVisibleItemScrollOffset > 0
-                )
+            scrollState.value > 0 || currentListState.firstVisibleItemIndex > 0 || currentListState.firstVisibleItemScrollOffset > 0
         }
     }
 
@@ -183,7 +177,7 @@ private fun FeedProfileScreen(
                 val tabType = if (pageIndex == 0) DiaryTabType.SHARED else DiaryTabType.LIKED
                 onTabRefresh(tabType)
                 coroutineScope.launch {
-                    profileListState.animateScrollToItem(0)
+                    scrollState.animateScrollTo(0)
                     when {
                         profile.isMine -> {
                             currentListState.animateScrollToItem(0)
@@ -219,146 +213,126 @@ private fun FeedProfileScreen(
                 )
             }
 
-            LazyColumn(
-                state = profileListState,
-                userScrollEnabled = finalScrollEnabled,
-                modifier = Modifier.fillMaxSize()
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .verticalScroll(scrollState)
             ) {
-                item {
-                    Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(8.dp))
 
-                    with(profile) {
-                        FeedProfileInfo(
-                            profileImageUrl = profileImageUrl,
-                            nickname = nickname,
-                            streak = streak,
-                            follower = follower,
-                            following = following,
-                            onFollowClick = { onFollowClick(isMine) },
-                            isMine = isMine,
-                            isFollowing = isFollowing,
-                            isFollowed = isFollowed,
-                            isBlock = isBlock,
-                            onActionButtonClick = {
-                                if (isBlock == true) {
-                                    onBlockClick()
+                with(profile) {
+                    FeedProfileInfo(
+                        profileImageUrl = profileImageUrl,
+                        nickname = nickname,
+                        streak = streak,
+                        follower = follower,
+                        following = following,
+                        onFollowClick = { onFollowClick(isMine) },
+                        isMine = isMine,
+                        isFollowing = isFollowing,
+                        isFollowed = isFollowed,
+                        isBlock = isBlock,
+                        onActionButtonClick = {
+                            if (isBlock == true) {
+                                onBlockClick()
+                            } else {
+                                onActionButtonClick(isFollowing)
+                            }
+                        },
+                        modifier = Modifier.padding(horizontal = 16.dp)
+                    )
+                }
+            }
+
+            when {
+                profile.isMine -> {
+                    FeedProfileTabRow(
+                        tabIndex = pagerState.currentPage,
+                        onTabSelected = { index ->
+                            coroutineScope.launch {
+                                val tabType = if (index == 0) DiaryTabType.SHARED else DiaryTabType.LIKED
+                                if (index == pagerState.currentPage) {
+                                    onTabRefresh(tabType)
                                 } else {
-                                    onActionButtonClick(isFollowing)
+                                    pagerState.animateScrollToPage(index)
                                 }
-                            },
-                            modifier = Modifier.padding(horizontal = 16.dp)
+                            }
+                        },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(HilingualTheme.colors.white)
+                            .stickyHeader(scrollState)
+                    )
+
+                    HorizontalPager(
+                        state = pagerState,
+                        modifier = Modifier.fillMaxSize()
+                    ) { page ->
+                        val tabType = DiaryTabType.entries[page]
+                        val (diaries, emptyCardType, listState) = when (tabType) {
+                            DiaryTabType.SHARED -> Triple(
+                                uiState.sharedDiaries,
+                                FeedEmptyCardType.NOT_SHARED,
+                                sharedDiaryListState
+                            )
+                            DiaryTabType.LIKED -> Triple(
+                                uiState.likedDiaries,
+                                FeedEmptyCardType.NOT_LIKED,
+                                likedDiaryListState
+                            )
+                        }
+
+                        DiaryListScreen(
+                            diaries = diaries,
+                            emptyCardType = emptyCardType,
+                            onProfileClick = onProfileClick,
+                            onContentDetailClick = onContentDetailClick,
+                            onLikeClick = { diaryId, isLiked -> onLikeClick(diaryId, isLiked, tabType) },
+                            onUnpublishClick = onUnpublishClick,
+                            onReportClick = onReportDiaryClick,
+                            listState = listState,
+                            modifier = Modifier.fillMaxSize()
                         )
                     }
                 }
 
-                when {
-                    profile.isMine -> {
-                        stickyHeader {
-                            FeedProfileTabRow(
-                                tabIndex = pagerState.currentPage,
-                                onTabSelected = { index ->
-                                    coroutineScope.launch {
-                                        val tabType = if (index == 0) DiaryTabType.SHARED else DiaryTabType.LIKED
-                                        if (index == pagerState.currentPage) {
-                                            onTabRefresh(tabType)
-                                        } else {
-                                            pagerState.animateScrollToPage(index)
-                                        }
-                                    }
-                                },
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .background(HilingualTheme.colors.white)
-                            )
-                        }
+                profile.isBlock == true -> {
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Spacer(modifier = Modifier.height(140.dp))
 
-                        item {
-                            HorizontalPager(
-                                state = pagerState,
-                                modifier = Modifier.fillParentMaxSize()
-                            ) { page ->
+                        Text(
+                            text = "${profile.nickname}님의 글을 확인할 수 없어요.",
+                            style = HilingualTheme.typography.headB18,
+                            color = HilingualTheme.colors.black,
+                            textAlign = TextAlign.Center
+                        )
 
-                                val tabType = DiaryTabType.entries[page]
-                                val (diaries, emptyCardType, listState) = when (tabType) {
-                                    DiaryTabType.SHARED -> Triple(
-                                        uiState.sharedDiaries,
-                                        FeedEmptyCardType.NOT_SHARED,
-                                        sharedDiaryListState
-                                    )
-                                    DiaryTabType.LIKED -> Triple(
-                                        uiState.likedDiaries,
-                                        FeedEmptyCardType.NOT_LIKED,
-                                        likedDiaryListState
-                                    )
-                                }
+                        Spacer(modifier = Modifier.height(8.dp))
 
-                                DiaryListScreen(
-                                    diaries = diaries,
-                                    emptyCardType = emptyCardType,
-                                    onProfileClick = onProfileClick,
-                                    onContentDetailClick = onContentDetailClick,
-                                    onLikeClick = { diaryId, isLiked -> onLikeClick(diaryId, isLiked, tabType) },
-                                    onUnpublishClick = onUnpublishClick,
-                                    onReportClick = onReportDiaryClick,
-                                    onScrollStateChanged = { isScrollable ->
-                                        shouldEnableScroll = isScrollable
-                                    },
-                                    isNestedScroll = true,
-                                    canParentScroll = canParentScrollForMine,
-                                    listState = listState,
-                                    modifier = Modifier.fillParentMaxSize()
-                                )
-                            }
-                        }
+                        Text(
+                            text = "차단을 해제하면 글을 확인할 수 있어요.",
+                            style = HilingualTheme.typography.bodyM16,
+                            color = HilingualTheme.colors.gray400,
+                            textAlign = TextAlign.Center
+                        )
                     }
+                }
 
-                    profile.isBlock == true -> {
-                        item {
-                            Column(
-                                modifier = Modifier.fillMaxWidth(),
-                                horizontalAlignment = Alignment.CenterHorizontally
-                            ) {
-                                Spacer(modifier = Modifier.height(140.dp))
-
-                                Text(
-                                    text = "${profile.nickname}님의 글을 확인할 수 없어요.",
-                                    style = HilingualTheme.typography.headB18,
-                                    color = HilingualTheme.colors.black,
-                                    textAlign = TextAlign.Center
-                                )
-
-                                Spacer(modifier = Modifier.height(8.dp))
-
-                                Text(
-                                    text = "차단을 해제하면 글을 확인할 수 있어요.",
-                                    style = HilingualTheme.typography.bodyM16,
-                                    color = HilingualTheme.colors.gray400,
-                                    textAlign = TextAlign.Center
-                                )
-                            }
-                        }
-                    }
-
-                    else -> {
-                        item {
-                            DiaryListScreen(
-                                diaries = uiState.sharedDiaries,
-                                emptyCardType = FeedEmptyCardType.NOT_SHARED,
-                                onProfileClick = onProfileClick,
-                                onContentDetailClick = onContentDetailClick,
-                                onLikeClick = { diaryId, isLiked -> onLikeClick(diaryId, isLiked, DiaryTabType.SHARED) },
-                                onUnpublishClick = onUnpublishClick,
-                                onReportClick = onReportDiaryClick,
-                                onScrollStateChanged = { isScrollable ->
-                                    shouldEnableScroll = isScrollable
-                                },
-                                isNestedScroll = true,
-                                canParentScroll = canParentScrollForOthers,
-                                listState = sharedDiaryListState,
-                                modifier = Modifier.fillParentMaxSize()
-                            )
-                        }
-                    }
+                else -> {
+                    DiaryListScreen(
+                        diaries = uiState.sharedDiaries,
+                        emptyCardType = FeedEmptyCardType.NOT_SHARED,
+                        onProfileClick = onProfileClick,
+                        onContentDetailClick = onContentDetailClick,
+                        onLikeClick = { diaryId, isLiked -> onLikeClick(diaryId, isLiked, DiaryTabType.SHARED) },
+                        onUnpublishClick = onUnpublishClick,
+                        onReportClick = onReportDiaryClick,
+                        listState = sharedDiaryListState,
+                        modifier = Modifier.fillMaxSize()
+                    )
                 }
             }
         }
@@ -367,7 +341,7 @@ private fun FeedProfileScreen(
             isVisible = isFabVisible,
             onClick = {
                 coroutineScope.launch {
-                    profileListState.animateScrollToItem(0)
+                    scrollState.animateScrollTo(0)
                     when {
                         profile.isMine -> {
                             currentListState.animateScrollToItem(0)
@@ -415,6 +389,28 @@ private fun FeedProfileScreen(
             onReportUserClick()
         }
     )
+}
+
+private fun Modifier.stickyHeader(scrollState: ScrollState): Modifier = composed {
+    var initialY by remember { mutableFloatStateOf(0f) }
+    var isPlaced by remember { mutableStateOf(false) }
+    this
+        .onGloballyPositioned { coordinates ->
+            if (!isPlaced) {
+                initialY = coordinates.parentLayoutCoordinates?.localPositionOf(
+                    coordinates,
+                    Offset.Zero
+                )?.y ?: 0f
+                isPlaced = true
+            }
+        }
+        .graphicsLayer {
+            translationY = if (scrollState.value > initialY) {
+                scrollState.value - initialY
+            } else {
+                0f
+            }
+        }
 }
 
 @Preview(showBackground = true)

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileViewModel.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileViewModel.kt
@@ -54,9 +54,10 @@ internal class FeedProfileViewModel @Inject constructor(
             val sharedDiariesResult = sharedDiariesDeferred.await()
             val likedDiariesResult = likedDiariesDeferred.await()
 
-            if (feedProfileResult.isFailure || sharedDiariesResult.isFailure) {
+            if (feedProfileResult.isFailure || sharedDiariesResult.isFailure || likedDiariesResult.isFailure) {
                 feedProfileResult.onLogFailure {}
                 sharedDiariesResult.onLogFailure {}
+                likedDiariesResult.onLogFailure {}
                 _sideEffect.emit(FeedProfileSideEffect.ShowRetryDialog { loadFeedProfile() })
                 return@launch
             }

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileViewModel.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileViewModel.kt
@@ -48,9 +48,11 @@ internal class FeedProfileViewModel @Inject constructor(
         viewModelScope.launch {
             val feedProfileDeferred = async { feedRepository.getFeedProfile(targetUserId) }
             val sharedDiariesDeferred = async { feedRepository.getSharedDiaries(targetUserId) }
+            val likedDiariesDeferred = async { feedRepository.getLikedDiaries(targetUserId) }
 
             val feedProfileResult = feedProfileDeferred.await()
             val sharedDiariesResult = sharedDiariesDeferred.await()
+            val likedDiariesResult = likedDiariesDeferred.await()
 
             if (feedProfileResult.isFailure || sharedDiariesResult.isFailure) {
                 feedProfileResult.onLogFailure {}
@@ -61,6 +63,7 @@ internal class FeedProfileViewModel @Inject constructor(
 
             val feedProfileInfoModel = feedProfileResult.getOrThrow()
             val sharedDiariesModel = sharedDiariesResult.getOrThrow()
+            val likedDiariesModel = likedDiariesResult.getOrThrow()
 
             val sharedDiaryUIModels = sharedDiariesModel.diaryList.map { sharedDiary ->
                 sharedDiary.toState(
@@ -69,11 +72,17 @@ internal class FeedProfileViewModel @Inject constructor(
                 )
             }.toImmutableList()
 
+            val likedDiaryUIModels = likedDiariesModel.diaryList.map { likedDiary ->
+                likedDiary.toState()
+            }.toImmutableList()
+
             _uiState.update {
                 UiState.Success(
                     FeedProfileUiState(
                         feedProfileInfo = feedProfileInfoModel.toState(),
-                        sharedDiaries = sharedDiaryUIModels
+                        sharedDiaries = sharedDiaryUIModels,
+                        likedDiaries = likedDiaryUIModels
+
                     )
                 )
             }

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileViewModel.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileViewModel.kt
@@ -44,11 +44,7 @@ internal class FeedProfileViewModel @Inject constructor(
     private val _sideEffect = MutableSharedFlow<FeedProfileSideEffect>()
     val sideEffect: SharedFlow<FeedProfileSideEffect> = _sideEffect.asSharedFlow()
 
-    init {
-        loadFeedProfile()
-    }
-
-    private fun loadFeedProfile() {
+    fun loadFeedProfile() {
         viewModelScope.launch {
             val feedProfileDeferred = async { feedRepository.getFeedProfile(targetUserId) }
             val sharedDiariesDeferred = async { feedRepository.getSharedDiaries(targetUserId) }

--- a/presentation/otp/src/main/java/com/hilingual/presentation/otp/OtpScreen.kt
+++ b/presentation/otp/src/main/java/com/hilingual/presentation/otp/OtpScreen.kt
@@ -188,7 +188,9 @@ private fun OtpFailureDialog(
             onDismiss = { },
             properties = DialogProperties(
                 dismissOnBackPress = false,
-                dismissOnClickOutside = false
+                dismissOnClickOutside = false,
+                usePlatformDefaultWidth = false,
+                decorFitsSystemWindows = false
             )
         )
     }

--- a/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaScreen.kt
+++ b/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaScreen.kt
@@ -286,7 +286,6 @@ private fun VocaListWithInfoSection(
         onRefresh = onRefresh,
         modifier = modifier.fillMaxSize()
     ) {
-
         LazyColumn(
             state = listState,
             modifier = Modifier

--- a/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaUiState.kt
+++ b/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaUiState.kt
@@ -32,7 +32,8 @@ data class VocaUiState(
     val vocaGroupList: UiState<ImmutableList<GroupingVocaModel>> = UiState.Loading,
     val searchKeyword: String = "",
     val searchResultList: ImmutableList<VocaItemModel> = persistentListOf(),
-    val vocaItemDetail: UiState<VocaDetailModel> = UiState.Loading
+    val vocaItemDetail: UiState<VocaDetailModel> = UiState.Loading,
+    val isRefreshing: Boolean = false
 )
 
 enum class ScreenType {

--- a/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaViewModel.kt
+++ b/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaViewModel.kt
@@ -207,7 +207,6 @@ constructor(
     fun refreshVocaList() {
         fetchWords(_uiState.value.sortType, isRefresh = true)
     }
-
 }
 
 sealed interface VocaSideEffect {

--- a/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaViewModel.kt
+++ b/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaViewModel.kt
@@ -30,7 +30,6 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -85,15 +84,13 @@ constructor(
         viewModelScope.launch {
             if (isRefresh) {
                 _uiState.update { it.copy(isRefreshing = true) }
-            } else {
-                delay(200)
             }
 
             vocaRepository.getVocaList(sort = sort.sortParam)
                 .onSuccess { (count, vocaLists) ->
                     _uiState.update {
                         it.copy(
-                            vocaGroupList = UiState.Success(vocaLists.toPersistentList()),
+                            vocaGroupList = UiState.Success(vocaLists.toImmutableList()),
                             vocaCount = count,
                             isRefreshing = false
                         )

--- a/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaViewModel.kt
+++ b/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaViewModel.kt
@@ -196,6 +196,30 @@ constructor(
                 }
         }
     }
+
+    fun refreshVocaList() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isRefreshing = true) }
+
+            vocaRepository.getVocaList(sort = _uiState.value.sortType.sortParam)
+                .onSuccess { (count, vocaLists) ->
+                    _uiState.update {
+                        it.copy(
+                            vocaGroupList = UiState.Success(vocaLists.toPersistentList()),
+                            vocaCount = count,
+                            isRefreshing = false
+                        )
+                    }
+                    AtoZGroupList = vocaLists.toPersistentList()
+                }
+
+                .onLogFailure {
+                    _uiState.update { it.copy(isRefreshing = false) }
+                    _sideEffect.emit(VocaSideEffect.ShowRetryDialog {})
+                }
+        }
+    }
+
 }
 
 sealed interface VocaSideEffect {

--- a/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaViewModel.kt
+++ b/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaViewModel.kt
@@ -75,7 +75,8 @@ constructor(
     fun updateSort(sort: WordSortType) {
         _uiState.update {
             it.copy(
-                sortType = sort
+                sortType = sort,
+                vocaGroupList = UiState.Loading
             )
         }
     }

--- a/presentation/voca/src/main/java/com/hilingual/presentation/voca/component/VocaDialog.kt
+++ b/presentation/voca/src/main/java/com/hilingual/presentation/voca/component/VocaDialog.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -82,9 +83,10 @@ internal fun VocaDialog(
             modifier = modifier
                 .fillMaxSize()
                 .background(HilingualTheme.colors.dim2)
+                .noRippleClickable(onClick = onDismiss)
+                .navigationBarsPadding()
                 .padding(horizontal = 16.dp)
-                .padding(bottom = 20.dp)
-                .noRippleClickable(onClick = onDismiss),
+                .padding(bottom = 20.dp),
             contentAlignment = Alignment.BottomCenter
         ) {
             Box(

--- a/presentation/voca/src/main/java/com/hilingual/presentation/voca/component/VocaDialog.kt
+++ b/presentation/voca/src/main/java/com/hilingual/presentation/voca/component/VocaDialog.kt
@@ -83,7 +83,8 @@ internal fun VocaDialog(
                 .fillMaxSize()
                 .background(HilingualTheme.colors.dim2)
                 .padding(horizontal = 16.dp)
-                .padding(bottom = 20.dp),
+                .padding(bottom = 20.dp)
+                .noRippleClickable(onClick = onDismiss),
             contentAlignment = Alignment.BottomCenter
         ) {
             Box(

--- a/presentation/voca/src/main/java/com/hilingual/presentation/voca/component/VocaDialog.kt
+++ b/presentation/voca/src/main/java/com/hilingual/presentation/voca/component/VocaDialog.kt
@@ -66,7 +66,7 @@ internal fun VocaDialog(
     modifier: Modifier = Modifier,
     properties: DialogProperties = DialogProperties(
         usePlatformDefaultWidth = false,
-        decorFitsSystemWindows = false,
+        decorFitsSystemWindows = false
     )
 ) {
     var isMarked by remember { mutableStateOf(isBookmarked) }

--- a/presentation/voca/src/main/java/com/hilingual/presentation/voca/component/VocaDialog.kt
+++ b/presentation/voca/src/main/java/com/hilingual/presentation/voca/component/VocaDialog.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -63,7 +64,10 @@ internal fun VocaDialog(
     isBookmarked: Boolean,
     onBookmarkClick: (Long, Boolean) -> Unit,
     modifier: Modifier = Modifier,
-    properties: DialogProperties = DialogProperties(usePlatformDefaultWidth = false)
+    properties: DialogProperties = DialogProperties(
+        usePlatformDefaultWidth = false,
+        decorFitsSystemWindows = false,
+    )
 ) {
     var isMarked by remember { mutableStateOf(isBookmarked) }
 
@@ -76,69 +80,76 @@ internal fun VocaDialog(
 
         Box(
             modifier = modifier
+                .fillMaxSize()
+                .background(HilingualTheme.colors.dim2)
                 .padding(horizontal = 16.dp)
-                .padding(bottom = 20.dp)
-                .clip(RoundedCornerShape(12.dp))
-                .fillMaxWidth()
-                .background(
-                    color = HilingualTheme.colors.white,
-                    shape = RoundedCornerShape(12.dp)
-                )
-                .padding(top = 28.dp, bottom = 40.dp)
-                .padding(horizontal = 24.dp)
+                .padding(bottom = 20.dp),
+            contentAlignment = Alignment.BottomCenter
         ) {
-            Column(
+            Box(
                 modifier = Modifier
-                    .align(Alignment.TopStart)
-                    .padding(bottom = 80.dp, end = 44.dp),
-                verticalArrangement = Arrangement.spacedBy(4.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .fillMaxWidth()
+                    .background(
+                        color = HilingualTheme.colors.white,
+                        shape = RoundedCornerShape(12.dp)
+                    )
+                    .padding(top = 28.dp, bottom = 40.dp)
+                    .padding(horizontal = 24.dp)
             ) {
-                Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                    phraseType.forEach { type ->
-                        key(type) {
-                            WordPhraseTypeTag(phraseType = type)
+                Column(
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
+                        .padding(bottom = 80.dp, end = 44.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                        phraseType.forEach { type ->
+                            key(type) {
+                                WordPhraseTypeTag(phraseType = type)
+                            }
                         }
                     }
+
+                    Text(
+                        text = phrase,
+                        style = HilingualTheme.typography.bodyM20,
+                        color = HilingualTheme.colors.black
+                    )
+
+                    Text(
+                        text = explanation,
+                        style = HilingualTheme.typography.bodyM14,
+                        color = HilingualTheme.colors.black
+                    )
                 }
 
-                Text(
-                    text = phrase,
-                    style = HilingualTheme.typography.bodyM20,
-                    color = HilingualTheme.colors.black
+                Icon(
+                    imageVector = ImageVector.vectorResource(
+                        id = if (isMarked) {
+                            DesignSystemR.drawable.ic_save_28_filled
+                        } else {
+                            DesignSystemR.drawable.ic_save_28_empty
+                        }
+                    ),
+                    contentDescription = null,
+                    modifier = Modifier
+                        .size(36.dp)
+                        .align(Alignment.TopEnd)
+                        .noRippleClickable {
+                            isMarked = !isMarked
+                            onBookmarkClick(phraseId, isMarked)
+                        },
+                    tint = Color.Unspecified
                 )
 
                 Text(
-                    text = explanation,
-                    style = HilingualTheme.typography.bodyM14,
-                    color = HilingualTheme.colors.black
+                    text = writtenDate,
+                    style = HilingualTheme.typography.captionM12,
+                    color = HilingualTheme.colors.gray400,
+                    modifier = Modifier.align(Alignment.BottomEnd)
                 )
             }
-
-            Icon(
-                imageVector = ImageVector.vectorResource(
-                    id = if (isMarked) {
-                        DesignSystemR.drawable.ic_save_28_filled
-                    } else {
-                        DesignSystemR.drawable.ic_save_28_empty
-                    }
-                ),
-                contentDescription = null,
-                modifier = Modifier
-                    .size(36.dp)
-                    .align(Alignment.TopEnd)
-                    .noRippleClickable {
-                        isMarked = !isMarked
-                        onBookmarkClick(phraseId, isMarked)
-                    },
-                tint = Color.Unspecified
-            )
-
-            Text(
-                text = writtenDate,
-                style = HilingualTheme.typography.captionM12,
-                color = HilingualTheme.colors.gray400,
-                modifier = Modifier.align(Alignment.BottomEnd)
-            )
         }
     }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #387 

## Work Description ✏️
- 화면에 꽉 안차던 dim2 이슈 해결(단어장, 인증 코드, ai 신고 다이얼로그)
- 피드 프로필 진입시 중복 호출 되던 공유된 일기 부분 수정
- 피드 프로필 재진입시 새로고침
- 단어장 PTR 추가

## Screenshot 📸

| Dialog | PTR | 
|:--:|:--:|
| <img width="300" alt="Screenshot_20250911_223433" src="https://github.com/user-attachments/assets/e4ea8ce9-8948-46ae-b22b-98704667e5f5" /> | <video src="https://github.com/user-attachments/assets/d4bbe1c8-5395-49d3-9607-d3dc20fcea48" width="300"/> | 


## Uncompleted Tasks 😅
- [ ] 피드프로필 스크롤..............

https://github.com/user-attachments/assets/bcc28ac9-21f2-4da6-a4b8-180d09e9f1d4

현재 피드에 일기 여러개를 가지고 스크롤 해볼 수 없어서 프리뷰로 대체했습니다,, 지금 프로필 정보 부분이 스크롤이 안되고 있는 상황입니도.. PR이 더 늦어지면 안될 것 같아 일단 먼저 올립니다

## To Reviewers 📢
피드 프로필 첫 화면 진입시 init과 LauncedEffect 때문에 공유한 일기가 중복 호출 되는 부분이 있었습니다. 플래그도 사용해봣는데 잘 안되더라구요... 찾아보니 drop이라는 Flow가 emit하는 처음 count개의 요소를 무시하고, 그 이후의 요소들만 downstream에 전달하는 연산자가 있어 사용해보았습니다! 또 사용자가 팔로우화면이나 다른 사람의 피드 프로필로 들어갔다가 돌아왔을 경우 새로고침 되어야 팔로우 수나 일기 부분에서도 변경사항이 반영되어야 할 것 같아 화면 진입시 LauncedEffect로 초기값이 로딩 되도록 수정해보았습니다. 