### PR TITLE
[FIX/#583] Google 로그인 시 UI가 표시되지 않는 오류 수정 (TransactionTooLargeException)

### DIFF
--- a/data/auth/src/main/java/com/hilingual/data/auth/datasourceimpl/GoogleAuthDataSourceImpl.kt
+++ b/data/auth/src/main/java/com/hilingual/data/auth/datasourceimpl/GoogleAuthDataSourceImpl.kt
@@ -18,7 +18,7 @@ package com.hilingual.data.auth.datasourceimpl
 import android.content.Context
 import androidx.credentials.CredentialManager
 import androidx.credentials.GetCredentialRequest
-import com.google.android.libraries.identity.googleid.GetGoogleIdOption
+import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import com.hilingual.core.common.util.suspendRunCatching
 import com.hilingual.data.auth.BuildConfig
@@ -30,14 +30,12 @@ internal class GoogleAuthDataSourceImpl @Inject constructor(
 ) : GoogleAuthDataSource {
     override suspend fun signIn(context: Context): Result<GoogleIdTokenCredential> =
         suspendRunCatching {
-            val googleIdOption = GetGoogleIdOption.Builder()
-                .setFilterByAuthorizedAccounts(false)
-                .setAutoSelectEnabled(false)
-                .setServerClientId(BuildConfig.GOOGLE_WEB_CLIENT_ID)
-                .build()
+            val signInWithGoogleOption = GetSignInWithGoogleOption.Builder(
+                serverClientId = BuildConfig.GOOGLE_WEB_CLIENT_ID
+            ).build()
 
             val request = GetCredentialRequest.Builder()
-                .addCredentialOption(googleIdOption)
+                .addCredentialOption(signInWithGoogleOption)
                 .build()
 
             val response = credentialManager.getCredential(context, request)


### PR DESCRIPTION
## Related issue 🛠
- closed #583 

## Work Description ✏️
   - Google 로그인 옵션 변경: GoogleAuthDataSourceImpl에서 사용하던 GetGoogleIdOption을 GetSignInWithGoogleOption으로 교체했습니다.
   - 기존 GetGoogleIdOption 사용 시, 기기에 등록된 구글 계정이 많거나 특정 환경에서 Bundle 크기가 Android Binder 트랜잭션 제한(약1MB)을 초과하여 TransactionTooLargeException이 발생하고 UI가 표시되지 않는 문제를 해결했습니다.
   - Google Play Services 버전이나 계정 개수에 상관없이 안정적으로 로그인 시트가 뜨도록 개선했습니다.

## Screenshot 📸

https://github.com/user-attachments/assets/697989c9-0859-4ab5-b10e-5b2522406efd

## To Reviewers 📢
아래의 아티클에 자세한 내용이 있습니다😊
[참고 아티클](https://angrypodo.tistory.com/23) 