### PR TITLE
[REF/#635] Decouple AuthRepository from Android framework using SystemDataSource

### DIFF
--- a/data/auth/src/main/java/com/hilingual/data/auth/datasource/SystemDataSource.kt
+++ b/data/auth/src/main/java/com/hilingual/data/auth/datasource/SystemDataSource.kt
@@ -1,0 +1,17 @@
+package com.hilingual.data.auth.datasource
+
+interface SystemDataSource {
+    fun getDeviceName(): String
+
+    fun getDeviceType(): String
+
+    fun getOsVersion(): String
+
+    fun getAppVersion(): String
+
+    fun getProvider(): String
+
+    fun getRole(): String
+
+    fun getOsType(): String
+}

--- a/data/auth/src/main/java/com/hilingual/data/auth/datasourceimpl/SystemDataSourceImpl.kt
+++ b/data/auth/src/main/java/com/hilingual/data/auth/datasourceimpl/SystemDataSourceImpl.kt
@@ -1,0 +1,39 @@
+package com.hilingual.data.auth.datasourceimpl
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import com.hilingual.data.auth.datasource.SystemDataSource
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+internal class SystemDataSourceImpl @Inject constructor(
+    @ApplicationContext private val context: Context
+) : SystemDataSource {
+
+    override fun getDeviceName(): String = Build.MODEL
+
+    override fun getDeviceType(): String =
+        if (context.resources.configuration.smallestScreenWidthDp >= 600) "TABLET" else "PHONE"
+
+    override fun getOsVersion(): String = Build.VERSION.RELEASE
+
+    override fun getAppVersion(): String {
+        val packageManager = context.packageManager
+        val packageName = context.packageName
+        
+        val packageInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            packageManager.getPackageInfo(packageName, PackageManager.PackageInfoFlags.of(0))
+        } else {
+            packageManager.getPackageInfo(packageName, 0)
+        }
+        
+        return packageInfo.versionName ?: "2.0.0"
+    }
+
+    override fun getProvider(): String = "GOOGLE"
+
+    override fun getRole(): String = "USER"
+
+    override fun getOsType(): String = "Android"
+}

--- a/data/auth/src/main/java/com/hilingual/data/auth/di/DataSourceModule.kt
+++ b/data/auth/src/main/java/com/hilingual/data/auth/di/DataSourceModule.kt
@@ -19,8 +19,10 @@ import android.content.Context
 import androidx.credentials.CredentialManager
 import com.hilingual.data.auth.datasource.AuthRemoteDataSource
 import com.hilingual.data.auth.datasource.GoogleAuthDataSource
+import com.hilingual.data.auth.datasource.SystemDataSource
 import com.hilingual.data.auth.datasourceimpl.AuthRemoteDataSourceImpl
 import com.hilingual.data.auth.datasourceimpl.GoogleAuthDataSourceImpl
+import com.hilingual.data.auth.datasourceimpl.SystemDataSourceImpl
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -43,6 +45,12 @@ internal abstract class DataSourceModule {
     abstract fun bindAuthRemoteDataSource(
         authRemoteDataSourceImpl: AuthRemoteDataSourceImpl
     ): AuthRemoteDataSource
+
+    @Binds
+    @Singleton
+    abstract fun bindSystemDataSource(
+        systemDataSourceImpl: SystemDataSourceImpl
+    ): SystemDataSource
 
     internal companion object {
         @Provides


### PR DESCRIPTION
## Related issue 🛠
- closed #635

## Work Description ✏️
- `data:auth` 모듈에 `SystemDataSource` 인터페이스 및 구현체 도입
- `AuthRepositoryImpl`에서 `Context`, `Build`, `PackageManager` 등 안드로이드 프레임워크 직접 의존성 제거
- Hilt를 통한 `SystemDataSource` 주입 및 `DataSourceModule` 바인딩 설정
- 기기 타입(Phone/Tablet) 동적 판별 로직 구현 및 DTO 변환 확장 함수(`toLoginRequestDto`) 적용

## Screenshot 📸
#### 안드로이드 태블릿 사양
<img width="499" height="266" alt="image" src="https://github.com/user-attachments/assets/f340213d-732e-4593-a6fe-f6874278e3c5" />

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
`AuthRepositoryImpl`에서 안드로이드 의존성을 제거하여 유닛 테스트가 가능한 구조로 리팩토링했습니다. `SystemDataSource`를 통해 기기 정보를 추상화하여 제공하도록 개선했습니다.👍🏻
