### PR TITLE
[CHORE/#545] CI 빌드 오류 수정 (Bundler 버전 업데이트)

### DIFF
--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -42,6 +42,9 @@ jobs:
           ruby-version: '3.4.7'
           bundler-cache: true
 
+      - name: Install Bundler
+        run: gem install bundler -v 2.5.23
+
       - name: Run unit tests
         run: ./gradlew testDebugUnitTest
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,4 +234,4 @@ DEPENDENCIES
   fastlane-plugin-firebase_app_distribution
 
 BUNDLED WITH
-   1.17.2
+   2.5.23


### PR DESCRIPTION
## PR chekList
- [x] ktLint 포맷을 지킨다.
- [x] indent(인덴트, 들여쓰기) depth를 3이 넘지 않도록 구현한다.
- [x] 함수(또는 메서드)가 한 가지 일만 하도록 최대한 작게 만든다.
- [x] class를 최대한 작게 만든다.
- [x] else를 지양한다(얼리 리턴 사용).

## Related issue 🛠
- closed #545

## Work Description ✏️
  - `Gemfile.lock`: Bundler 의존성 버전을 `2.5.23`으로 업데이트했습니다.
  - `.github/workflows/deploy-qa.yml`: CI 환경에서 `gem install bundler -v 2.5.23` 명령어를 실행하여 올바른 Bundler 버전을 사용하도록 강제했습니다.

## To Reviewers 📢
Ruby 버전을 다운그레이드하지 않고, Bundler를 최신화하여 문제를 해결하는 방향으로 잡았습니다.
