### PR TITLE
[chore/#407] Set proguard, consumer rules config

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,72 +1,63 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
-
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
-
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
+# 여기에 프로젝트별 ProGuard 규칙을 추가하세요.
 -keepattributes SourceFile,LineNumberTable
 
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+# Hilingual 특정 규칙
 
-# Hilingual Specific Rules
-
-##---------------Begin: kotlin serialization ----------
--keepattributes *Annotation*, InnerClasses
--dontnote kotlinx.serialization.AnnotationsKt # core serialization annotations
-
-# kotlinx-serialization-json specific. Add this if you have java.lang.NoClassDefFoundError kotlinx.serialization.json.JsonObjectSerializer
--keepclassmembers class kotlinx.serialization.json.** {
+##---------------시작: kotlin serialization ----------
+# DTO를 위해 필수적인, 프로젝트 내 @Serializable 어노테이션이 붙은 클래스를 유지합니다.
+-keepclassmembers,allowobfuscation,allowshrinking @kotlinx.serialization.Serializable class com.hilingual.** {
     *** Companion;
-}
--keepclasseswithmembers class kotlinx.serialization.json.** {
     kotlinx.serialization.KSerializer serializer(...);
 }
 
-# Application rules
--keepclassmembers @kotlinx.serialization.Serializable class com.hilingual.** {
-    # lookup for plugin generated serializable classes
-    *** Companion;
-    # lookup for serializable objects
-    *** INSTANCE;
-    kotlinx.serialization.KSerializer serializer(...);
-}
-# lookup for plugin generated serializable classes
+# 직렬화 가능 클래스의 Companion 객체를 유지합니다.
 -if @kotlinx.serialization.Serializable class com.hilingual.**
 -keepclassmembers class com.hilingual.<1>$Companion {
     kotlinx.serialization.KSerializer serializer(...);
 }
 
-# Serialization supports named companions but for such classes it is necessary to add an additional rule.
-# This rule keeps serializer and serializable class from obfuscation. Therefore, it is recommended not to use wildcards in it, but to write rules for each such class.
-# -keep class com.hilingual.SerializableClassWithNamedCompanion$$serializer {
-#     *** INSTANCE;
-# }
-
--keep class com.hilingual.** {
+# @SerialName 어노테이션이 붙은 필드를 유지합니다.
+-keepclassmembers class com.hilingual.** {
     @kotlinx.serialization.SerialName <fields>;
 }
 
-##---------------END: kotlin serialization ----------
+# 생성된 serializer를 유지합니다.
+-keep,allowobfuscation,allowshrinking class **$$serializer {
+    *** Companion;
+    *** INSTANCE;
+}
 
-##---------------Begin: Coroutines ----------
-# Keep critical classes for coroutines to work correctly.
--keep class kotlinx.coroutines.android.AndroidDispatcherFactory
--keep class kotlinx.coroutines.android.AndroidExceptionPreHandler
-##---------------End: Coroutines ----------
+# kotlinx.serialization 기본 클래스를 유지합니다.
+-keep class kotlinx.serialization.** { *; }
+-dontwarn kotlinx.serialization.**
+##---------------종료: kotlin serialization ----------
 
-##---------------Begin: Timber ----------
+##---------------시작: Hilt ----------
+-keepnames @dagger.hilt.android.lifecycle.HiltViewModel class * extends androidx.lifecycle.ViewModel
+##---------------종료: Hilt ----------
+
+##---------------시작: Room ----------
+# Room은 자체 consumer rule을 가지고 있지만, 페이징 등을 위해 안전하게 추가합니다.
+-keep class androidx.room.paging.** { *; }
+-dontwarn androidx.room.paging.**
+##---------------종료: Room ----------
+
+##---------------시작: Coil 3 ----------
+-keep class * extends coil3.util.DecoderServiceLoaderTarget { *; }
+##---------------종료: Coil 3 ----------
+
+##---------------시작: ML Kit ----------
+-keep class com.google.mlkit.** { *; }
+-dontwarn com.google.mlkit.**
+##---------------종료: ML Kit ----------
+
+##---------------시작: AndroidX Credentials ----------
+-if class androidx.credentials.CredentialManager
+-keep class androidx.credentials.playservices.** { *; }
+-keep class androidx.credentials.fido.** { *; }
+##---------------종료: AndroidX Credentials ----------
+
+##---------------시작: Timber ----------
 -keep class timber.log.Timber$Tree { *; }
 -keep class timber.log.Timber$DebugTree { *; }
-##---------------End: Timber ----------
+##---------------종료: Timber ----------

--- a/core/network/consumer-rules.pro
+++ b/core/network/consumer-rules.pro
@@ -1,69 +1,42 @@
-##---------------Begin: Okio  ----------
-# Animal Sniffer compileOnly dependency to ensure APIs are compatible with older versions of Java.
--dontwarn org.codehaus.mojo.animal_sniffer.*
-##---------------End: Okio  ----------
+# 이 파일은 이 모듈에 의존하는 모든 프로젝트에 자동으로 적용됩니다.
 
-##---------------Begin: Retrofit  ----------
-
-# Retrofit does reflection on generic parameters. InnerClasses is required to use Signature and
-# EnclosingMethod is required to use InnerClasses.
--keepattributes Signature, InnerClasses, EnclosingMethod
-
-# Retrofit does reflection on method and parameter annotations.
--keepattributes RuntimeVisibleAnnotations, RuntimeVisibleParameterAnnotations
-
-# Keep annotation default values (e.g., retrofit2.http.Field.encoded).
--keepattributes AnnotationDefault
-
-# Retain service method parameters when optimizing.
--keepclassmembers,allowshrinking,allowobfuscation interface * {
-    @retrofit2.http.* <methods>;
-}
-
-# Ignore annotation used for build tooling.
--dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
-
-# Ignore JSR 305 annotations for embedding nullability information.
+##---------------시작: Retrofit & OkHttp ----------
+# JSR 305 어노테이션은 null 허용 여부 정보를 포함하기 위한 것입니다.
 -dontwarn javax.annotation.**
-
-# Guarded by a NoClassDefFoundError try/catch and only used when on the classpath.
--dontwarn kotlin.Unit
-
-# Top-level functions that can only be used by Kotlin.
--dontwarn retrofit2.KotlinExtensions
--dontwarn retrofit2.KotlinExtensions$*
-
-# With R8 full mode, it sees no subtypes of Retrofit interfaces since they are created with a Proxy
-# and replaces all potential values with null. Explicitly keeping the interfaces prevents this.
--if interface * { @retrofit2.http.* <methods>; }
--keep,allowobfuscation interface <1>
-
-# Keep generic signature of Call, Response (R8 full mode strips signatures from non-kept items).
--keep interface retrofit2.Call { *; }
--keep class retrofit2.Response { *; }
-
-# With R8 full mode generic signatures are stripped for classes that are not
-# kept. Suspend functions are wrapped in continuations where the type argument
-# is used.
--keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
-
-##---------------End: Retrofit  ----------
-
-##---------------Begin: OkHttp -------------
-
-# JSR 305 annotations are for embedding nullability information.
--dontwarn javax.annotation.**
-
-# A resource is loaded with a relative path so the package of this class must be preserved.
+# 리소스가 상대 경로로 로드되므로 이 클래스의 패키지는 유지되어야 합니다.
 -adaptresourcefilenames okhttp3/internal/publicsuffix/PublicSuffixDatabase.gz
-
-# Animal Sniffer compileOnly dependency to ensure APIs are compatible with older versions of Java.
+# Animal Sniffer는 이전 버전의 Java와 API 호환성을 보장하기 위한 compileOnly 의존성입니다.
 -dontwarn org.codehaus.mojo.animal_sniffer.*
-
-# OkHttp platform used only on JVM and when Conscrypt and other security providers are available.
+# OkHttp 플랫폼은 JVM에서만 사용되며, Conscrypt 및 기타 보안 제공자가 있을 때 사용됩니다.
 -dontwarn okhttp3.internal.platform.**
 -dontwarn org.conscrypt.**
 -dontwarn org.bouncycastle.**
 -dontwarn org.openjsse.**
 
-##---------------End : OkHttp --------------
+# Retrofit은 제네릭 파라미터, 메소드 및 파라미터 어노테이션에 리플렉션을 사용합니다.
+-keepattributes Signature, InnerClasses, EnclosingMethod, RuntimeVisibleAnnotations, RuntimeVisibleParameterAnnotations, AnnotationDefault
+
+# 최적화 시 서비스 메소드 파라미터를 유지합니다.
+-keepclassmembers,allowshrinking,allowobfuscation interface * {
+    @retrofit2.http.* <methods>;
+}
+# 빌드 도구에 사용되는 어노테이션 경고를 무시합니다.
+-dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
+# 클래스패스에 있을 때만 NoClassDefFoundError try/catch로 보호되어 사용됩니다.
+-dontwarn kotlin.Unit
+# Kotlin에서만 사용할 수 있는 최상위 함수에 대한 경고를 무시합니다.
+-dontwarn retrofit2.KotlinExtensions
+-dontwarn retrofit2.KotlinExtensions$*
+
+# R8 전체 모드에서는 Retrofit 인터페이스의 하위 유형을 볼 수 없으므로 (프록시로 생성됨)
+# 모든 잠재적 값을 null로 대체합니다. 인터페이스를 명시적으로 유지하면 이를 방지할 수 있습니다.
+-if interface * { @retrofit2.http.* <methods>; }
+-keep,allowobfuscation interface <1>
+
+# Call, Response의 제네릭 시그니처를 유지합니다 (R8 전체 모드는 유지되지 않은 항목에서 시그니처를 제거합니다).
+-keep interface retrofit2.Call { *; }
+-keep class retrofit2.Response { *; }
+
+# Suspend 함수는 타입 인자가 사용되는 continuation으로 래핑됩니다.
+-keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
+##---------------종료: Retrofit & OkHttp ----------


### PR DESCRIPTION
## Related issue 🛠
- closed #407 

## Work Description ✏️
- proguard-rules.pro 세팅
- consumer-rules.pro 세팅

## To Reviewers 📢
Hilt, Kotlinx Serialization, 데이터 클래스(DTO/Model) 보호 규칙은 `app/proguard-rules.pro`에, Retrofit 등 네트워크 라이브러리 규칙은                         `core/network/consumer-rules.pro`에 아키텍처에 맞게 분리 적용되었습니다. 
테스트는 난독화 적용한 디버그 빌드로 홈 -> 일기 작성 -> 피드 조회 까지 이상없는것 확인했습니다.