### PR TITLE
[REF/634] Improve logging interceptor

### DIFF
--- a/core/network/src/main/java/com/hilingual/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/hilingual/core/network/di/NetworkModule.kt
@@ -54,11 +54,13 @@ object NetworkModule {
     @Provides
     @Singleton
     fun provideLoggingInterceptor(json: Json): HttpLoggingInterceptor {
-        if (!BuildConfig.DEBUG) {
-            return HttpLoggingInterceptor { }.apply { level = HttpLoggingInterceptor.Level.NONE }
+        if (BuildConfig.DEBUG) {
+            return HttpLoggingInterceptor(createSmartLogger(json)).apply {
+                level = HttpLoggingInterceptor.Level.BODY
+            }
         }
-        return HttpLoggingInterceptor(createSmartLogger(json)).apply {
-            level = HttpLoggingInterceptor.Level.BODY
+        return HttpLoggingInterceptor().apply {
+            level = HttpLoggingInterceptor.Level.NONE
         }
     }
 


### PR DESCRIPTION
## Related issue 🛠
- closed #634

## Work Description ✏️
- `BuildConfig.DEBUG`가 `false`인 경우 `HttpLoggingInterceptor`의 레벨을 `NONE`으로 설정하여 불필요한 리소스 소모(문자열 생성, JSON 파싱 등)를 방지
- `NetworkModule` 내의 로깅 로직을 `createSmartLogger`, `prettyPrintJson`, `isPotentialJson` 함수로 분리하여 가독성을 높이고 역할을 분리
- JSON 형식인 경우에만 파싱을 시도하도록 `isPotentialJson` 검사를 추가하고, `runCatching`을 통해 안전하게 포맷팅하도록 개선

## Screenshot 📸
N/A

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
릴리즈 빌드에서 Timber가 로그를 출력하지 않더라도 인터셉터 레벨에서 차단하지 않으면 `body` 문자열 연산 및 JSON 파싱 비용이 발생하므로 이를 원천 차단하기 위한 분기 처리를 추가했습니다.
[테스트 과정](https://angrypodo.tistory.com/28)이 담긴 아티클도 공유합니다😊