### PR TITLE
[FIX/#464] 타인 프로필 공감 탭 미표시 버그 수정

### DIFF
--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/navigation/FeedProfileNavigation.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/profile/navigation/FeedProfileNavigation.kt
@@ -77,7 +77,7 @@ fun NavGraphBuilder.feedProfileNavGraph(
                 viewModel = viewModel,
                 paddingValues = paddingValues,
                 navigateUp = navigateUp,
-                navigateToMyFeedProfile = { navigateToMyFeedProfile(false) },
+                navigateToMyFeedProfile = navigateToMyFeedProfile,
                 navigateToFollowList = { navController.navigateToFollowList(userId = 0L) },
                 navigateToFeedProfile = navigateToFeedProfile,
                 navigateToFeedDiary = navigateToFeedDiary


### PR DESCRIPTION
## Related issue 🛠
- closed #464 

## Work Description ✏️
- 타인 프로필에서 공감 일기 탭으로 이동하지 않는 버그를 수정했습니다.

## Screenshot 📸
| 수정 전 | 수정 후 |
|:--:|:--:|
| <video src="https://github.com/user-attachments/assets/c10557a8-5024-4598-8f41-51eaca50d808" width="300"/> | <video src="https://github.com/user-attachments/assets/ca83d621-cf8a-4cb4-8ec3-c978b9055498" width="300"/> |

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢

왜 피드에서는 잘 작동하고 타인 프로필에서는 작동하지 않았을까?
- 피드에서 공감 후 "보러가기":

피드 화면 → 공감 버튼 클릭
피드의 `ViewModel`에서 `SideEffect `발생
피드 화면에서 `navigateToMyFeedProfile(true)` 직접 호출 

- 타인 프로필에서 공감 후 "보러가기" (기존 코드):

타인 프로필 화면 → 공감 버튼 클릭
`FeedProfileRoute`에서 `navigateToMyFeedProfile(true)` 호출
그런데 feedProfileNavGraph에서:

`navigateToMyFeedProfile = { navigateToMyFeedProfile(false) }  // 람다!`
이 람다가 실행되면서 전달받은 true 값을 무시하고 false로 덮어씌움 

람다로 감싸면 람다 안의 로직이 우선이 되어서 전달받은 파라미터가 무시되어서 작동하지 않았던것 같아요. 해결해서 수정해두었습니다!