### PR TITLE
[FIX/#472] TabRow deprecated 오류 수정

### DIFF
--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/tabrow/HilingualBasicTabRow.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/tabrow/HilingualBasicTabRow.kt
@@ -20,12 +20,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LocalRippleConfiguration
+import androidx.compose.material3.SecondaryTabRow
 import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
 import androidx.compose.material3.TabRowDefaults
-import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -38,7 +36,6 @@ import com.hilingual.core.designsystem.theme.HilingualTheme
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HilingualBasicTabRow(
     tabTitles: ImmutableList<String>,
@@ -47,13 +44,13 @@ fun HilingualBasicTabRow(
     modifier: Modifier = Modifier
 ) {
     CompositionLocalProvider(LocalRippleConfiguration provides null) {
-        TabRow(
+        SecondaryTabRow(
             selectedTabIndex = tabIndex,
             containerColor = HilingualTheme.colors.white,
             contentColor = HilingualTheme.colors.black,
-            indicator = { tabPositions ->
+            indicator = {
                 TabRowDefaults.SecondaryIndicator(
-                    modifier = Modifier.tabIndicatorOffset(tabPositions[tabIndex]),
+                    modifier = Modifier.tabIndicatorOffset(tabIndex),
                     color = HilingualTheme.colors.black
                 )
             },


### PR DESCRIPTION
## Related issue 🛠
- closed #472

## Work Description ✏️
- 기존 TabRow가 deprecated 이슈를 수정했습니다

## Screenshot 📸
<img width="295" height="108" alt="image" src="https://github.com/user-attachments/assets/62f9b6cd-5c21-48e2-af30-9788cff89de9" />

## To Reviewers 📢
- 공통 컴포넌트 분리 작업이 머지되기 전에 했더니 오류가 너무 많이 나서 다시 올립니다! 코드 수정은 많지 않아요. (이전 PR: https://github.com/Hi-lingual/Hilingual-Android/pull/483) 그래서 리뷰도 다시 달아주시면 감사하겠습니다,,ㅎㅎ
- 찾아보니까 TabRow 대신 PrimaryTabRow, SecondaryTabRow로 구분되는데, Primary는 앱의 주요 내비게이션, Secondary는 주 섹션 내의 하위 구분에 사용되는 컴포넌트라 해서 SecondaryTabRow를 선택했습니다.
- @Daljyeong 이 이전 PR에 코멘트로 남겨주신 참고 자료도 하나 첨부합니다! [탭 | Jetpack Compose](https://developer.android.com/develop/ui/compose/components/tabs?hl=ko) 