### PR TITLE
[REF/#468] 일기 작성, 마이페이지 코드 일관화

### DIFF
--- a/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/DiaryWriteScreen.kt
+++ b/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/DiaryWriteScreen.kt
@@ -56,7 +56,9 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hilingual.core.common.extension.addFocusCleaner
 import com.hilingual.core.common.extension.advancedImePadding
+import com.hilingual.core.common.extension.collectSideEffect
 import com.hilingual.core.common.extension.statusBarColor
+import com.hilingual.core.common.trigger.LocalDialogTrigger
 import com.hilingual.core.designsystem.component.button.HilingualButton
 import com.hilingual.core.designsystem.component.textfield.HilingualLongTextField
 import com.hilingual.core.designsystem.component.topappbar.BackTopAppBar
@@ -94,6 +96,7 @@ internal fun DiaryWriteRoute(
 ) {
     val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val dialogTrigger = LocalDialogTrigger.current
     val feedbackState by viewModel.feedbackState.collectAsStateWithLifecycle()
 
     var diaryTextImageUri by remember { mutableStateOf<Uri?>(null) }
@@ -126,6 +129,10 @@ internal fun DiaryWriteRoute(
         contract = ActivityResultContracts.PickVisualMedia()
     ) { uri ->
         uri?.let { viewModel.extractTextFromImage(it) }
+    }
+
+    viewModel.sideEffect.collectSideEffect { sideEffect ->
+        if (sideEffect is DiaryWriteSideEffect.ShowErrorDialog) dialogTrigger.show(navigateUp)
     }
 
     when (feedbackState) {

--- a/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/DiaryWriteScreen.kt
+++ b/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/DiaryWriteScreen.kt
@@ -132,7 +132,9 @@ internal fun DiaryWriteRoute(
     }
 
     viewModel.sideEffect.collectSideEffect { sideEffect ->
-        if (sideEffect is DiaryWriteSideEffect.ShowErrorDialog) dialogTrigger.show(navigateUp)
+        when (sideEffect) {
+            is DiaryWriteSideEffect.ShowErrorDialog -> dialogTrigger.show(navigateUp)
+        }
     }
 
     when (feedbackState) {

--- a/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/DiaryWriteViewModel.kt
+++ b/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/DiaryWriteViewModel.kt
@@ -89,9 +89,7 @@ internal class DiaryWriteViewModel @Inject constructor(
                     _uiState.update { it.copy(topicKo = topic.topicKor, topicEn = topic.topicEn) }
                 }
                 .onLogFailure {
-                    viewModelScope.launch {
-                        _sideEffect.emit(DiaryWriteSideEffect.ShowErrorDialog)
-                    }
+                    _sideEffect.emit(DiaryWriteSideEffect.ShowErrorDialog)
                 }
         }
     }
@@ -120,7 +118,8 @@ internal class DiaryWriteViewModel @Inject constructor(
                 runCatching {
                     withContext(Dispatchers.IO) {
                         val image = InputImage.fromFilePath(context, uri)
-                        val recognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
+                        val recognizer =
+                            TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
                         recognizer.process(image).await().text
                     }
                 }.onSuccess { extractedText ->

--- a/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/DiaryWriteViewModel.kt
+++ b/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/DiaryWriteViewModel.kt
@@ -32,8 +32,11 @@ import com.hilingual.presentation.diarywrite.navigation.DiaryWrite
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -60,6 +63,9 @@ internal class DiaryWriteViewModel @Inject constructor(
     )
     val uiState: StateFlow<DiaryWriteUiState> = _uiState.asStateFlow()
 
+    private val _sideEffect = MutableSharedFlow<DiaryWriteSideEffect>()
+    val sideEffect: SharedFlow<DiaryWriteSideEffect> = _sideEffect.asSharedFlow()
+
     private var _feedbackState: MutableStateFlow<DiaryFeedbackState> =
         MutableStateFlow(DiaryFeedbackState.Default)
     val feedbackState: StateFlow<DiaryFeedbackState> = _feedbackState.asStateFlow()
@@ -82,7 +88,11 @@ internal class DiaryWriteViewModel @Inject constructor(
                 .onSuccess { topic ->
                     _uiState.update { it.copy(topicKo = topic.topicKor, topicEn = topic.topicEn) }
                 }
-                .onLogFailure { }
+                .onLogFailure {
+                    viewModelScope.launch {
+                        _sideEffect.emit(DiaryWriteSideEffect.ShowErrorDialog)
+                    }
+                }
         }
     }
 
@@ -135,4 +145,8 @@ internal class DiaryWriteViewModel @Inject constructor(
     companion object {
         private const val MAX_DIARY_TEXT_LENGTH = 1000
     }
+}
+
+sealed interface DiaryWriteSideEffect {
+    data object ShowErrorDialog : DiaryWriteSideEffect
 }

--- a/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/MyPageScreen.kt
+++ b/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/MyPageScreen.kt
@@ -44,6 +44,7 @@ import com.hilingual.core.common.extension.collectSideEffect
 import com.hilingual.core.common.extension.launchCustomTabs
 import com.hilingual.core.common.extension.statusBarColor
 import com.hilingual.core.common.trigger.LocalDialogTrigger
+import com.hilingual.core.common.trigger.LocalToastTrigger
 import com.hilingual.core.common.util.UiState
 import com.hilingual.core.designsystem.R
 import com.hilingual.core.designsystem.component.topappbar.TitleLeftAlignedTopAppBar
@@ -66,6 +67,7 @@ internal fun MyPageRoute(
     val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val dialogTrigger = LocalDialogTrigger.current
+    val toastTrigger = LocalToastTrigger.current
 
     viewModel.sideEffect.collectSideEffect { sideEffect ->
         when (sideEffect) {
@@ -73,7 +75,9 @@ internal fun MyPageRoute(
                 dialogTrigger.show(sideEffect.onRetry)
             }
 
-            MyPageSideEffect.RestartApp -> {
+            is MyPageSideEffect.ShowToast -> toastTrigger(sideEffect.message)
+
+            is MyPageSideEffect.RestartApp -> {
                 ProcessPhoenix.triggerRebirth(context)
             }
         }

--- a/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/MyPageScreen.kt
+++ b/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/MyPageScreen.kt
@@ -71,15 +71,11 @@ internal fun MyPageRoute(
 
     viewModel.sideEffect.collectSideEffect { sideEffect ->
         when (sideEffect) {
-            is MyPageSideEffect.ShowErrorDialog -> {
-                dialogTrigger.show(sideEffect.onRetry)
-            }
+            is MyPageSideEffect.ShowErrorDialog -> dialogTrigger.show(sideEffect.onRetry)
 
             is MyPageSideEffect.ShowToast -> toastTrigger(sideEffect.message)
 
-            is MyPageSideEffect.RestartApp -> {
-                ProcessPhoenix.triggerRebirth(context)
-            }
+            is MyPageSideEffect.RestartApp -> ProcessPhoenix.triggerRebirth(context)
         }
     }
 

--- a/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/MyPageViewModel.kt
+++ b/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/MyPageViewModel.kt
@@ -63,9 +63,7 @@ internal class MyPageViewModel @Inject constructor(
                     }
                 }
                 .onLogFailure {
-                    viewModelScope.launch {
-                        _sideEffect.emit(MyPageSideEffect.ShowErrorDialog(onRetry = ::getProfileInfo))
-                    }
+                    _sideEffect.emit(MyPageSideEffect.ShowErrorDialog(onRetry = ::getProfileInfo))
                 }
         }
     }
@@ -77,9 +75,7 @@ internal class MyPageViewModel @Inject constructor(
                     getProfileInfo()
                 }
                 .onLogFailure {
-                    viewModelScope.launch {
-                        _sideEffect.emit(MyPageSideEffect.ShowToast("프로필 이미지 업데이트에 실패했어요."))
-                    }
+                    _sideEffect.emit(MyPageSideEffect.ShowToast("프로필 이미지 업데이트에 실패했어요."))
                 }
         }
     }
@@ -91,9 +87,7 @@ internal class MyPageViewModel @Inject constructor(
                     _sideEffect.emit(MyPageSideEffect.RestartApp)
                 }
                 .onLogFailure {
-                    viewModelScope.launch {
-                        _sideEffect.emit(MyPageSideEffect.ShowToast("로그아웃에 실패했어요."))
-                    }
+                    _sideEffect.emit(MyPageSideEffect.ShowToast("로그아웃에 실패했어요."))
                 }
         }
     }
