### PR TITLE
[FIX/#399] 2차 QA 수정 사항 반영

### DIFF
--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileViewModel.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileViewModel.kt
@@ -67,7 +67,7 @@ internal class FeedProfileViewModel @Inject constructor(
             if (feedProfileResult.isFailure || sharedDiariesResult.isFailure) {
                 feedProfileResult.onLogFailure {}
                 sharedDiariesResult.onLogFailure {}
-                _sideEffect.emit(FeedProfileSideEffect.ShowRetryDialog { loadFeedProfileInfo() })
+                _sideEffect.emit(FeedProfileSideEffect.ShowRetryDialog { loadFeedProfile() })
                 return@launch
             }
 
@@ -144,7 +144,7 @@ internal class FeedProfileViewModel @Inject constructor(
                     }
                 }
                 .onLogFailure {
-                    _sideEffect.emit(FeedProfileSideEffect.ShowRetryDialog { loadFeedProfile() })
+                    _sideEffect.emit(FeedProfileSideEffect.ShowRetryDialog { loadLikedDiaries() })
                 }
         }
     }
@@ -252,8 +252,13 @@ internal class FeedProfileViewModel @Inject constructor(
             } else {
                 userRepository.putBlockUser(targetUserId)
             }
-            result.onSuccess { loadFeedProfile() }
-                .onLogFailure { }
+            result.onSuccess {
+                if (isCurrentlyBlocked) {
+                    loadFeedProfile()
+                } else {
+                    loadFeedProfileInfo()
+                }
+            }.onLogFailure { }
         }
     }
 }

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileViewModel.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileViewModel.kt
@@ -228,14 +228,8 @@ internal class FeedProfileViewModel @Inject constructor(
             } else {
                 userRepository.putBlockUser(targetUserId)
             }
-            result.onSuccess {
-                _uiState.updateSuccess { currentState ->
-                    val updatedProfile = currentState.feedProfileInfo.copy(
-                        isBlock = !isCurrentlyBlocked
-                    )
-                    currentState.copy(feedProfileInfo = updatedProfile)
-                }
-            }.onLogFailure { }
+            result.onSuccess { loadFeedProfile() }
+                .onLogFailure { }
         }
     }
 }

--- a/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaScreen.kt
+++ b/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaScreen.kt
@@ -88,10 +88,6 @@ internal fun VocaRoute(
         }
     }
 
