### PR TITLE
[REF/#636] DiaryFeedback try-catch 코드 개선

### DIFF
--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackViewModel.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackViewModel.kt
@@ -88,8 +88,7 @@ internal class DiaryFeedbackViewModel @Inject constructor(
                 writtenDate = diaryResult.writtenDate,
                 diaryContent = diaryResult.toState(),
                 feedbackList = feedbacksResult.map { it.toState() }.toImmutableList(),
-                recommendExpressionList = recommendExpressionsResult.map { it.toState() }
-                    .toImmutableList()
+                recommendExpressionList = recommendExpressionsResult.map { it.toState() }.toImmutableList()
             )
         }
 

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackViewModel.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackViewModel.kt
@@ -75,19 +75,13 @@ internal class DiaryFeedbackViewModel @Inject constructor(
 
     private suspend fun requestDiaryFeedbackData(): DiaryFeedbackUiState =
         coroutineScope {
-            val contentDeferred = async {
-                diaryRepository.getDiaryContent(diaryId).getOrThrow()
-            }
-            val feedbacksDeferred = async {
-                diaryRepository.getDiaryFeedbacks(diaryId).getOrThrow()
-            }
-            val recommendExpressionsDeferred = async {
-                diaryRepository.getDiaryRecommendExpressions(diaryId).getOrThrow()
-            }
+            val contentDeferred = async { diaryRepository.getDiaryContent(diaryId) }
+            val feedbacksDeferred = async { diaryRepository.getDiaryFeedbacks(diaryId) }
+            val recommendExpressionsDeferred = async { diaryRepository.getDiaryRecommendExpressions(diaryId) }
 
-            val diaryResult = contentDeferred.await()
-            val feedbacksResult = feedbacksDeferred.await()
-            val recommendExpressionsResult = recommendExpressionsDeferred.await()
+            val diaryResult = contentDeferred.await().getOrThrow()
+            val feedbacksResult = feedbacksDeferred.await().getOrThrow()
+            val recommendExpressionsResult = recommendExpressionsDeferred.await().getOrThrow()
 
             DiaryFeedbackUiState(
                 isPublished = diaryResult.isPublished,


### PR DESCRIPTION
## PR chekList
- [x] ktLint 포맷을 지킨다.
- [x] indent(인덴트, 들여쓰기) depth를 3이 넘지 않도록 구현한다.
- [x] 함수(또는 메서드)가 한 가지 일만 하도록 최대한 작게 만든다.
- [x] class를 최대한 작게 만든다.
- [x] else를 지양한다(얼리 리턴 사용).

## Related issue 🛠
- closed #636 

## Work Description ✏️
- `DiaryFeedbackViewModel` 초기 로딩에서 `try-catch` + `throw` 기반 흐름을 제거하고, `suspendRunCatching` + `getOrThrow()` 조합으로 `Result` 처리 방식에 맞게 리팩터링했습니다.
- 성공 시 `UiState.Success`, 실패 시 `UiState.Failure`로 상태 전환을 통일하고, 비동기 요청은 `async/await`로 병렬 처리 유지했습니다.

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
- 같은 API 사용하는 `FeedDiaryViewModel`과 비슷한 구조로 코드 구현했습니다.