@@ -105,9 +99,7 @@ internal class MyPageViewModel @Inject constructor(
                     _sideEffect.emit(MyPageSideEffect.RestartApp)
                 }
                 .onLogFailure {
-                    viewModelScope.launch {
-                        _sideEffect.emit(MyPageSideEffect.ShowToast("회원 탈퇴에 실패했어요."))
-                    }
+                    _sideEffect.emit(MyPageSideEffect.ShowToast("회원 탈퇴에 실패했어요."))
                 }
         }
     }

--- a/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/MyPageViewModel.kt
+++ b/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/MyPageViewModel.kt
@@ -76,7 +76,11 @@ internal class MyPageViewModel @Inject constructor(
                 .onSuccess {
                     getProfileInfo()
                 }
-                .onLogFailure { }
+                .onLogFailure {
+                    viewModelScope.launch {
+                        _sideEffect.emit(MyPageSideEffect.ShowToast("프로필 이미지 업데이트에 실패했어요."))
+                    }
+                }
         }
     }
 
@@ -86,7 +90,11 @@ internal class MyPageViewModel @Inject constructor(
                 .onSuccess {
                     _sideEffect.emit(MyPageSideEffect.RestartApp)
                 }
-                .onLogFailure { }
+                .onLogFailure {
+                    viewModelScope.launch {
+                        _sideEffect.emit(MyPageSideEffect.ShowToast("로그아웃에 실패했어요."))
+                    }
+                }
         }
     }
 
