### PR TITLE
[FEAT/#569] 푸시 알림 권한 요청 기능 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,8 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
 
     <uses-feature
         android:name="android.hardware.camera"

--- a/presentation/home/src/main/java/com/hilingual/presentation/home/HomeScreen.kt
+++ b/presentation/home/src/main/java/com/hilingual/presentation/home/HomeScreen.kt
@@ -15,6 +15,10 @@
  */
 package com.hilingual.presentation.home
 
+import android.Manifest
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -42,8 +46,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hilingual.core.common.analytics.FakeTracker
@@ -75,6 +81,7 @@ import com.hilingual.presentation.home.component.footer.HomeDropDownMenu
 import com.hilingual.presentation.home.component.footer.TodayTopic
 import com.hilingual.presentation.home.component.footer.WriteDiaryButton
 import com.hilingual.presentation.home.type.DiaryCardState
+import com.hilingual.presentation.home.type.NotificationPermissionState
 import java.time.LocalDate
 import java.time.YearMonth
 
@@ -93,6 +100,13 @@ internal fun HomeRoute(
     val toastTrigger = LocalToastTrigger.current
     val snackbarTrigger = LocalSnackbarTrigger.current
     val tracker = LocalTracker.current
+    val context = LocalContext.current
+
+    val notificationPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        viewModel.onNotificationPermissionResult(isGranted)
+    }
 
     viewModel.sideEffect.collectSideEffect { sideEffect ->
         when (sideEffect) {
@@ -108,6 +122,10 @@ internal fun HomeRoute(
                         onClick = navigateToFeed
                     )
                 )
+            }
+
+            is HomeSideEffect.RequestNotificationPermission -> {
+                notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
             }
         }
     }
