### PR TITLE
[REF/#452] core:localstorage 모듈의 DI 구조 개선

### DIFF
--- a/core/localstorage/src/main/java/com/hilingual/core/localstorage/TokenManagerImpl.kt
+++ b/core/localstorage/src/main/java/com/hilingual/core/localstorage/TokenManagerImpl.kt
@@ -1,34 +1,14 @@
-/*
- * Copyright 2025 The Hilingual Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hilingual.core.localstorage
 
-import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
-import androidx.datastore.preferences.preferencesDataStore
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.first
-import javax.inject.Inject
 import javax.inject.Singleton
 
-val Context.dataStore by preferencesDataStore(name = "hilingual_prefs")
-
-@Singleton
-class TokenManagerImpl @Inject constructor(
-    @ApplicationContext private val context: Context
+class TokenManagerImpl constructor(
+    private val dataStore: DataStore<Preferences>
 ) : TokenManager {
 
     @Volatile
@@ -41,38 +21,38 @@ class TokenManagerImpl @Inject constructor(
 
     override suspend fun saveAccessToken(token: String) {
         cachedAccessToken = token
-        context.dataStore.edit { preferences ->
+        dataStore.edit { preferences ->
             preferences[PreferencesKeys.ACCESS_TOKEN] = token
         }
     }
 
     override suspend fun saveRefreshToken(token: String) {
-        context.dataStore.edit { preferences ->
+        dataStore.edit { preferences ->
             preferences[PreferencesKeys.REFRESH_TOKEN] = token
         }
     }
 
     override suspend fun saveTokens(accessToken: String, refreshToken: String) {
         cachedAccessToken = accessToken
-        context.dataStore.edit {
+        dataStore.edit {
             it[PreferencesKeys.ACCESS_TOKEN] = accessToken
             it[PreferencesKeys.REFRESH_TOKEN] = refreshToken
         }
     }
 
     override suspend fun getAccessToken(): String? {
-        return cachedAccessToken ?: context.dataStore.data.first()[PreferencesKeys.ACCESS_TOKEN].also {
+        return cachedAccessToken ?: dataStore.data.first()[PreferencesKeys.ACCESS_TOKEN].also {
             cachedAccessToken = it
         }
     }
 
     override suspend fun getRefreshToken(): String? {
-        return context.dataStore.data.first()[PreferencesKeys.REFRESH_TOKEN]
+        return dataStore.data.first()[PreferencesKeys.REFRESH_TOKEN]
     }
 
     override suspend fun clearTokens() {
         cachedAccessToken = null
-        context.dataStore.edit { preferences ->
+        dataStore.edit { preferences ->
             preferences.remove(PreferencesKeys.ACCESS_TOKEN)
             preferences.remove(PreferencesKeys.REFRESH_TOKEN)
         }

--- a/core/localstorage/src/main/java/com/hilingual/core/localstorage/TokenManagerImpl.kt
+++ b/core/localstorage/src/main/java/com/hilingual/core/localstorage/TokenManagerImpl.kt
@@ -5,7 +5,6 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.first
-import javax.inject.Singleton
 
 class TokenManagerImpl constructor(
     private val dataStore: DataStore<Preferences>

--- a/core/localstorage/src/main/java/com/hilingual/core/localstorage/TokenManagerImpl.kt
+++ b/core/localstorage/src/main/java/com/hilingual/core/localstorage/TokenManagerImpl.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 The Hilingual Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hilingual.core.localstorage
 
 import androidx.datastore.core.DataStore

--- a/core/localstorage/src/main/java/com/hilingual/core/localstorage/UserInfoManagerImpl.kt
+++ b/core/localstorage/src/main/java/com/hilingual/core/localstorage/UserInfoManagerImpl.kt
@@ -5,7 +5,6 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import kotlinx.coroutines.flow.first
-import javax.inject.Singleton
 
 class UserInfoManagerImpl constructor(
     private val dataStore: DataStore<Preferences>

--- a/core/localstorage/src/main/java/com/hilingual/core/localstorage/UserInfoManagerImpl.kt
+++ b/core/localstorage/src/main/java/com/hilingual/core/localstorage/UserInfoManagerImpl.kt
@@ -1,19 +1,14 @@
 package com.hilingual.core.localstorage
 
-import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.preferencesDataStore
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.first
-import javax.inject.Inject
 import javax.inject.Singleton
 
-val Context.userInfoDataStore by preferencesDataStore(name = "hilingual_user_info_prefs")
-
-@Singleton
-class UserInfoManagerImpl @Inject constructor(
-    @ApplicationContext private val context: Context
+class UserInfoManagerImpl constructor(
+    private val dataStore: DataStore<Preferences>
 ) : UserInfoManager {
 
     private object PreferencesKeys {
@@ -22,27 +17,27 @@ class UserInfoManagerImpl @Inject constructor(
     }
 
     override suspend fun saveRegisterStatus(isCompleted: Boolean) {
-        context.userInfoDataStore.edit { preferences ->
+        dataStore.edit { preferences ->
             preferences[PreferencesKeys.IS_REGISTER_COMPLETED] = isCompleted
         }
     }
 
     override suspend fun getRegisterStatus(): Boolean {
-        return context.userInfoDataStore.data.first()[PreferencesKeys.IS_REGISTER_COMPLETED] ?: false
+        return dataStore.data.first()[PreferencesKeys.IS_REGISTER_COMPLETED] ?: false
     }
 
     override suspend fun saveOtpVerified(isVerified: Boolean) {
-        context.userInfoDataStore.edit { preferences ->
+        dataStore.edit { preferences ->
             preferences[PreferencesKeys.IS_OTP_VERIFIED] = isVerified
         }
     }
 
     override suspend fun isOtpVerified(): Boolean {
-        return context.userInfoDataStore.data.first()[PreferencesKeys.IS_OTP_VERIFIED] ?: false
+        return dataStore.data.first()[PreferencesKeys.IS_OTP_VERIFIED] ?: false
     }
 
     override suspend fun clear() {
-        context.userInfoDataStore.edit { preferences ->
+        dataStore.edit { preferences ->
             preferences.clear()
         }
     }

--- a/core/localstorage/src/main/java/com/hilingual/core/localstorage/constant/DataStoreConstant.kt
+++ b/core/localstorage/src/main/java/com/hilingual/core/localstorage/constant/DataStoreConstant.kt
@@ -1,0 +1,6 @@
+package com.hilingual.core.localstorage.constant
+
+object DataStoreConstant {
+    const val HILINGUAL_PREFS = "hilingual_prefs"
+    const val HILINGUAL_USER_INFO_PREFS = "hilingual_user_info_prefs"
+}

--- a/core/localstorage/src/main/java/com/hilingual/core/localstorage/di/LocalStorageModule.kt
+++ b/core/localstorage/src/main/java/com/hilingual/core/localstorage/di/LocalStorageModule.kt
@@ -1,39 +1,33 @@
-/*
- * Copyright 2025 The Hilingual Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hilingual.core.localstorage.di
 
+import android.content.Context
+import androidx.datastore.preferences.preferencesDataStore
 import com.hilingual.core.localstorage.TokenManager
 import com.hilingual.core.localstorage.TokenManagerImpl
 import com.hilingual.core.localstorage.UserInfoManager
 import com.hilingual.core.localstorage.UserInfoManagerImpl
-import dagger.Binds
+import com.hilingual.core.localstorage.constant.DataStoreConstant
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-abstract class LocalStorageModule {
+object LocalStorageModule {
 
-    @Binds
-    @Singleton
-    abstract fun bindTokenManager(tokenManagerImpl: TokenManagerImpl): TokenManager
+    private val Context.tokenDataStore by preferencesDataStore(name = DataStoreConstant.HILINGUAL_PREFS)
+    private val Context.userInfoDataStore by preferencesDataStore(name = DataStoreConstant.HILINGUAL_USER_INFO_PREFS)
 
-    @Binds
+    @Provides
     @Singleton
-    abstract fun bindUserInfoManager(userInfoManagerImpl: UserInfoManagerImpl): UserInfoManager
+    fun provideTokenManager(@ApplicationContext context: Context): TokenManager =
+        TokenManagerImpl(context.tokenDataStore)
+
+    @Provides
+    @Singleton
+    fun provideUserInfoManager(@ApplicationContext context: Context): UserInfoManager =
+        UserInfoManagerImpl(context.userInfoDataStore)
 }

--- a/core/localstorage/src/main/java/com/hilingual/core/localstorage/di/LocalStorageModule.kt
+++ b/core/localstorage/src/main/java/com/hilingual/core/localstorage/di/LocalStorageModule.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 The Hilingual Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hilingual.core.localstorage.di
 
 import android.content.Context


### PR DESCRIPTION
## Related issue 🛠
- closed #452 

## Work Description ✏️
- 기존에 `Manager` 구현체가 `Context`를 직접 주입받던 방식에서, DI 모듈(`LocalStorageModule`)이 `DataStore`를 생성하여 `Manager` 구현체에 주입하는 방식으로 변경
- 이 변경으로 `TokenManagerImpl`과 `UserInfoManagerImpl`은 더 이상 `Context`에 의존하지 않으며, `DataStore<Preferences>`에만 의존
- DataStore 파일 이름들을 `DataStoreConstant.kt` 파일로 분리하여 상수로 중앙 관리하도록 개선
- `LocalStorageModule`을 `@Binds`를 사용한 `abstract class`에서, `@Provides`를 사용하는 `object`로 변경하여 DI 패턴을 통일

## To Reviewers 📢
`Manager` 구현체가 `Context` 대신 `DataStore`에만 의존하도록 변경했습니다 :)
