### PR TITLE
[FIX/#461] AnnotatedString diffRanges 예외 처리

### DIFF
--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/content/diary/DiaryCard.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/content/diary/DiaryCard.kt
@@ -42,6 +42,9 @@ import com.hilingual.core.designsystem.theme.SuitMedium
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
+private const val MAX_AI = 1500
+private const val MAX_ORIGINAL = 1000
+
 @Composable
 internal fun DiaryCard(
     isAIWritten: Boolean,
@@ -51,7 +54,7 @@ internal fun DiaryCard(
     diffRanges: ImmutableList<Pair<Int, Int>> = persistentListOf(),
     imageUrl: String? = null
 ) {
-    val maxContentLength = if (isAIWritten) 1500 else 1000
+    val maxContentLength = if (isAIWritten) MAX_AI else MAX_ORIGINAL
 
     val clipContent = diaryContent.run {
         if (length > maxContentLength) this.take(maxContentLength) else this
@@ -111,6 +114,7 @@ private fun getAnnotatedString(
     return buildAnnotatedString {
         append(content)
         diffRanges.forEach {
+            if (it.second >= MAX_AI) return@forEach
             addStyle(
                 style = SpanStyle(
                     color = HilingualTheme.colors.hilingualOrange,
@@ -160,7 +164,7 @@ private class DiaryContentCardPreviewProvider :
     )
 }
 
-@Preview(showBackground = true, backgroundColor = 0x000000)
+@Preview
 @Composable
 private fun DiaryCardPreview(
     @PreviewParameter(DiaryContentCardPreviewProvider::class) state: DiaryCardPreviewState


### PR DESCRIPTION
## Related issue 🛠
- closed #461 

## Work Description ✏️
- diffRanges에서의 `IndexOutOfBoundsException` 오류에 대해 예외처리를 진행했습니다.

## To Reviewers 📢
- 예외 처리를 추가하는 김에 AI, original 텍스트 길이를 상수로 추출했습니다.
- AI 피드백이 1500자가 넘어가고, diffRanges가 범위 이상인 경우에 대해 1) 하이라이팅을 아예 해주지 않을지, 2) 1500자까지는 하이라이팅을 해줄지 고민하다가 전자로 진행했습니다. 피드백 내용이 1500자를 넘어가 잘렸을 때, 잘린 부분까지 하이라이팅 표시가 되어 있다면 이상할 것 같아서요! (애초에 서비스 정책에 위배되는 오류기도 하구요)