### PR TITLE
[MOD/#412] 다이얼로그 일관화

### DIFF
--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/content/diary/DiaryViewModeToggle.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/content/diary/DiaryViewModeToggle.kt
@@ -42,7 +42,7 @@ internal fun DiaryViewModeToggle(
         modifier = modifier
     ) {
         Text(
-            text = "AI가 쓴 일기",
+            text = "교정된 일기",
             style = HilingualTheme.typography.captionR14,
             color = HilingualTheme.colors.gray500
         )

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
@@ -93,7 +93,7 @@ internal fun DiaryFeedbackRoute(
 
     viewModel.sideEffect.collectSideEffect {
         when (it) {
-            is DiaryFeedbackSideEffect.ShowRetryDialog -> dialogTrigger.show(it.onRetry)
+            is DiaryFeedbackSideEffect.ShowErrorDialog -> dialogTrigger.show(navigateUp)
 
             is DiaryFeedbackSideEffect.ShowDiaryPublishSnackbar -> {
                 snackbarTrigger(

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackViewModel.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackViewModel.kt
@@ -37,7 +37,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -92,11 +91,10 @@ internal class DiaryFeedbackViewModel @Inject constructor(
         viewModelScope.launch {
             runCatching {
                 requestDiaryFeedbackData()
-            }.onFailure { e ->
-                Timber.d("일기 상세 조회 실패: $e")
+            }.onFailure {
                 _uiState.value = UiState.Failure
                 _sideEffect.emit(
-                    DiaryFeedbackSideEffect.ShowRetryDialog { loadInitialData() }
+                    DiaryFeedbackSideEffect.ShowErrorDialog
                 )
             }
         }
@@ -122,10 +120,10 @@ internal class DiaryFeedbackViewModel @Inject constructor(
                 } else {
                     showToast("일기가 비공개되었어요!")
                 }
-            }.onLogFailure { exception ->
+            }.onLogFailure {
                 _uiState.value = UiState.Failure
                 _sideEffect.emit(
-                    DiaryFeedbackSideEffect.ShowRetryDialog { loadInitialData() }
+                    DiaryFeedbackSideEffect.ShowErrorDialog
                 )
             }
         }
@@ -193,7 +191,7 @@ internal class DiaryFeedbackViewModel @Inject constructor(
 
 sealed interface DiaryFeedbackSideEffect {
     data object NavigateToHome : DiaryFeedbackSideEffect
-    data class ShowRetryDialog(val onRetry: () -> Unit) : DiaryFeedbackSideEffect
+    data object ShowErrorDialog : DiaryFeedbackSideEffect
     data class ShowDiaryPublishSnackbar(val message: String, val actionLabel: String) : DiaryFeedbackSideEffect
     data class ShowVocaOverflowSnackbar(val message: String, val actionLabel: String) : DiaryFeedbackSideEffect
     data class ShowToast(val message: String) : DiaryFeedbackSideEffect

--- a/presentation/feed/src/main/java/com/hilingual/presentation/feed/FeedScreen.kt
+++ b/presentation/feed/src/main/java/com/hilingual/presentation/feed/FeedScreen.kt
@@ -75,7 +75,7 @@ internal fun FeedRoute(
                 toastTrigger(sideEffect.message)
             }
 
-            is FeedSideEffect.ShowRetryDialog -> {
+            is FeedSideEffect.ShowErrorDialog -> {
                 dialogTrigger.show(sideEffect.onRetry)
             }
         }

--- a/presentation/feed/src/main/java/com/hilingual/presentation/feed/FeedViewModel.kt
+++ b/presentation/feed/src/main/java/com/hilingual/presentation/feed/FeedViewModel.kt
@@ -224,7 +224,7 @@ internal class FeedViewModel @Inject constructor(
     }
 
     private suspend fun showLikeSnackbar() {
-        _sideEffect.emit(FeedSideEffect.ShowDiaryLikeSnackbar(message = "일기를 공감했습니다.", actionLabel = "보러가기"))
+        _sideEffect.emit(FeedSideEffect.ShowDiaryLikeSnackbar(message = "공감한 일기에 추가되었어요.", actionLabel = "보러가기"))
     }
 
     private suspend fun emitErrorDialogSideEffect(onRetry: () -> Unit) {

--- a/presentation/feed/src/main/java/com/hilingual/presentation/feed/FeedViewModel.kt
+++ b/presentation/feed/src/main/java/com/hilingual/presentation/feed/FeedViewModel.kt
@@ -96,7 +96,7 @@ internal class FeedViewModel @Inject constructor(
                     }
                 }
                 .onLogFailure {
-                    emitRetrySideEffect { getRecommendFeeds(isUserRefresh) }
+                    emitErrorDialogSideEffect { getRecommendFeeds(isUserRefresh) }
                 }
 
             if (isUserRefresh) {
@@ -121,7 +121,7 @@ internal class FeedViewModel @Inject constructor(
                     }
                 }
                 .onLogFailure {
-                    emitRetrySideEffect { getFollowingFeeds(isUserRefresh) }
+                    emitErrorDialogSideEffect { getFollowingFeeds(isUserRefresh) }
                 }
 
             if (isUserRefresh) {
@@ -217,8 +217,8 @@ internal class FeedViewModel @Inject constructor(
         }
     }
 
-    private suspend fun emitRetrySideEffect(onRetry: () -> Unit) {
-        _sideEffect.emit(FeedSideEffect.ShowRetryDialog(onRetry = onRetry))
+    private suspend fun emitErrorDialogSideEffect(onRetry: () -> Unit) {
+        _sideEffect.emit(FeedSideEffect.ShowErrorDialog(onRetry = onRetry))
     }
 
     private suspend fun emitToastSideEffect(message: String) {
@@ -227,6 +227,6 @@ internal class FeedViewModel @Inject constructor(
 }
 
 sealed interface FeedSideEffect {
-    data class ShowRetryDialog(val onRetry: () -> Unit) : FeedSideEffect
+    data class ShowErrorDialog(val onRetry: () -> Unit) : FeedSideEffect
     data class ShowToast(val message: String) : FeedSideEffect
 }

--- a/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/FeedDiaryScreen.kt
+++ b/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/FeedDiaryScreen.kt
@@ -99,7 +99,7 @@ internal fun FeedDiaryRoute(
                 dialogTrigger.show(navigateUp)
             }
 
-            is FeedDiarySideEffect.ShowRetryDialog -> { TODO() }
+            is FeedDiarySideEffect.ShowErrorDialog -> dialogTrigger.show(navigateUp)
         }
     }
 

--- a/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/FeedDiaryViewModel.kt
+++ b/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/FeedDiaryViewModel.kt
@@ -182,7 +182,7 @@ internal class FeedDiaryViewModel @Inject constructor(
     }
 
     private suspend fun showLikeSnackbar() {
-        _sideEffect.emit(FeedDiarySideEffect.ShowDiaryLikeSnackbar(message = "일기를 공감했습니다.", actionLabel = "보러가기"))
+        _sideEffect.emit(FeedDiarySideEffect.ShowDiaryLikeSnackbar(message = "공감한 일기에 추가되었어요.", actionLabel = "보러가기"))
     }
 
     private suspend fun showVocaOverflowSnackbar() {

--- a/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/FeedDiaryViewModel.kt
+++ b/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/FeedDiaryViewModel.kt
@@ -97,7 +97,7 @@ internal class FeedDiaryViewModel @Inject constructor(
             }.onSuccess { combinedState ->
                 _uiState.update { UiState.Success(combinedState) }
             }.onLogFailure {
-                _sideEffect.emit(FeedDiarySideEffect.ShowRetryDialog(onRetry = ::loadInitialData))
+                _sideEffect.emit(FeedDiarySideEffect.ShowErrorDialog)
             }
         }
     }
@@ -193,7 +193,6 @@ internal class FeedDiaryViewModel @Inject constructor(
 sealed interface FeedDiarySideEffect {
     data object NavigateToUp : FeedDiarySideEffect
     data class NavigateToFeedProfile(val userId: Long) : FeedDiarySideEffect
-    data class ShowRetryDialog(val onRetry: () -> Unit) : FeedDiarySideEffect
     data class ShowVocaOverflowSnackbar(val message: String, val actionLabel: String) :
         FeedDiarySideEffect
 

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileScreen.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileScreen.kt
@@ -85,7 +85,7 @@ internal fun FeedProfileRoute(
                 toastTrigger(it.message)
             }
 
-            is FeedProfileSideEffect.ShowRetryDialog -> dialogTrigger.show(it.onRetry)
+            is FeedProfileSideEffect.ShowErrorDialog -> dialogTrigger.show(navigateUp)
         }
     }
 

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileViewModel.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileViewModel.kt
@@ -67,7 +67,7 @@ internal class FeedProfileViewModel @Inject constructor(
             if (feedProfileResult.isFailure || sharedDiariesResult.isFailure) {
                 feedProfileResult.onLogFailure {}
                 sharedDiariesResult.onLogFailure {}
-                _sideEffect.emit(FeedProfileSideEffect.ShowRetryDialog { loadFeedProfile() })
+                _sideEffect.emit(FeedProfileSideEffect.ShowErrorDialog)
                 return@launch
             }
 
@@ -79,7 +79,7 @@ internal class FeedProfileViewModel @Inject constructor(
                     onSuccess = { it.diaryList },
                     onFailure = { throwable ->
                         Timber.e(throwable)
-                        _sideEffect.emit(FeedProfileSideEffect.ShowRetryDialog { loadLikedDiaries() })
+                        _sideEffect.emit(FeedProfileSideEffect.ShowErrorDialog)
                         return@launch
                     }
                 )
@@ -126,7 +126,7 @@ internal class FeedProfileViewModel @Inject constructor(
                     }
                 }
                 .onLogFailure {
-                    _sideEffect.emit(FeedProfileSideEffect.ShowRetryDialog { loadFeedProfile() })
+                    _sideEffect.emit(FeedProfileSideEffect.ShowErrorDialog)
                 }
         }
     }
@@ -144,7 +144,7 @@ internal class FeedProfileViewModel @Inject constructor(
                     }
                 }
                 .onLogFailure {
-                    _sideEffect.emit(FeedProfileSideEffect.ShowRetryDialog { loadLikedDiaries() })
+                    _sideEffect.emit(FeedProfileSideEffect.ShowErrorDialog)
                 }
         }
     }
@@ -265,5 +265,5 @@ internal class FeedProfileViewModel @Inject constructor(
 
 sealed interface FeedProfileSideEffect {
     data class ShowToast(val message: String) : FeedProfileSideEffect
-    data class ShowRetryDialog(val onRetry: () -> Unit) : FeedProfileSideEffect
+    data object ShowErrorDialog : FeedProfileSideEffect
 }

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileViewModel.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/FeedProfileViewModel.kt
@@ -270,7 +270,7 @@ internal class FeedProfileViewModel @Inject constructor(
     }
 
     private suspend fun showLikeSnackbar() {
-        _sideEffect.emit(FeedProfileSideEffect.ShowDiaryLikeSnackbar(message = "일기를 공감했습니다.", actionLabel = "보러가기"))
+        _sideEffect.emit(FeedProfileSideEffect.ShowDiaryLikeSnackbar(message = "공감한 일기에 추가되었어요.", actionLabel = "보러가기"))
     }
 }
 

--- a/presentation/home/src/main/java/com/hilingual/presentation/home/HomeScreen.kt
+++ b/presentation/home/src/main/java/com/hilingual/presentation/home/HomeScreen.kt
@@ -87,7 +87,7 @@ internal fun HomeRoute(
 
     viewModel.sideEffect.collectSideEffect { sideEffect ->
         when (sideEffect) {
-            is HomeSideEffect.ShowRetryDialog -> dialogTrigger.show(sideEffect.onRetry)
+            is HomeSideEffect.ShowErrorDialog -> dialogTrigger.show(sideEffect.onRetry)
 
             is HomeSideEffect.ShowToast -> toastTrigger(sideEffect.text)
 

--- a/presentation/home/src/main/java/com/hilingual/presentation/home/HomeViewModel.kt
+++ b/presentation/home/src/main/java/com/hilingual/presentation/home/HomeViewModel.kt
@@ -78,7 +78,7 @@ class HomeViewModel @Inject constructor(
             if (userInfoResult.isFailure || calendarResult.isFailure) {
                 userInfoResult.onLogFailure {}
                 calendarResult.onLogFailure {}
-                emitRetrySideEffect { loadInitialData() }
+                emitErrorDialogSideEffect { loadInitialData() }
                 return@launch
             }
 
@@ -135,7 +135,7 @@ class HomeViewModel @Inject constructor(
                     updateContentForDate(newDate)
                 }
                 .onLogFailure {
-                    emitRetrySideEffect { onMonthChanged(yearMonth) }
+                    emitErrorDialogSideEffect { onMonthChanged(yearMonth) }
                 }
         }
     }
@@ -158,7 +158,7 @@ class HomeViewModel @Inject constructor(
                     )
                 }
                 .onLogFailure {
-                    emitRetrySideEffect { }
+                    emitErrorDialogSideEffect { }
                 }
         }
     }
@@ -178,7 +178,7 @@ class HomeViewModel @Inject constructor(
                     emitToastSideEffect("일기가 비공개 되었어요.")
                 }
                 .onLogFailure {
-                    emitRetrySideEffect { }
+                    emitErrorDialogSideEffect { }
                 }
         }
     }
