### PR TITLE
[FIX/#401] 2차 QA 수정사항 반영

### DIFF
--- a/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/DiaryWriteScreen.kt
+++ b/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/DiaryWriteScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
@@ -243,6 +244,7 @@ private fun DiaryWriteScreen(
     val focusManager = LocalFocusManager.current
     var isDialogVisible by remember { mutableStateOf(false) }
     var isBottomSheetVisible by remember { mutableStateOf(false) }
+    var isTextFieldFocused by remember { mutableStateOf(false) }
 
     BackHandler {
         cancelDiaryWrite(
@@ -328,6 +330,9 @@ private fun DiaryWriteScreen(
             Spacer(modifier = Modifier.height(8.dp))
 
             HilingualLongTextField(
+                modifier = Modifier.onFocusChanged {
+                    if (it.isFocused) isTextFieldFocused = true
+                },
                 value = diaryText,
                 onValueChanged = onDiaryTextChanged,
                 maxLength = 1000,
@@ -365,6 +370,11 @@ private fun DiaryWriteScreen(
                 delay(5000)
                 balloon.dismiss()
             }
+
+            LaunchedEffect(isTextFieldFocused) {
+                if (isTextFieldFocused) balloon.dismiss()
+            }
+
             HilingualButton(
                 modifier = Modifier
                     .fillMaxWidth()

--- a/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/DiaryWriteScreen.kt
+++ b/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/DiaryWriteScreen.kt
@@ -297,23 +297,6 @@ private fun DiaryWriteScreen(
             }
         )
 
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp)
-                .padding(top = 12.dp, bottom = 16.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween
-        ) {
-            DateText(
-                selectedDateProvider = { selectedDate }
-            )
-
-            TextScanButton(
-                onClick = { isBottomSheetVisible = true }
-            )
-        }
-
         Column(
             modifier = Modifier
                 .weight(1f)
@@ -321,6 +304,23 @@ private fun DiaryWriteScreen(
                 .verticalScroll(verticalScrollState)
                 .padding(start = 16.dp, end = 16.dp, bottom = 16.dp)
         ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .padding(top = 12.dp, bottom = 16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                DateText(
+                    selectedDateProvider = { selectedDate }
+                )
+
+                TextScanButton(
+                    onClick = { isBottomSheetVisible = true }
+                )
+            }
+
             RecommendedTopicDropdown(
                 enTopic = topicEn,
                 koTopic = topicKo,


### PR DESCRIPTION
## Related issue 🛠
- closed #401 

## Work Description ✏️
- 2차 QA 수정사항을 일부 반영했습니다
    - 일기 작성 - 작성 안내 툴팁: 5초 동안 지속됨, 그러나 키보드가 활성화 된 후에도 키보드 위에 툴팁이 존재함
    - 일기 작성 - 스크롤 범위 맞지 않음. n월 n일 n요일 + 텍스트 스캔하기도 스크롤 되어야함

## Screenshot 📸
https://github.com/user-attachments/assets/13eb74a9-bb91-4e25-9957-7a8cf12cb898

https://github.com/user-attachments/assets/da91d28d-ad71-4084-8592-9392a0f6d508

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
- 디바이스 세로 사이즈에 따라 기명에서 요구하는 조건이 달라질 수 있는 것 같아 물어본 내용이 있는데, 기획 측 답변 확인 후 반영해두겠습니다..!! (디자인 측이랑 논의가 필요할 것 같다고 해 추후 반영해두겠습니다)