### PR TITLE
[REF/#627] Replace ProcessPhoenix with custom AppRestarter

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -100,7 +100,6 @@ dependencies {
     implementation(libs.timber)
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.credentials.play.services.auth)
-    implementation(libs.jakewharton.process.phoenix)
 
     implementation(platform(libs.coil.bom))
     implementation(libs.bundles.coil)

--- a/app/src/main/java/com/hilingual/app/AppRestarterImpl.kt
+++ b/app/src/main/java/com/hilingual/app/AppRestarterImpl.kt
@@ -16,15 +16,30 @@
 package com.hilingual.app
 
 import android.content.Context
+import android.content.Intent
+import android.os.Process
 import com.hilingual.core.common.app.AppRestarter
-import com.jakewharton.processphoenix.ProcessPhoenix
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
+import kotlin.system.exitProcess
 
 class AppRestarterImpl @Inject constructor(
     @ApplicationContext private val context: Context
 ) : AppRestarter {
+
     override fun restartApp() {
-        ProcessPhoenix.triggerRebirth(context)
+        val intent = context.packageManager
+            .getLaunchIntentForPackage(context.packageName)
+            ?.apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            } ?: return
+
+        context.startActivity(intent)
+        killCurrentProcess()
+    }
+
+    private fun killCurrentProcess() {
+        Process.killProcess(Process.myPid())
+        exitProcess(0)
     }
 }

