### PR TITLE
[REF/#607] Remove unStable property

### DIFF
--- a/presentation/home/src/main/java/com/hilingual/presentation/home/HomeViewModel.kt
+++ b/presentation/home/src/main/java/com/hilingual/presentation/home/HomeViewModel.kt
@@ -66,8 +66,6 @@ class HomeViewModel @Inject constructor(
     )
     val sideEffect: SharedFlow<HomeSideEffect> = _sideEffect.asSharedFlow()
 
-    private var lastKnownPermissionGranted: Boolean? = null
-
     fun loadInitialData() {
         viewModelScope.launch {
             _uiState.update { UiState.Loading }
@@ -115,13 +113,6 @@ class HomeViewModel @Inject constructor(
         if (currentState !is UiState.Success) return
 
         val isPermissionGranted = !requiresPermission || isGranted
-
-        if (lastKnownPermissionGranted == isPermissionGranted) {
-            return
-        }
-
-        lastKnownPermissionGranted = isPermissionGranted
-
         val previousState = currentState.data.notificationPermissionState
 
         val newPermissionState = if (isPermissionGranted) {
@@ -129,6 +120,8 @@ class HomeViewModel @Inject constructor(
         } else {
             NotificationPermissionState.DENIED
         }
+
+        if (previousState == newPermissionState) return
 
         _uiState.updateSuccess {
             it.copy(notificationPermissionState = newPermissionState)
@@ -142,8 +135,6 @@ class HomeViewModel @Inject constructor(
     fun onNotificationPermissionResult(isGranted: Boolean) {
         val currentState = uiState.value
         if (currentState !is UiState.Success) return
-
-        lastKnownPermissionGranted = isGranted
 
         val newPermissionState = if (isGranted) {
             NotificationPermissionState.GRANTED


### PR DESCRIPTION
## Related issue 🛠
- closed #607

## Work Description ✏️
- HomeViewModel 내의`var`를 제거하여 Compose 안정성 이슈를 해결
- `lastKnownPermissionGranted` 변수를 제거하고`UiState`를 SSOT 으로 활용하도록 로직을 개선

## Screenshot 📸
- N/A

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
기존 로직 변경 없이 `UiState`기반으로 비교 로직만 수정했습니다.