### PR TITLE
[FIX/#385] 1차 QA 이슈 수정

### DIFF
--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
@@ -43,6 +43,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hilingual.core.common.constant.UrlConstant
 import com.hilingual.core.common.extension.collectSideEffect
 import com.hilingual.core.common.extension.launchCustomTabs
+import com.hilingual.core.common.extension.statusBarColor
 import com.hilingual.core.common.model.SnackbarRequest
 import com.hilingual.core.common.trigger.LocalDialogTrigger
 import com.hilingual.core.common.trigger.LocalSnackbarTrigger
@@ -180,6 +181,7 @@ private fun DiaryFeedbackScreen(
     Column(
         modifier = modifier
             .fillMaxSize()
+            .statusBarColor(HilingualTheme.colors.white)
             .background(HilingualTheme.colors.white)
             .padding(paddingValues)
     ) {

--- a/presentation/feed/src/main/java/com/hilingual/presentation/feed/search/FeedSearchScreen.kt
+++ b/presentation/feed/src/main/java/com/hilingual/presentation/feed/search/FeedSearchScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -17,6 +18,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hilingual.core.common.util.UiState
 import com.hilingual.core.designsystem.component.content.UserActionItem
@@ -37,6 +41,23 @@ internal fun FeedSearchRoute(
     viewModel: FeedSearchViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                if (uiState.searchWord.isNotBlank()) {
+                    viewModel.searchUser()
+                }
+            }
+        }
+
+        lifecycleOwner.lifecycle.addObserver(observer)
+
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
 
     FeedSearchScreen(
         paddingValues = paddingValues,

--- a/presentation/feed/src/main/java/com/hilingual/presentation/feed/search/FeedSearchScreen.kt
+++ b/presentation/feed/src/main/java/com/hilingual/presentation/feed/search/FeedSearchScreen.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -18,9 +18,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hilingual.core.common.util.UiState
 import com.hilingual.core.designsystem.component.content.UserActionItem
@@ -41,21 +38,10 @@ internal fun FeedSearchRoute(
     viewModel: FeedSearchViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val lifecycleOwner = LocalLifecycleOwner.current
 
-    DisposableEffect(lifecycleOwner) {
-        val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_RESUME) {
-                if (uiState.searchWord.isNotBlank()) {
-                    viewModel.searchUser()
-                }
-            }
-        }
-
-        lifecycleOwner.lifecycle.addObserver(observer)
-
-        onDispose {
-            lifecycleOwner.lifecycle.removeObserver(observer)
+    LaunchedEffect(Unit) {
+        if (uiState.searchWord.isNotBlank()) {
+            viewModel.searchUser()
         }
     }
 


### PR DESCRIPTION
## Related issue 🛠
- closed #385 

## Work Description ✏️
- '검색 > 유저 프로필 진입 > 차단 > 다시 검색으로 돌아옴' 시에 검색 결과에 차단한 유저가 남아있는 이슈를 수정했습니다.

## Screenshot 📸
https://github.com/user-attachments/assets/9f77b492-6579-4fea-9349-361a4be7d7c0

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
- 신고하기 다이얼로그는 나현 언니가 버튼 문구 바꿔줬대서 안 건드렸습니다. (언니 고마오~~)
- 화면에 다시 돌아왔을 때를 감지하고 검색 결과를 새로고침하는 걸 생각했는데, 이렇게 구현하면 괜찮을까요?