-    LaunchedEffect(uiState.sortType) {
-        viewModel.fetchWords(uiState.sortType)
-    }
-
     viewModel.sideEffect.collectSideEffect {
         when (it) {
             is VocaSideEffect.ShowRetryDialog -> {
@@ -175,6 +171,10 @@ private fun VocaScreen(
         if (viewType == ScreenType.DEFAULT) {
             listState.animateScrollToItem(0)
         }
+    }
+
+    LaunchedEffect(sortType) {
+        listState.animateScrollToItem(0)
     }
 
     Box(

--- a/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaScreen.kt
+++ b/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaScreen.kt
@@ -388,9 +388,9 @@ private fun SearchResultSection(
     } else {
         LazyColumn(
             state = listState,
+            contentPadding = PaddingValues(16.dp),
             modifier = Modifier
                 .fillMaxSize()
-                .padding(16.dp)
         ) {
             items(
                 searchResultList,

--- a/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaViewModel.kt
+++ b/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaViewModel.kt
@@ -73,11 +73,16 @@ constructor(
     }
 
     fun updateSort(sort: WordSortType) {
+        val isSameSortType = _uiState.value.sortType == sort
         _uiState.update {
             it.copy(
                 sortType = sort,
                 vocaGroupList = UiState.Loading
             )
+        }
+
+        if (isSameSortType) {
+            fetchWords(sort, isRefresh = true)
         }
     }
 

--- a/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaViewModel.kt
+++ b/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaViewModel.kt
@@ -28,7 +28,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/presentation/voca/src/main/java/com/hilingual/presentation/voca/component/VocaHeader.kt
+++ b/presentation/voca/src/main/java/com/hilingual/presentation/voca/component/VocaHeader.kt
@@ -35,7 +35,7 @@ import com.hilingual.core.designsystem.component.textfield.HilingualSearchTextFi
 import com.hilingual.core.designsystem.component.topappbar.TitleLeftAlignedTopAppBar
 import com.hilingual.core.designsystem.theme.HilingualTheme
 
-private val INPUT_FILTER_REGEX = Regex("""[^a-zA-Z ]""")
+private val INPUT_FILTER_REGEX = Regex("""[^a-zA-Z -]""")
 
 @Composable
 internal fun VocaHeader(

--- a/presentation/voca/src/main/java/com/hilingual/presentation/voca/component/VocaHeader.kt
+++ b/presentation/voca/src/main/java/com/hilingual/presentation/voca/component/VocaHeader.kt
@@ -35,7 +35,7 @@ import com.hilingual.core.designsystem.component.textfield.HilingualSearchTextFi
 import com.hilingual.core.designsystem.component.topappbar.TitleLeftAlignedTopAppBar
 import com.hilingual.core.designsystem.theme.HilingualTheme
 
-private val INPUT_FILTER_REGEX = Regex("""[^a-zA-Z]""")
+private val INPUT_FILTER_REGEX = Regex("""[^a-zA-Z ]""")
 
 @Composable
 internal fun VocaHeader(
@@ -60,8 +60,7 @@ internal fun VocaHeader(
             value = searchText(),
             onValueChanged = {
                 val filteredText = it.replace(INPUT_FILTER_REGEX, "")
-                val newText = filteredText.filter { !it.isWhitespace() }
-                onSearchTextChanged(newText)
+                onSearchTextChanged(filteredText)
             },
             modifier = Modifier
                 .fillMaxWidth()

--- a/presentation/voca/src/main/java/com/hilingual/presentation/voca/component/VocaHeader.kt
+++ b/presentation/voca/src/main/java/com/hilingual/presentation/voca/component/VocaHeader.kt
@@ -35,6 +35,8 @@ import com.hilingual.core.designsystem.component.textfield.HilingualSearchTextFi
 import com.hilingual.core.designsystem.component.topappbar.TitleLeftAlignedTopAppBar
 import com.hilingual.core.designsystem.theme.HilingualTheme
 
+private val INPUT_FILTER_REGEX = Regex("""[^a-zA-Z]""")
+
 @Composable
 internal fun VocaHeader(
     searchText: () -> String,
@@ -56,7 +58,11 @@ internal fun VocaHeader(
         )
         HilingualSearchTextField(
             value = searchText(),
-            onValueChanged = onSearchTextChanged,
+            onValueChanged = {
+                val filteredText = it.replace(INPUT_FILTER_REGEX, "")
+                val newText = filteredText.filter { !it.isWhitespace() }
+                onSearchTextChanged(newText)
+            },
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp)


### PR DESCRIPTION
## Related issue 🛠
- closed #399 

## Work Description ✏️
- 단어장 최신순 -> 최신순, AZ순 -> AZ순 클릭시 발생하는 무한 로딩을 수정했습니다
- 단어장 검색창에 영어 및 띄어쓰기만 입력 가능하도록 수정했습니다
- 피드 프로필 유저 차단 / 해제 시 프로필 정보가 새로고침 되도록 수정했습니다
- 검색 시 AtoZ 순 노출 되도록 수정했습니다
- 타인 프로필에서 공감한 일기를 호출하지 않도록 수정했습니다

## Screenshot 📸
| 단어 정렬 | 단어 검색창 | 검색 결과 | 차단 및 해제 |
|:--:|:--:|:--:|:--:|
| <video src="https://github.com/user-attachments/assets/a5d33104-c092-4d31-904e-e441b38e7252" width="300"/> | <video src="https://github.com/user-attachments/assets/6f4cdc85-1fd7-4247-93c8-62e01e61239b" width="300"/> | <video src="https://github.com/user-attachments/assets/ab26fb15-c3b5-4435-a621-95c133fa47c4" width="300"/> | <video src="https://github.com/user-attachments/assets/8815ce4e-9742-4fe8-be98-b758a4a45661" width="300"/> |



## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
- 2차 QA 수정 사항 반영했습니다 !!
- 검색 기능을 수정하면서 몇 가지 포인트를 고민했습니다. 검색할 때마다 서버에서 A-Z 데이터를 가져올지 아니면 캐시를 유지할지 결정하는 문제와 최신순이나 북마크순으로 정렬이 바뀌거나 사용자가 북마크를 토글하고 새로고침할 때, 검색 결과와 UI 상태가 일관되도록 유지하는 것도 고려해야 했습니다. 결국 검색 속도와 데이터 최신성을 균형 있게 유지하기 위해 캐시를 기본으로 사용하고 필요할 때만 서버에서 갱신하는 방법으로 수정해보았습니다 !! 더 좋은 방법이 있다면 리뷰 남겨주세요 !!