### PR TITLE
[CHORE/#552] 앰플리튜드 디버그 빌드 분리

### DIFF
--- a/app/src/main/java/com/hilingual/analytics/AmplitudeTracker.kt
+++ b/app/src/main/java/com/hilingual/analytics/AmplitudeTracker.kt
@@ -32,17 +32,26 @@ class AmplitudeTracker @Inject constructor(
     @ApplicationContext private val context: Context
 ) : Tracker {
 
-    private val amplitude = Amplitude(
-        Configuration(
-            apiKey = BuildConfig.AMPLITUDE_API_KEY,
-            context = context
+    private val amplitude: Amplitude? = run {
+        if (BuildConfig.DEBUG) return@run null
+
+        Amplitude(
+            Configuration(
+                apiKey = BuildConfig.AMPLITUDE_API_KEY,
+                context = context
+            )
         )
-    )
+    }
 
     override fun logEvent(trigger: TriggerType, page: Page, event: String) {
         val eventName = "${trigger.value}_${page.pageName}.$event"
-        Timber.tag("AmplitudeTracker").d("Tracking event: $eventName, properties: None")
-        amplitude.track(eventName)
+
+        if (BuildConfig.DEBUG) {
+            Timber.tag("AmplitudeTracker").d("Tracking event: $eventName, properties: None")
+            return
+        }
+
+        amplitude?.track(eventName)
     }
 
     override fun logEvent(
@@ -52,7 +61,12 @@ class AmplitudeTracker @Inject constructor(
         properties: Map<String, Any>
     ) {
         val eventName = "${trigger.value}_${page.pageName}.$event"
-        Timber.tag("AmplitudeTracker").d("Tracking event: $eventName, properties: $properties")
-        amplitude.track(eventName, properties.toMutableMap())
+
+        if (BuildConfig.DEBUG) {
+            Timber.tag("AmplitudeTracker").d("Tracking event: $eventName, properties: $properties")
+            return
+        }
+
+        amplitude?.track(eventName, properties.toMutableMap())
     }
 }


### PR DESCRIPTION
## PR chekList
- [x] ktLint 포맷을 지킨다.
- [x] indent(인덴트, 들여쓰기) depth를 3이 넘지 않도록 구현한다.
- [x] 함수(또는 메서드)가 한 가지 일만 하도록 최대한 작게 만든다.
- [x] class를 최대한 작게 만든다.
- [x] else를 지양한다(얼리 리턴 사용).

## Related issue 🛠
- closed #552

## Work Description ✏️
- 디버그 빌드시 앰플리튜드 객체를 null로 초기화 합니다.

## To Reviewers 📢
디버그 앰플리튜드 키가 있었다면 로컬 프로퍼티를 추가했겠지만 아직 계획이 없으므로 더미 키를 넣기 보단 null을 반환하도록 수정했습니다.
