### PR TITLE
[FIX/#557] String 및 디자인 요소 수정

### DIFF
--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/image/HilingualLottieImage.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/image/HilingualLottieImage.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.layout.ContentScale
+import com.airbnb.lottie.LottieComposition
 import com.airbnb.lottie.compose.LottieAnimation
 import com.airbnb.lottie.compose.LottieCompositionSpec
 import com.airbnb.lottie.compose.LottieConstants
@@ -39,10 +40,31 @@ fun HilingualLottieAnimation(
     isInfinite: Boolean = false
 ) {
     val lottieComposition by rememberLottieComposition(LottieCompositionSpec.RawRes(rawResFile))
+    HilingualLottieAnimation(
+        composition = lottieComposition,
+        modifier = modifier,
+        shape = shape,
+        contentScale = contentScale,
+        speed = speed,
+        iterations = iterations,
+        isInfinite = isInfinite
+    )
+}
+
+@Composable
+fun HilingualLottieAnimation(
+    composition: LottieComposition?,
+    modifier: Modifier = Modifier,
+    shape: Shape = RectangleShape,
+    contentScale: ContentScale = ContentScale.Fit,
+    speed: Float = 1f,
+    iterations: Int = 1,
+    isInfinite: Boolean = false
+) {
     LottieAnimation(
         modifier = modifier.clip(shape),
         speed = speed,
-        composition = lottieComposition,
+        composition = composition,
         iterations = if (isInfinite) LottieConstants.IterateForever else iterations,
         contentScale = contentScale,
         clipToCompositionBounds = false

--- a/presentation/auth/src/main/java/com/hilingual/presentation/auth/AuthScreen.kt
+++ b/presentation/auth/src/main/java/com/hilingual/presentation/auth/AuthScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -119,13 +120,15 @@ private fun AuthScreen(
             Image(
                 painter = painterResource(DesignSystemR.drawable.img_logo),
                 contentDescription = null,
-                modifier = Modifier.sharedElement(
-                    sharedContentState = rememberSharedContentState(key = "logo"),
-                    animatedVisibilityScope = animatedVisibilityScope,
-                    boundsTransform = { _, _ ->
-                        tween(durationMillis = 400)
-                    }
-                )
+                modifier = Modifier
+                    .sharedElement(
+                        sharedContentState = rememberSharedContentState(key = "logo"),
+                        animatedVisibilityScope = animatedVisibilityScope,
+                        boundsTransform = { _, _ ->
+                            tween(durationMillis = 400)
+                        }
+                    )
+                    .size(width = 200.dp, height = 50.dp)
             )
         }
 

--- a/presentation/diarywrite/build.gradle.kts
+++ b/presentation/diarywrite/build.gradle.kts
@@ -31,4 +31,6 @@ dependencies {
     // ML Kit
     implementation(libs.mlkit.text.recognition)
     implementation(libs.kotlinx.coroutines.play.services)
+
+    implementation(libs.lottie)
 }

--- a/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/DiaryWriteScreen.kt
+++ b/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/DiaryWriteScreen.kt
@@ -56,6 +56,8 @@ import androidx.compose.ui.unit.dp
 import androidx.core.content.FileProvider
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.airbnb.lottie.compose.LottieCompositionSpec
+import com.airbnb.lottie.compose.rememberLottieComposition
 import com.hilingual.core.common.analytics.FakeTracker
 import com.hilingual.core.common.analytics.Page.WRITE_DIARY
 import com.hilingual.core.common.analytics.Tracker
@@ -91,6 +93,7 @@ import com.skydoves.balloon.BalloonSizeSpec
 import com.skydoves.balloon.compose.Balloon
 import com.skydoves.balloon.compose.rememberBalloonBuilder
 import com.skydoves.balloon.compose.setBackgroundColor
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.delay
 import java.io.File
 import java.time.LocalDate
@@ -112,6 +115,20 @@ internal fun DiaryWriteRoute(
     val toastTrigger = LocalToastTrigger.current
     val feedbackUiState by viewModel.feedbackUiState.collectAsStateWithLifecycle()
     val tracker = LocalTracker.current
+
+    val lottieComposition1 by rememberLottieComposition(
+        LottieCompositionSpec.RawRes(R.raw.lottie_feedback_loading_1)
+    )
+    val lottieComposition2 by rememberLottieComposition(
+        LottieCompositionSpec.RawRes(R.raw.lottie_feedback_loading_2)
+    )
+    val lottieComposition3 by rememberLottieComposition(
+        LottieCompositionSpec.RawRes(R.raw.lottie_feedback_loading_3)
+    )
+
+    val lottieCompositions = remember(lottieComposition1, lottieComposition2, lottieComposition3) {
+        persistentListOf(lottieComposition1, lottieComposition2, lottieComposition3)
+    }
 
     var diaryTextImageUri by remember { mutableStateOf<Uri?>(null) }
 
@@ -196,7 +213,10 @@ internal fun DiaryWriteRoute(
         }
 
         is UiState.Loading -> {
-            DiaryFeedbackLoadingScreen(paddingValues = paddingValues)
+            DiaryFeedbackLoadingScreen(
+                lottieCompositions = lottieCompositions,
+                paddingValues = paddingValues
+            )
         }
 
         is UiState.Success -> {

--- a/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/component/AnimatedLoadingLottie.kt
+++ b/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/component/AnimatedLoadingLottie.kt
@@ -32,23 +32,17 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.airbnb.lottie.LottieComposition
 import com.hilingual.core.designsystem.component.image.HilingualLottieAnimation
-import com.hilingual.presentation.diarywrite.R
-import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.delay
 
 @Composable
 internal fun AnimatedLoadingLottie(
+    lottieCompositions: ImmutableList<LottieComposition?>,
     height: Dp,
     modifier: Modifier = Modifier
 ) {
-    val lottieFiles = remember {
-        persistentListOf(
-            R.raw.lottie_feedback_loading_1,
-            R.raw.lottie_feedback_loading_2,
-            R.raw.lottie_feedback_loading_3
-        )
-    }
     var currentIndex by remember { mutableIntStateOf(0) }
     val transition = rememberInfiniteTransition(label = "lottie fade transition")
 
@@ -65,7 +59,7 @@ internal fun AnimatedLoadingLottie(
     LaunchedEffect(Unit) {
         while (true) {
             delay(3000)
-            currentIndex = (currentIndex + 1) % lottieFiles.size
+            currentIndex = (currentIndex + 1) % lottieCompositions.size
         }
     }
 
@@ -74,7 +68,7 @@ internal fun AnimatedLoadingLottie(
             .width(200.dp)
             .height(height)
             .alpha(alpha),
-        rawResFile = lottieFiles[currentIndex],
+        composition = lottieCompositions[currentIndex],
         isInfinite = true
     )
 }

--- a/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/screen/DiaryFeedbackLoadingScreen.kt
+++ b/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/screen/DiaryFeedbackLoadingScreen.kt
@@ -52,7 +52,7 @@ internal fun DiaryFeedbackLoadingScreen(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Text(
-                text = "일기 저장 중..",
+                text = "일기 저장 중...",
                 color = HilingualTheme.colors.gray850,
                 style = HilingualTheme.typography.headSB20,
                 textAlign = TextAlign.Center

--- a/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/screen/DiaryFeedbackLoadingScreen.kt
+++ b/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/screen/DiaryFeedbackLoadingScreen.kt
@@ -30,14 +30,17 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.airbnb.lottie.LottieComposition
 import com.hilingual.core.designsystem.theme.HilingualTheme
 import com.hilingual.presentation.diarywrite.component.AnimatedLoadingLottie
 import com.hilingual.presentation.diarywrite.component.AnimatedLoadingText
 import com.hilingual.presentation.diarywrite.component.FeedbackLoadingContent
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 internal fun DiaryFeedbackLoadingScreen(
+    lottieCompositions: ImmutableList<LottieComposition?>,
     paddingValues: PaddingValues,
     modifier: Modifier = Modifier
 ) {
@@ -70,7 +73,10 @@ internal fun DiaryFeedbackLoadingScreen(
 
             Spacer(modifier = Modifier.height(20.dp))
 
-            AnimatedLoadingLottie(height = 194.dp)
+            AnimatedLoadingLottie(
+                lottieCompositions = lottieCompositions,
+                height = 194.dp
+            )
         }
 
         FeedbackLoadingContent()
@@ -81,6 +87,9 @@ internal fun DiaryFeedbackLoadingScreen(
 @Composable
 private fun DiaryFeedbackLoadingScreenPreview() {
     HilingualTheme {
-        DiaryFeedbackLoadingScreen(paddingValues = PaddingValues(0.dp))
+        DiaryFeedbackLoadingScreen(
+            lottieCompositions = persistentListOf(),
+            paddingValues = PaddingValues(0.dp)
+        )
     }
 }

--- a/presentation/splash/src/main/java/com/hilingual/presentation/splash/SplashScreen.kt
+++ b/presentation/splash/src/main/java/com/hilingual/presentation/splash/SplashScreen.kt
@@ -23,10 +23,12 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.hilingual.core.common.extension.collectLatestSideEffect
 import com.hilingual.core.common.extension.statusBarColor
@@ -74,13 +76,15 @@ private fun SplashScreen(
             Image(
                 painter = painterResource(DesignSystemR.drawable.img_logo),
                 contentDescription = null,
-                modifier = Modifier.sharedElement(
-                    sharedContentState = rememberSharedContentState(key = "logo"),
-                    animatedVisibilityScope = animatedVisibilityScope,
-                    boundsTransform = { _, _ ->
-                        tween(durationMillis = 400)
-                    }
-                )
+                modifier = Modifier
+                    .sharedElement(
+                        sharedContentState = rememberSharedContentState(key = "logo"),
+                        animatedVisibilityScope = animatedVisibilityScope,
+                        boundsTransform = { _, _ ->
+                            tween(durationMillis = 400)
+                        }
+                    )
+                    .size(width = 200.dp, height = 50.dp)
             )
         }
 


### PR DESCRIPTION
## PR chekList
- [x] ktLint 포맷을 지킨다.
- [x] indent(인덴트, 들여쓰기) depth를 3이 넘지 않도록 구현한다.
- [x] 함수(또는 메서드)가 한 가지 일만 하도록 최대한 작게 만든다.
- [x] class를 최대한 작게 만든다.
- [x] else를 지양한다(얼리 리턴 사용).

## Related issue 🛠
- closed #557 
## Work Description ✏️
- 로고 크기를 동적이 아닌 정적 사이즈로 변경
- "일기 저장 중" 텍스트 dot 개수 수정
- 피드백 요청시 로티 로딩이 늦는 이슈 수정

## Screenshot 📸

https://github.com/user-attachments/assets/436d0a95-b742-444c-b19a-dfc62852fa64

## To Reviewers 📢
로티 파싱이 아닌 애니메이션 객체를 미리 메모리에 올리는 방식으로 로딩시간을 줄였습니다. 앞으로 텍스트가 먼저 표시되는 경우는 없을거에요
