### PR TITLE
[REF/#643] Migrate to official Modifier.dropShadow API

### DIFF
--- a/core/common/src/main/java/com/hilingual/core/common/extension/ModfierExt.kt
+++ b/core/common/src/main/java/com/hilingual/core/common/extension/ModfierExt.kt
@@ -15,7 +15,6 @@
  */
 package com.hilingual.core.common.extension
 
-import android.graphics.BlurMaskFilter
 import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
@@ -36,6 +35,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.draw.dropShadow
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
@@ -43,18 +43,17 @@ import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
-import androidx.compose.ui.graphics.Paint
 import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.graphics.drawOutline
-import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.graphics.shadow.Shadow
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.findRootCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowCompat
 
@@ -91,49 +90,27 @@ fun Modifier.advancedImePadding() = composed {
         .imePadding()
 }
 
-@Composable
 fun Modifier.dropShadow(
     shape: Shape,
-    color: Color = Color.Black.copy(0.25f),
+    color: Color = Color.Black,
+    alpha: Float = 0.25f,
     blur: Dp = 1.dp,
     offsetY: Dp = 1.dp,
     offsetX: Dp = 1.dp,
     spread: Dp = 1.dp
-) = composed {
-    val density = LocalDensity.current
-
-    val paint = remember(color, blur) {
-        Paint().apply {
-            this.color = color
-            val blurPx = with(density) { blur.toPx() }
-            if (blurPx > 0f) {
-                this.asFrameworkPaint().maskFilter =
-                    BlurMaskFilter(blurPx, BlurMaskFilter.Blur.NORMAL)
-            }
-        }
-    }
-
-    drawBehind {
-        val spreadPx = spread.toPx()
-        val offsetXPx = offsetX.toPx()
-        val offsetYPx = offsetY.toPx()
-
-        val shadowWidth = size.width + spreadPx
-        val shadowHeight = size.height + spreadPx
-
-        if (shadowWidth <= 0f || shadowHeight <= 0f) return@drawBehind
-
-        val shadowSize = Size(shadowWidth, shadowHeight)
-        val shadowOutline = shape.createOutline(shadowSize, layoutDirection, this)
-
-        drawIntoCanvas { canvas ->
-            canvas.save()
-            canvas.translate(offsetXPx, offsetYPx)
-            canvas.drawOutline(shadowOutline, paint)
-            canvas.restore()
-        }
-    }
-}
+) = this.dropShadow(
+    shape = shape,
+    shadow = Shadow(
+        alpha = alpha,
+        radius = blur,
+        color = color,
+        spread = spread,
+        offset = DpOffset(
+            x = offsetX,
+            y = offsetY
+        )
+    )
+)
 
 fun Modifier.fadingEdge(brush: Brush) = this
     .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/button/HilingualFloatingButton.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/button/HilingualFloatingButton.kt
@@ -70,7 +70,8 @@ fun BoxScope.HilingualFloatingButton(
                 .noRippleClickable(onClick = onClick)
                 .dropShadow(
                     shape = CircleShape,
-                    color = HilingualTheme.colors.black.copy(alpha = 0.2f),
+                    color = HilingualTheme.colors.black,
+                    alpha = 0.2f,
                     offsetX = 0.dp,
                     offsetY = 2.dp,
                     blur = 4.dp,

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/dropdown/HilingualBasicDropdownMenu.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/dropdown/HilingualBasicDropdownMenu.kt
@@ -91,7 +91,8 @@ fun HilingualBasicDropdownMenu(
                 Column(
                     modifier = modifier
                         .dropShadow(
-                            color = HilingualTheme.colors.black.copy(alpha = 0.2f),
+                            color = HilingualTheme.colors.black,
+                            alpha = 0.2f,
                             shape = RoundedCornerShape(size = 10.dp),
                             offsetX = 0.dp,
                             offsetY = 0.dp,


### PR DESCRIPTION
## Related issue 🛠
- closed #643

## Work Description ✏️
- 커스텀 `dropShadow` api 삭제 및 공식 `dropShadow` API를 래핑한 확장함수 구현
- 기존 커스텀 호출부의 파라미터 수정

## Screenshot 📸
### Before
<img width="1774" height="636" alt="image" src="https://github.com/user-attachments/assets/f6ba461a-49c1-403e-b107-89f3238f4dae" />

### After
<img width="1774" height="636" alt="image" src="https://github.com/user-attachments/assets/762d6734-2444-48db-884d-7a4c45c5605e" />


## To Reviewers 📢
[공식 dropShadow](https://developer.android.com/develop/ui/compose/graphics/draw/shadows?hl=ko#implement-drop)가 릴리즈 되었었습니다.
[Compose BOM](https://developer.android.com/develop/ui/compose/bom) version to 2025.08.00 부터 사용가능하며 내부적으로 node를 사용해 구현되어있습니다. 커스텀으로 제작한 `composed`방식 보다 성능면에서 향상이 많이 되었지만 호출마다 Shadow객체를 매번 작성하기에 불편함이 있다고 생각해, 기존 커스텀 처럼 Figma와 일치하도록 파라미터를 래핑했습니다.