@@ -130,6 +148,18 @@ internal fun HomeRoute(
         }
 
         is UiState.Success -> {
+            LaunchedEffect(state.data.notificationPermissionState) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+                    state.data.notificationPermissionState == NotificationPermissionState.NOT_DETERMINED
+                ) {
+                    val permissionState = ContextCompat.checkSelfPermission(
+                        context,
+                        Manifest.permission.POST_NOTIFICATIONS
+                    )
+                    viewModel.checkNotificationPermission(permissionState)
+                }
+            }
+
             HomeScreen(
                 paddingValues = paddingValues,
                 uiState = state.data,

--- a/presentation/home/src/main/java/com/hilingual/presentation/home/HomeUiState.kt
+++ b/presentation/home/src/main/java/com/hilingual/presentation/home/HomeUiState.kt
@@ -21,6 +21,7 @@ import com.hilingual.presentation.home.model.DiaryThumbnailUiModel
 import com.hilingual.presentation.home.model.TodayTopicUiModel
 import com.hilingual.presentation.home.model.UserProfileUiModel
 import com.hilingual.presentation.home.type.DiaryCardState
+import com.hilingual.presentation.home.type.NotificationPermissionState
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import java.time.LocalDate
@@ -33,7 +34,8 @@ data class HomeUiState(
     val diaryThumbnail: DiaryThumbnailUiModel? = null,
     val dateList: ImmutableList<DateUiModel> = persistentListOf(),
     val todayTopic: TodayTopicUiModel? = null,
-    val cardState: DiaryCardState = DiaryCardState.PAST
+    val cardState: DiaryCardState = DiaryCardState.PAST,
+    val notificationPermissionState: NotificationPermissionState = NotificationPermissionState.NOT_DETERMINED
 ) {
     companion object {
         val Fake = HomeUiState(

--- a/presentation/home/src/main/java/com/hilingual/presentation/home/HomeViewModel.kt
+++ b/presentation/home/src/main/java/com/hilingual/presentation/home/HomeViewModel.kt
@@ -66,6 +66,8 @@ class HomeViewModel @Inject constructor(
     )
     val sideEffect: SharedFlow<HomeSideEffect> = _sideEffect.asSharedFlow()
 
+    private var lastKnownPermissionGranted: Boolean? = null
+
     fun loadInitialData() {
         viewModelScope.launch {
             _uiState.update { UiState.Loading }
@@ -112,9 +114,15 @@ class HomeViewModel @Inject constructor(
         val currentState = uiState.value
         if (currentState !is UiState.Success) return
 
-        val previousState = currentState.data.notificationPermissionState
-
         val isPermissionGranted = !requiresPermission || isGranted
+
+        if (lastKnownPermissionGranted == isPermissionGranted) {
+            return
+        }
+
+        lastKnownPermissionGranted = isPermissionGranted
+
+        val previousState = currentState.data.notificationPermissionState
 
         val newPermissionState = if (isPermissionGranted) {
             NotificationPermissionState.GRANTED
@@ -134,6 +142,8 @@ class HomeViewModel @Inject constructor(
     fun onNotificationPermissionResult(isGranted: Boolean) {
         val currentState = uiState.value
         if (currentState !is UiState.Success) return
+
+        lastKnownPermissionGranted = isGranted
 
         val newPermissionState = if (isGranted) {
             NotificationPermissionState.GRANTED

--- a/presentation/home/src/main/java/com/hilingual/presentation/home/HomeViewModel.kt
+++ b/presentation/home/src/main/java/com/hilingual/presentation/home/HomeViewModel.kt
@@ -112,13 +112,13 @@ class HomeViewModel @Inject constructor(
         if (currentState !is UiState.Success) return
 
         val previousState = currentState.data.notificationPermissionState
-        val isPermissionGranted = shouldGrantPermission(isGranted, requiresPermission)
+        val isPermissionGranted = isPermissionGranted(isGranted, requiresPermission)
 
         updateNotificationPermissionState(isPermissionGranted)
         requestPermissionIfNeeded(previousState, isPermissionGranted)
     }
 
-    private fun shouldGrantPermission(
+    private fun isPermissionGranted(
         isGranted: Boolean,
         requiresPermission: Boolean
     ): Boolean {

--- a/presentation/home/src/main/java/com/hilingual/presentation/home/type/NotificationPermissionState.kt
+++ b/presentation/home/src/main/java/com/hilingual/presentation/home/type/NotificationPermissionState.kt
@@ -1,0 +1,7 @@
+package com.hilingual.presentation.home.type
+
+enum class NotificationPermissionState {
+    NOT_DETERMINED,
+    GRANTED,
+    DENIED
+}

--- a/presentation/onboarding/src/main/java/com/hilingual/presentation/onboarding/OnboardingScreen.kt
+++ b/presentation/onboarding/src/main/java/com/hilingual/presentation/onboarding/OnboardingScreen.kt
@@ -174,7 +174,13 @@ private fun OnboardingScreen(
             }
         )
 
-        Spacer(Modifier.weight(79f))
+        Spacer(Modifier.weight(73f))
+
+        Text(
+            text = "설정한 닉네임은 변경이 불가능해요.",
+            style = HilingualTheme.typography.bodyM14,
+            color = HilingualTheme.colors.gray400
+        )
 
         HilingualButton(
             text = "가입하기",


### PR DESCRIPTION
## PR chekList
- [x] ktLint 포맷을 지킨다.
- [x] indent(인덴트, 들여쓰기) depth를 3이 넘지 않도록 구현한다.
- [x] 함수(또는 메서드)가 한 가지 일만 하도록 최대한 작게 만든다.
- [x] class를 최대한 작게 만든다.
- [x] else를 지양한다(얼리 리턴 사용).

## Related issue 🛠
- closed #569 

## Work Description ✏️
- 푸시 알림 권한 요청 기능을 구현했습니다.
- 닉네임 수정 불가 안내 라이팅을 추가했습니다.

## Screenshot 📸

### 🔔 푸시 알림 권한

| 거절 | 허용 |
|:--:|:--:|
| <video width="150" src="https://github.com/user-attachments/assets/229a42f7-3112-4546-af5c-e50567dc634e"></video> | <video width="150" src="https://github.com/user-attachments/assets/393ecb0b-419c-4347-a698-f1a99bd28185"></video> |


### ✏️ 닉네임 수정 불가 안내

| 스크린샷 |
|:--:|
| <img width="310" height="677" alt="스크린샷 2025-12-18 오후 6 04 34" src="https://github.com/user-attachments/assets/6d2a3757-bed3-44c8-8fb4-1a72d2d27862" /> |

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
HomeViewModel의 checkNotificationPermission() 메서드에서 권한 상태를 확인하고 권한이 미결정 상태일 때 HomeSideEffect.RequestNotificationPermission 발생 시켜서 HomeScreen의 LaunchedEffect에서 권한 상태 변경을 감지 및 체크 하도록 구현해보았습니다..! 더 좋은 방법이 있다면 리뷰 많이 남겨주세요 !! 빠르게 반영해 두겠습니닷
