### PR TITLE
[FIX/#554] 폰트 사일로 QA 반영

### DIFF
--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/textfield/HilingualBasicTextField.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/textfield/HilingualBasicTextField.kt
@@ -144,7 +144,7 @@ fun HilingualBasicTextField(
                     if (isShowLength) {
                         Spacer(Modifier.height(12.dp))
                         Text(
-                            text = "${value.length} / $maxLength",
+                            text = "${value.length}/$maxLength",
                             style = HilingualTheme.typography.captionR12,
                             color = HilingualTheme.colors.gray400,
                             modifier = Modifier.align(Alignment.End)

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/textfield/HilingualShortTextField.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/textfield/HilingualShortTextField.kt
@@ -98,7 +98,7 @@ fun HilingualShortTextField(
             Spacer(modifier = Modifier.weight(1f))
 
             Text(
-                text = "${text.graphemeLength} / $maxLength",
+                text = "${text.graphemeLength}/$maxLength",
                 style = HilingualTheme.typography.captionR12,
                 color = HilingualTheme.colors.gray300
             )

--- a/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/component/RecommendedTopicDropdown.kt
+++ b/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/component/RecommendedTopicDropdown.kt
@@ -105,7 +105,7 @@ internal fun RecommendedTopicDropdown(
                 Text(
                     modifier = Modifier.weight(1f),
                     text = if (isKo) koTopic else enTopic,
-                    style = HilingualTheme.typography.bodyM16,
+                    style = HilingualTheme.typography.bodyM15,
                     color = HilingualTheme.colors.gray700,
                     maxLines = 2
                 )

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/component/card/FeedProfileInfo.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/component/card/FeedProfileInfo.kt
@@ -118,13 +118,13 @@ internal fun FeedProfileInfo(
                     )
                     Text(
                         text = "팔로잉",
-                        style = HilingualTheme.typography.bodyM14,
+                        style = HilingualTheme.typography.bodyR14,
                         color = HilingualTheme.colors.gray400,
                         modifier = Modifier.padding(end = 2.dp)
                     )
                     Text(
                         text = "$following",
-                        style = HilingualTheme.typography.bodySB14,
+                        style = HilingualTheme.typography.bodyM14,
                         color = HilingualTheme.colors.gray400
                     )
                 }

--- a/presentation/onboarding/src/main/java/com/hilingual/presentation/onboarding/component/TermsBottomSheet.kt
+++ b/presentation/onboarding/src/main/java/com/hilingual/presentation/onboarding/component/TermsBottomSheet.kt
@@ -152,7 +152,7 @@ internal fun TermsBottomSheet(
                 ) {
                     Text(
                         text = "전체 동의",
-                        style = HilingualTheme.typography.headSB18,
+                        style = HilingualTheme.typography.bodyM16,
                         color = HilingualTheme.colors.black
                     )
 


### PR DESCRIPTION
## PR chekList
- [x] ktLint 포맷을 지킨다.
- [x] indent(인덴트, 들여쓰기) depth를 3이 넘지 않도록 구현한다.
- [x] 함수(또는 메서드)가 한 가지 일만 하도록 최대한 작게 만든다.
- [x] class를 최대한 작게 만든다.
- [x] else를 지양한다(얼리 리턴 사용).

## Related issue 🛠
- closed #554 

## Work Description ✏️
- QA 이슈에서 걸린 부분 작업했어요. (텍스트 스타일, 닉네임 글자수 세는 텍스트 띄어쓰기)

## Screenshot 📸

<TextStyle>

|약관 "전체 동의" 폰트 | "팔로잉" 텍스트 | 일기 - 추천 주제|
|:--:|:--:|:--:|
<img width="208" height="465" alt="스크린샷 2025-12-09 오전 3 14 21" src="https://github.com/user-attachments/assets/cc9ecf2d-96a1-45a7-b702-391f1b209c73" /> | <img width="300" height="212" alt="스크린샷 2025-12-09 오전 3 15 05" src="https://github.com/user-attachments/assets/2da14115-6149-4342-8994-820b68342fb1" /> | <img width="277" height="110" alt="스크린샷 2025-12-09 오전 3 14 39" src="https://github.com/user-attachments/assets/75bbc461-3835-44cc-822a-46775db350c7" />

<글자수 띄어쓰기>
| 일기 | 닉네임 |
|:--:|:--:|
<img width="361" height="294" alt="스크린샷 2025-12-09 오전 3 20 46" src="https://github.com/user-attachments/assets/038de5fb-653c-42ae-90fc-e995efe76abe" /> | <img width="200" height="778" alt="스크린샷 2025-12-09 오전 3 25 43" src="https://github.com/user-attachments/assets/3a102bc6-3ba5-4b71-8e1f-f23f38dc6c69" />



## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
- 디자인 상으로 TextField 글자수 셀 때 띄어쓰기가 안 들어가는데, 앱에서는 슬래시(`/`) 앞뒤로 뛰어쓰기가 들어가 있더라구요! 해당 부분 QA 때 언급해주셔서 이번에 같이 수정했습니다. ([QA 문서 참고](https://www.notion.so/hilingual/2c3829677ebf80b58628ddfaedb1641d))