@@ -96,12 +104,17 @@ internal class MyPageViewModel @Inject constructor(
                 .onSuccess {
                     _sideEffect.emit(MyPageSideEffect.RestartApp)
                 }
-                .onLogFailure { }
+                .onLogFailure {
+                    viewModelScope.launch {
+                        _sideEffect.emit(MyPageSideEffect.ShowToast("회원 탈퇴에 실패했어요."))
+                    }
+                }
         }
     }
 }
 
 sealed interface MyPageSideEffect {
     data class ShowErrorDialog(val onRetry: () -> Unit) : MyPageSideEffect
+    data class ShowToast(val message: String) : MyPageSideEffect
     data object RestartApp : MyPageSideEffect
 }

--- a/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/blockeduser/BlockedUserScreen.kt
+++ b/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/blockeduser/BlockedUserScreen.kt
@@ -43,7 +43,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hilingual.core.common.extension.collectSideEffect
 import com.hilingual.core.common.extension.statusBarColor
+import com.hilingual.core.common.trigger.LocalDialogTrigger
 import com.hilingual.core.common.util.UiState
 import com.hilingual.core.designsystem.R
 import com.hilingual.core.designsystem.component.content.UserActionItem
@@ -61,6 +63,11 @@ internal fun BlockedUserRoute(
     viewModel: BlockedUserViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val dialogTrigger = LocalDialogTrigger.current
+
+    viewModel.sideEffect.collectSideEffect { sideEffect ->
+        if (sideEffect is BlockedUserSideEffect.ShowErrorDialog) dialogTrigger.show(navigateUp)
+    }
 
     LaunchedEffect(Unit) {
         viewModel.getBlockList()

--- a/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/blockeduser/BlockedUserScreen.kt
+++ b/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/blockeduser/BlockedUserScreen.kt
@@ -66,7 +66,9 @@ internal fun BlockedUserRoute(
     val dialogTrigger = LocalDialogTrigger.current
 
     viewModel.sideEffect.collectSideEffect { sideEffect ->
-        if (sideEffect is BlockedUserSideEffect.ShowErrorDialog) dialogTrigger.show(navigateUp)
+        when (sideEffect) {
+            is BlockedUserSideEffect.ShowErrorDialog -> dialogTrigger.show(navigateUp)
+        }
     }
 
     LaunchedEffect(Unit) {

--- a/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/blockeduser/BlockedUserViewModel.kt
+++ b/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/blockeduser/BlockedUserViewModel.kt
@@ -57,9 +57,7 @@ internal class BlockedUserViewModel @Inject constructor(
                     _uiState.update { it.copy(blockedUserList = UiState.Success(data = blockUiModel)) }
                 }
                 .onLogFailure {
-                    viewModelScope.launch {
-                        _sideEffect.emit(BlockedUserSideEffect.ShowErrorDialog)
-                    }
+                    _sideEffect.emit(BlockedUserSideEffect.ShowErrorDialog)
                 }
         }
     }
@@ -94,9 +92,7 @@ internal class BlockedUserViewModel @Inject constructor(
                     }
                 }
                 .onLogFailure {
-                    viewModelScope.launch {
-                        _sideEffect.emit(BlockedUserSideEffect.ShowErrorDialog)
-                    }
+                    _sideEffect.emit(BlockedUserSideEffect.ShowErrorDialog)
                 }
         }
     }