@@ -203,7 +203,7 @@ class HomeViewModel @Inject constructor(
                     emitToastSideEffect("삭제가 완료되었어요.")
                 }
                 .onLogFailure {
-                    emitRetrySideEffect { }
+                    emitErrorDialogSideEffect { }
                 }
         }
     }
@@ -235,7 +235,7 @@ class HomeViewModel @Inject constructor(
                                 )
                             }
                         }
-                        .onLogFailure { emitRetrySideEffect { updateContentForDate(date) } }
+                        .onLogFailure { emitErrorDialogSideEffect { updateContentForDate(date) } }
                 }
 
                 isDateWritable(date) -> {
@@ -278,8 +278,8 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    private suspend fun emitRetrySideEffect(onRetry: () -> Unit) =
-        _sideEffect.emit(HomeSideEffect.ShowRetryDialog(onRetry = onRetry))
+    private suspend fun emitErrorDialogSideEffect(onRetry: () -> Unit) =
+        _sideEffect.emit(HomeSideEffect.ShowErrorDialog(onRetry = onRetry))
 
     private suspend fun emitToastSideEffect(text: String) =
         _sideEffect.emit(HomeSideEffect.ShowToast(text = text))
@@ -289,7 +289,7 @@ class HomeViewModel @Inject constructor(
 }
 
 sealed interface HomeSideEffect {
-    data class ShowRetryDialog(val onRetry: () -> Unit) : HomeSideEffect
+    data class ShowErrorDialog(val onRetry: () -> Unit) : HomeSideEffect
 
     data class ShowToast(val text: String) : HomeSideEffect
 

--- a/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/MyPageScreen.kt
+++ b/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/MyPageScreen.kt
@@ -68,7 +68,7 @@ internal fun MyPageRoute(
 
     viewModel.sideEffect.collectSideEffect { sideEffect ->
         when (sideEffect) {
-            is MyPageSideEffect.ShowRetryDialog -> {
+            is MyPageSideEffect.ShowErrorDialog -> {
                 dialogTrigger.show(sideEffect.onRetry)
             }
 

--- a/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/MyPageViewModel.kt
+++ b/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/MyPageViewModel.kt
@@ -47,7 +47,11 @@ internal class MyPageViewModel @Inject constructor(
                         )
                     }
                 }
-                .onLogFailure { }
+                .onLogFailure {
+                    viewModelScope.launch {
+                        _sideEffect.emit(MyPageSideEffect.ShowErrorDialog(onRetry = ::getProfileInfo))
+                    }
+                }
         }
     }
 
@@ -83,6 +87,6 @@ internal class MyPageViewModel @Inject constructor(
 }
 
 sealed interface MyPageSideEffect {
-    data class ShowRetryDialog(val onRetry: () -> Unit) : MyPageSideEffect
+    data class ShowErrorDialog(val onRetry: () -> Unit) : MyPageSideEffect
     data object RestartApp : MyPageSideEffect
 }

--- a/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/profileedit/ProfileEditScreen.kt
+++ b/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/profileedit/ProfileEditScreen.kt
@@ -53,7 +53,7 @@ internal fun ProfileEditRoute(
 
     viewModel.sideEffect.collectSideEffect { sideEffect ->
         when (sideEffect) {
-            is MyPageSideEffect.ShowRetryDialog -> {
+            is MyPageSideEffect.ShowErrorDialog -> {
                 dialogTrigger.show(sideEffect.onRetry)
             }
 

--- a/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaScreen.kt
+++ b/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaScreen.kt
@@ -90,8 +90,8 @@ internal fun VocaRoute(
 
     viewModel.sideEffect.collectSideEffect {
         when (it) {
-            is VocaSideEffect.ShowRetryDialog -> {
-                dialogTrigger.show { dialogTrigger.dismiss() }
+            is VocaSideEffect.ShowErrorDialog -> {
+                dialogTrigger.show(it.onRetry)
             }
         }
     }

--- a/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaViewModel.kt
+++ b/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaViewModel.kt
@@ -103,7 +103,7 @@ constructor(
                 }
                 .onLogFailure {
                     _uiState.update { it.copy(isRefreshing = false) }
-                    _sideEffect.emit(VocaSideEffect.ShowRetryDialog {})
+                    _sideEffect.emit(VocaSideEffect.ShowErrorDialog {})
                 }
         }
     }
@@ -137,7 +137,7 @@ constructor(
                     }
                 }
                 .onLogFailure {
-                    _sideEffect.emit(VocaSideEffect.ShowRetryDialog {})
+                    _sideEffect.emit(VocaSideEffect.ShowErrorDialog(onRetry = ::refreshVocaList))
                 }
         }
     }
@@ -229,7 +229,7 @@ constructor(
                     }
                 }
                 .onLogFailure {
-                    _sideEffect.emit(VocaSideEffect.ShowRetryDialog {})
+                    _sideEffect.emit(VocaSideEffect.ShowErrorDialog {})
                 }
         }
     }
