### PR TITLE
[FIX] 일기 카드 AnnotatedString 범위 오류 수정

### DIFF
--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/content/diary/DiaryCard.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/content/diary/DiaryCard.kt
@@ -106,24 +106,31 @@ internal fun DiaryCard(
     }
 }
 
+private fun Pair<Int, Int>.isValid(textLength: Int): Boolean {
+    val (start, end) = this
+    return start in 0 until textLength && end <= textLength && start < end
+}
+
 @Composable
 private fun getAnnotatedString(
     content: String,
     diffRanges: ImmutableList<Pair<Int, Int>>
 ): AnnotatedString {
+    val contentLength = content.length
     return buildAnnotatedString {
         append(content)
-        diffRanges.forEach {
-            if (it.second >= MAX_AI) return@forEach
-            addStyle(
-                style = SpanStyle(
-                    color = HilingualTheme.colors.hilingualOrange,
-                    fontFamily = SuitMedium
-                ),
-                start = it.first,
-                end = it.second
-            )
-        }
+        diffRanges
+            .filter { it.isValid(contentLength) }
+            .forEach { (start, end) ->
+                addStyle(
+                    style = SpanStyle(
+                        color = HilingualTheme.colors.hilingualOrange,
+                        fontFamily = SuitMedium
+                    ),
+                    start = start,
+                    end = end
+                )
+            }
     }
 }
 


### PR DESCRIPTION
## Work Description ✏️
- 하이라이팅 방어 코드를 견고하게 수정

## To Reviewers 📢
기존 코드는 1500자 이상의 경우만 대응해서 1500자 이하의 범위 오류에 대해서는 여전히 크래시를 발생 시켰어요.
모든 경우에 대해서 인덱싱 범위를 벗어나느 경우의 방어 코드를 작성했어요