--- a/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/blockeduser/BlockedUserViewModel.kt
+++ b/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/blockeduser/BlockedUserViewModel.kt
@@ -22,8 +22,11 @@ import com.hilingual.core.common.util.UiState
 import com.hilingual.data.user.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -35,6 +38,9 @@ internal class BlockedUserViewModel @Inject constructor(
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(BlockedUserUiState())
     val uiState: StateFlow<BlockedUserUiState> = _uiState.asStateFlow()
+
+    private val _sideEffect = MutableSharedFlow<BlockedUserSideEffect>()
+    val sideEffect: SharedFlow<BlockedUserSideEffect> = _sideEffect.asSharedFlow()
 
     fun getBlockList() {
         viewModelScope.launch {
@@ -50,7 +56,11 @@ internal class BlockedUserViewModel @Inject constructor(
 
                     _uiState.update { it.copy(blockedUserList = UiState.Success(data = blockUiModel)) }
                 }
-                .onLogFailure { }
+                .onLogFailure {
+                    viewModelScope.launch {
+                        _sideEffect.emit(BlockedUserSideEffect.ShowErrorDialog)
+                    }
+                }
         }
     }
 
@@ -83,7 +93,15 @@ internal class BlockedUserViewModel @Inject constructor(
                         }
                     }
                 }
-                .onLogFailure { }
+                .onLogFailure {
+                    viewModelScope.launch {
+                        _sideEffect.emit(BlockedUserSideEffect.ShowErrorDialog)
+                    }
+                }
         }
     }
+}
+
+sealed interface BlockedUserSideEffect {
+    data object ShowErrorDialog : BlockedUserSideEffect
 }

--- a/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/navigation/MyPageNavigation.kt
+++ b/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/navigation/MyPageNavigation.kt
@@ -129,6 +129,7 @@ fun NavGraphBuilder.myPageNavGraph(
 
             ProfileEditRoute(
                 paddingValues = paddingValues,
+                navigateUp = navigateUp,
                 viewModel = viewModel
             )
         }

--- a/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/profileedit/ProfileEditScreen.kt
+++ b/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/profileedit/ProfileEditScreen.kt
@@ -45,6 +45,7 @@ import com.hilingual.core.common.extension.collectSideEffect
 import com.hilingual.core.common.extension.noRippleClickable
 import com.hilingual.core.common.extension.statusBarColor
 import com.hilingual.core.common.trigger.LocalDialogTrigger
