### PR TITLE
[FIX/#423] 피드 홈 토스트 표시 이슈 수정

### DIFF
--- a/core/common/src/main/java/com/hilingual/core/common/extension/FlowExt.kt
+++ b/core/common/src/main/java/com/hilingual/core/common/extension/FlowExt.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.flowWithLifecycle
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.flow
 
 @Composable
 fun <T> Flow<T>.collectSideEffect(
@@ -44,5 +45,13 @@ fun <T> Flow<T>.collectLatestSideEffect(
     LaunchedEffect(key) {
         flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
             .collectLatest(collector)
+    }
+}
+
+fun <T> Flow<T>.pairwise(): Flow<Pair<T?, T>> = flow {
+    var previous: T? = null
+    collect { current ->
+        emit(Pair(previous, current))
+        previous = current
     }
 }

--- a/presentation/feed/src/main/java/com/hilingual/presentation/feed/FeedScreen.kt
+++ b/presentation/feed/src/main/java/com/hilingual/presentation/feed/FeedScreen.kt
@@ -202,7 +202,7 @@ private fun FeedScreen(
             .collect { (isScrolling, currentIndex, currentOffset) ->
                 if (isScrolling) {
                     val isScrollingDown = currentIndex > previousFirstVisibleItemIndex ||
-                            (currentIndex == previousFirstVisibleItemIndex && currentOffset > previousFirstVisibleItemScrollOffset)
+                        (currentIndex == previousFirstVisibleItemIndex && currentOffset > previousFirstVisibleItemScrollOffset)
 
                     previousFirstVisibleItemIndex = currentIndex
                     previousFirstVisibleItemScrollOffset = currentOffset

--- a/presentation/feed/src/main/java/com/hilingual/presentation/feed/FeedViewModel.kt
+++ b/presentation/feed/src/main/java/com/hilingual/presentation/feed/FeedViewModel.kt
@@ -188,6 +188,16 @@ internal class FeedViewModel @Inject constructor(
         }
     }
 
+    fun isScrollingDown(previous: FeedScrollState?, current: FeedScrollState): Boolean {
+        if (previous == null) return false
+
+        return current.firstVisibleItemIndex > previous.firstVisibleItemIndex ||
+            (
+                current.firstVisibleItemIndex == previous.firstVisibleItemIndex &&
+                    current.firstVisibleItemScrollOffset > previous.firstVisibleItemScrollOffset
+                )
+    }
+
     private fun UiState<ImmutableList<FeedItemUiModel>>.updateIfSuccess(
         transform: (ImmutableList<FeedItemUiModel>) -> ImmutableList<FeedItemUiModel>
     ): UiState<ImmutableList<FeedItemUiModel>> {
@@ -235,6 +245,11 @@ internal class FeedViewModel @Inject constructor(
         _sideEffect.emit(FeedSideEffect.ShowToast(message))
     }
 }
+
+internal data class FeedScrollState(
+    val firstVisibleItemIndex: Int,
+    val firstVisibleItemScrollOffset: Int
+)
 
 sealed interface FeedSideEffect {
     data class ShowErrorDialog(val onRetry: () -> Unit) : FeedSideEffect


### PR DESCRIPTION
## Related issue 🛠
- closed #423 

## Work Description ✏️
"피드 목록 최하단을 도달했음에도 토스트가 표시되지 않는 이슈"에 대해 @angryPodo 가 제보해주셔서 확인해본 결과, 에러 케이스가 아래와 같았습니다.

**<이슈 상황>**
1. 발생 환경: 스크롤 아이템이 충분히 많지 않은 상태, 마지막 아이템이 최하단이 걸려서 보일 때
2. 이슈 내용
   a. 화면 진입 시에 토스트가 바로 표시됨 (에러)
   b. 스크롤을 내렸을 때는 토스트 표시 X (에러)

**<이슈 발생 원인>**
- 스크롤 아이템이 얼마 없어 한 화면 내에 모든 아이템이 보이는 경우 `isAtBottom`이 항상 true로 계산됐음

**<해결 방법>**
- `isScrolling` 여부를 확인하고, 스크롤 방향이 하단을 향할 때 계산

## Screenshot 📸
| Before | After|
|:--:|:--:|
<video src="https://github.com/user-attachments/assets/1982e5d7-42c4-4675-a88b-dadc753c30e0" width="360"/> | <video src="https://github.com/user-attachments/assets/36eaea29-985f-441e-99d1-158dc67fe40d" width="360"/>

## Uncompleted Tasks 😅
- N/A


## To Reviewers 📢
- 작업이 늦어져서 죄송합니다..
- `isAtBottom`이 계속 true로 나오는 것이 토스트 오류의 근본적인 원인이었습니다. 처음에는 `isAtBottom` 계산 조건을 바꿔주려고 하다가 스크롤만 하면 계속 토스트가 뜨는 등의 다른 오류가 발생해서, 지금 방식을 채택하게 되었습니다.
- 아이디어 떠올린다고 시간을 꽤 쓰긴 했는데 이게 정말 최선의 해결 방법일까? 싶은 의심은 계속 드네요. 좋은 방법이 있다면 편하게 알려주시면 감사하겠습니다!
- 겸사겸사 기존 기획 의도대로 아이템 많이 없을 때(스크롤되지 않는 경우)는 토스트가 표시되지 않도록 같이 수정했어요!!