@@ -240,5 +240,5 @@ constructor(
 }
 
 sealed interface VocaSideEffect {
-    data class ShowRetryDialog(val onRetry: () -> Unit) : VocaSideEffect
+    data class ShowErrorDialog(val onRetry: () -> Unit) : VocaSideEffect
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #412

## Work Description ✏️
- 다이얼로그 동작 일관화
- 단어장 에러의 경우 새로고침
- 이벤트 네이밍 통일

## Screenshot 📸

https://github.com/user-attachments/assets/68e05029-40a9-4a43-97b0-ed98d06697bf

## To Reviewers 📢
작업한 기준에 대해서 설명드릴게요
1. 기존에 DialogTrigger를 사용하고 있던 경우
- 최상위 뷰 -> 뒤로가기가 아닌 재시도
- 하위 뷰 -> 뒤로가기

2. DialogTrigger를 사용하지 않은 경우
- init과 같은 첫 로딩에만 뒤로가기 적용

3. onLogFailure가 비여있던 경우
- 이 경우는 다이얼로그 이벤트 방출을 넣지않음.
- 작업자 본인이 나중에 핸들링 해주세요.

일단 기존에 있던 로직 위주로 수정했습니다. 본인 담당에서 실패처리가 미흡한 부분이 있거나 수정할 부분이 있다면 따로 진행해주세요