+import com.hilingual.core.common.trigger.LocalToastTrigger
 import com.hilingual.core.common.util.UiState
 import com.hilingual.core.designsystem.component.bottomsheet.HilingualProfileImageBottomSheet
 import com.hilingual.core.designsystem.component.picker.ProfileImagePicker
@@ -66,6 +67,7 @@ internal fun ProfileEditRoute(
     val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val dialogTrigger = LocalDialogTrigger.current
+    val toastTrigger = LocalToastTrigger.current
 
     viewModel.sideEffect.collectSideEffect { sideEffect ->
         when (sideEffect) {
@@ -73,7 +75,9 @@ internal fun ProfileEditRoute(
                 dialogTrigger.show(navigateUp)
             }
 
-            MyPageSideEffect.RestartApp -> {
+            is MyPageSideEffect.ShowToast -> toastTrigger(sideEffect.message)
+
+            is MyPageSideEffect.RestartApp -> {
                 ProcessPhoenix.triggerRebirth(context)
             }
         }

--- a/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/profileedit/ProfileEditScreen.kt
+++ b/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/profileedit/ProfileEditScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.hilingual.core.common.extension.collectSideEffect
 import com.hilingual.core.common.extension.noRippleClickable
 import com.hilingual.core.common.extension.statusBarColor
@@ -71,15 +72,11 @@ internal fun ProfileEditRoute(
 
     viewModel.sideEffect.collectSideEffect { sideEffect ->
         when (sideEffect) {
-            is MyPageSideEffect.ShowErrorDialog -> {
-                dialogTrigger.show(navigateUp)
-            }
+            is MyPageSideEffect.ShowErrorDialog -> dialogTrigger.show(navigateUp)
 
             is MyPageSideEffect.ShowToast -> toastTrigger(sideEffect.message)
 
-            is MyPageSideEffect.RestartApp -> {
-                ProcessPhoenix.triggerRebirth(context)
-            }
+            is MyPageSideEffect.RestartApp -> ProcessPhoenix.triggerRebirth(context)
         }
     }
 

--- a/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/profileedit/ProfileEditScreen.kt
+++ b/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/profileedit/ProfileEditScreen.kt
@@ -60,6 +60,7 @@ import com.jakewharton.processphoenix.ProcessPhoenix
 @Composable
 internal fun ProfileEditRoute(
     paddingValues: PaddingValues,
+    navigateUp: () -> Unit,
     viewModel: MyPageViewModel = hiltViewModel()
 ) {
     val context = LocalContext.current
@@ -69,7 +70,7 @@ internal fun ProfileEditRoute(
     viewModel.sideEffect.collectSideEffect { sideEffect ->
         when (sideEffect) {
             is MyPageSideEffect.ShowErrorDialog -> {
-                dialogTrigger.show(sideEffect.onRetry)
+                dialogTrigger.show(navigateUp)
             }
 
             MyPageSideEffect.RestartApp -> {


### PR DESCRIPTION
## Related issue 🛠
- closed #468 

## Work Description ✏️
- 에러 헨들링 일관화
    - 프로필 수정 화면: dialogTrigger를 재시도 -> 뒤로 가기로 수정함)
    - 차단된 유저 화면: (뒤로 가기가 가능한) dialogTrigger를 추가함
    - 마이페이지 화면: toastTrigger를 추가함
- 코틀린 컨벤션 일관화

## Screenshot 📸
N/A

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
- 마이페이지에서는 이미 '로그아웃/회원탈퇴하기 or 아니오(뒤로 가기)' 다이얼로그를 띄우는 부분이 많아 `toastTrigger`를 추가하는 방법으로 누락된 `onLogFailure`를 작성했는데 혹시 다른 좋은 방법이 있다면 의견 부탁드립니당..!!