--- a/core/common/src/main/java/com/hilingual/core/common/provider/LocalAppRestarter.kt
+++ b/core/common/src/main/java/com/hilingual/core/common/provider/LocalAppRestarter.kt
@@ -1,0 +1,8 @@
+package com.hilingual.core.common.provider
+
+import androidx.compose.runtime.staticCompositionLocalOf
+import com.hilingual.core.common.app.AppRestarter
+
+val LocalAppRestarter = staticCompositionLocalOf<AppRestarter> {
+    error("No AppRestarter provided")
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,7 +59,6 @@ lottieCompose = "6.7.1"
 coroutine = "1.10.2"
 ktlint = "11.5.1"
 pebble = "0.1.0"
-phoenix = "3.0.0"
 balloonCompose = "1.7.3"
 richeditorCompose = "1.0.0-rc13"
 
@@ -173,7 +172,6 @@ balloon-compose = { group = "com.github.skydoves", name = "balloon-compose", ver
 # Utilities
 richeditor-compose = { module = "com.mohamedrejeb.richeditor:richeditor-compose", version.ref = "richeditorCompose" }
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
-jakewharton-process-phoenix = { group = "com.jakewharton", name = "process-phoenix", version.ref = "phoenix" }
 pebble = { group = "io.github.chattymin", name = "pebble", version.ref = "pebble" }
 
 # Room

--- a/presentation/main/src/main/java/com/hilingual/presentation/main/MainActivity.kt
+++ b/presentation/main/src/main/java/com/hilingual/presentation/main/MainActivity.kt
@@ -22,6 +22,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import com.hilingual.core.common.analytics.Tracker
+import com.hilingual.core.common.app.AppRestarter
 import com.hilingual.core.designsystem.theme.HilingualTheme
 import com.hilingual.core.network.monitor.NetworkMonitor
 import com.hilingual.presentation.main.state.rememberMainAppState
@@ -36,6 +37,9 @@ class MainActivity : ComponentActivity() {
     @Inject
     lateinit var tracker: Tracker
 
+    @Inject
+    lateinit var appRestarter: AppRestarter
+
     @SuppressLint("SourceLockedOrientationActivity")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -47,7 +51,8 @@ class MainActivity : ComponentActivity() {
 
                 MainScreen(
                     appState = appState,
-                    tracker = tracker
+                    tracker = tracker,
+                    appRestarter = appRestarter
                 )
             }
         }

--- a/presentation/main/src/main/java/com/hilingual/presentation/main/MainScreen.kt
+++ b/presentation/main/src/main/java/com/hilingual/presentation/main/MainScreen.kt
@@ -41,6 +41,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.NavHost
 import androidx.navigation.navOptions
 import com.hilingual.core.common.analytics.Tracker
+import com.hilingual.core.common.app.AppRestarter
+import com.hilingual.core.common.provider.LocalAppRestarter
 import com.hilingual.core.common.model.HilingualMessage
 import com.hilingual.core.common.model.HilingualMessage.Snackbar
 import com.hilingual.core.common.model.HilingualMessage.Toast
@@ -74,7 +76,8 @@ import kotlinx.coroutines.launch
 @Composable
 internal fun MainScreen(
     appState: MainAppState,
-    tracker: Tracker
+    tracker: Tracker,
+    appRestarter: AppRestarter
 ) {
     val isOffline by appState.isOffline.collectAsStateWithLifecycle()
     val isBottomBarVisible by appState.isBottomBarVisible.collectAsStateWithLifecycle()
@@ -117,7 +120,8 @@ internal fun MainScreen(
     CompositionLocalProvider(
         LocalDialogTrigger provides dialogTrigger,
         LocalMessageController provides onShowMessage,
-        LocalTracker provides tracker
+        LocalTracker provides tracker,
+        LocalAppRestarter provides appRestarter
     ) {
         Scaffold(
             bottomBar = {

--- a/presentation/mypage/build.gradle.kts
+++ b/presentation/mypage/build.gradle.kts
@@ -25,7 +25,6 @@ android {
 
 dependencies {
     implementation(libs.aboutlibraries.compose.m3)
-    implementation(libs.jakewharton.process.phoenix)
     implementation(projects.data.user)
     implementation(projects.data.auth)
 }

--- a/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/MyPageScreen.kt
+++ b/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/MyPageScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hilingual.core.common.provider.LocalAppRestarter
 import com.hilingual.core.common.constant.UrlConstant
 import com.hilingual.core.common.extension.collectSideEffect
 import com.hilingual.core.common.extension.launchCustomTabs
@@ -53,7 +54,6 @@ import com.hilingual.core.ui.component.topappbar.TitleLeftAlignedTopAppBar
 import com.hilingual.presentation.mypage.component.LogoutDialog
 import com.hilingual.presentation.mypage.component.MyInfoBox
 import com.hilingual.presentation.mypage.component.SettingItem
-import com.jakewharton.processphoenix.ProcessPhoenix
 
 @Composable
 internal fun MyPageRoute(
@@ -69,6 +69,7 @@ internal fun MyPageRoute(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val dialogTrigger = LocalDialogTrigger.current
     val messageController = LocalMessageController.current
+    val appRestarter = LocalAppRestarter.current
 
     viewModel.sideEffect.collectSideEffect { sideEffect ->
         when (sideEffect) {
@@ -76,7 +77,7 @@ internal fun MyPageRoute(
 
             is MyPageSideEffect.ShowToast -> messageController(HilingualMessage.Toast(sideEffect.message))
 
-            is MyPageSideEffect.RestartApp -> ProcessPhoenix.triggerRebirth(context)
+            is MyPageSideEffect.RestartApp -> appRestarter.restartApp()
         }
     }
 

--- a/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/profileedit/ProfileEditScreen.kt
+++ b/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/profileedit/ProfileEditScreen.kt
@@ -35,7 +35,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -45,6 +44,7 @@ import com.hilingual.core.common.extension.collectSideEffect
 import com.hilingual.core.common.extension.noRippleClickable
 import com.hilingual.core.common.extension.statusBarColor
 import com.hilingual.core.common.model.HilingualMessage
+import com.hilingual.core.common.provider.LocalAppRestarter
 import com.hilingual.core.common.trigger.LocalDialogTrigger
 import com.hilingual.core.common.trigger.LocalMessageController
 import com.hilingual.core.common.util.UiState
@@ -57,7 +57,6 @@ import com.hilingual.presentation.mypage.MyPageUiState
 import com.hilingual.presentation.mypage.MyPageViewModel
 import com.hilingual.presentation.mypage.component.ProfileItem
 import com.hilingual.presentation.mypage.component.WithdrawDialog
-import com.jakewharton.processphoenix.ProcessPhoenix
 
 @Composable
 internal fun ProfileEditRoute(
@@ -65,10 +64,10 @@ internal fun ProfileEditRoute(
     navigateUp: () -> Unit,
     viewModel: MyPageViewModel = hiltViewModel()
 ) {
-    val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val dialogTrigger = LocalDialogTrigger.current
     val messageController = LocalMessageController.current
+    val appRestarter = LocalAppRestarter.current
 
     viewModel.sideEffect.collectSideEffect { sideEffect ->
         when (sideEffect) {
@@ -76,7 +75,7 @@ internal fun ProfileEditRoute(
 
             is MyPageSideEffect.ShowToast -> messageController(HilingualMessage.Toast(sideEffect.message))
 
-            is MyPageSideEffect.RestartApp -> ProcessPhoenix.triggerRebirth(context)
+            is MyPageSideEffect.RestartApp -> appRestarter.restartApp()
         }
     }
 


### PR DESCRIPTION
## Related issue 🛠
- closed #627

## Work Description ✏️
- 외부 라이브러리인 `ProcessPhoenix` 의존성을 완전히 제거
- `ProcessPhoenix`를 대체하기 위해 `packageManager.getLaunchIntentForPackage`를 활용한 커스텀 앱 재시작 로직을 구현
- Compose UI 계층에서 앱 재시작 기능에 쉽게 접근할 수 있도록 `LocalAppRestarter` CompositionLocal을 `core/common`에 추가

## Screenshot 📸
| After |
|--------|
| <video src="https://github.com/user-attachments/assets/ba17a4bf-4d68-4a94-998b-dafcf518009f" controls muted loop style="max-width:100%;"></video> | 

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
제가 가지고 있는 API 34기기에서 자주 프레임 드랍이 발생하고 간헐적으로 재시작이 안되는 경우를 발견했습니다.
때문에 무거운 `ProcessPhoenix` 라이브러리를 제거하고, 안드로이드 네이티브 API를 활용하여 앱 재시작 기능을 직접 구현했습니다.
그리고 의존성 추가 없이 `LocalAppRestarter`를 통해 필요한 스크린 어디서든 쉽게 앱을 재시작할 수 있는 구조를 의도했습니다. 따라서 앱 재시작을 SideEffect로서 UI에서 처리할 수 있습니다.
