### PR TITLE
[REF/#628] date format 로직을 중앙화 해요.

### DIFF
--- a/core/common/src/main/java/com/hilingual/core/common/util/DateFormatter.kt
+++ b/core/common/src/main/java/com/hilingual/core/common/util/DateFormatter.kt
@@ -1,0 +1,19 @@
+package com.hilingual.core.common.util
+
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+object DateFormatters {
+    val KOREAN_FULL_DATE: DateTimeFormatter = DateTimeFormatter.ofPattern("M월 d일 EEEE", Locale.KOREAN)
+
+    val KOREAN_SHORT_DATE: DateTimeFormatter = DateTimeFormatter.ofPattern("M월 d일", Locale.KOREA)
+
+    val ISO_DATE: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE
+}
+
+fun LocalDate.toKoreanFullDate(): String = this.format(DateFormatters.KOREAN_FULL_DATE)
+
+fun LocalDate.toKoreanShortDate(): String = this.format(DateFormatters.KOREAN_SHORT_DATE)
+
+fun LocalDate.toIsoDate(): String = this.format(DateFormatters.ISO_DATE)

--- a/core/common/src/main/java/com/hilingual/core/common/util/DateFormatter.kt
+++ b/core/common/src/main/java/com/hilingual/core/common/util/DateFormatter.kt
@@ -1,19 +1,38 @@
 package com.hilingual.core.common.util
 
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 object DateFormatters {
-    val KOREAN_FULL_DATE: DateTimeFormatter = DateTimeFormatter.ofPattern("M월 d일 EEEE", Locale.KOREAN)
+    val KOREAN_FULL_DATE: DateTimeFormatter = DateTimeFormatter.ofPattern("M월 d일 EEEE", Locale.KOREA)
 
     val KOREAN_SHORT_DATE: DateTimeFormatter = DateTimeFormatter.ofPattern("M월 d일", Locale.KOREA)
 
     val ISO_DATE: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE
 }
 
+/**
+ * LocalDate를 한국어 전체 날짜 형식으로 변환합니다.
+ * @return "M월 d일 EEEE" 형식의 문자열 (예: "2월 6일 목요일")
+ */
 fun LocalDate.toKoreanFullDate(): String = this.format(DateFormatters.KOREAN_FULL_DATE)
 
+fun LocalDateTime.toKoreanFullDate(): String = this.format(DateFormatters.KOREAN_FULL_DATE)
+
+/**
+ * LocalDate를 한국어 짧은 날짜 형식으로 변환합니다.
+ * @return "M월 d일" 형식의 문자열 (예: "2월 6일")
+ */
 fun LocalDate.toKoreanShortDate(): String = this.format(DateFormatters.KOREAN_SHORT_DATE)
 
+fun LocalDateTime.toKoreanShortDate(): String = this.format(DateFormatters.KOREAN_SHORT_DATE)
+
+/**
+ * LocalDate를 ISO 날짜 형식으로 변환합니다.
+ * @return "yyyy-MM-dd" 형식의 문자열 (예: "2026-02-06")
+ */
 fun LocalDate.toIsoDate(): String = this.format(DateFormatters.ISO_DATE)
+
+fun LocalDateTime.toIsoDate(): String = this.format(DateFormatters.ISO_DATE)

--- a/core/common/src/main/java/com/hilingual/core/common/util/FormatRelativeTime.kt
+++ b/core/common/src/main/java/com/hilingual/core/common/util/FormatRelativeTime.kt
@@ -27,8 +27,6 @@ private const val ONE_HOUR_IN_MINUTES = 60L
 private const val ONE_DAY_IN_MINUTES = 1440L
 private const val ONE_WEEK_IN_MINUTES = 10080L
 
-private val DATE_FORMATTER = DateTimeFormatter.ofPattern("M월 d일", Locale.KOREA)
-
 fun formatRelativeTime(minutesAgo: Long): String {
     return when {
         minutesAgo < ONE_MINUTE -> "방금 전"
@@ -39,7 +37,7 @@ fun formatRelativeTime(minutesAgo: Long): String {
             val pastTime = System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(minutesAgo)
             val instant = Instant.ofEpochMilli(pastTime)
             val localDateTime = LocalDateTime.ofInstant(instant, ZoneId.systemDefault())
-            DATE_FORMATTER.format(localDateTime)
+            DateFormatters.KOREAN_SHORT_DATE.format(localDateTime)
         }
     }
 }

--- a/core/common/src/main/java/com/hilingual/core/common/util/FormatRelativeTime.kt
+++ b/core/common/src/main/java/com/hilingual/core/common/util/FormatRelativeTime.kt
@@ -18,8 +18,6 @@ package com.hilingual.core.common.util
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
-import java.time.format.DateTimeFormatter
-import java.util.Locale
 import java.util.concurrent.TimeUnit
 
 private const val ONE_MINUTE = 1L

--- a/core/common/src/main/java/com/hilingual/core/common/util/FormatRelativeTime.kt
+++ b/core/common/src/main/java/com/hilingual/core/common/util/FormatRelativeTime.kt
@@ -37,7 +37,7 @@ fun formatRelativeTime(minutesAgo: Long): String {
             val pastTime = System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(minutesAgo)
             val instant = Instant.ofEpochMilli(pastTime)
             val localDateTime = LocalDateTime.ofInstant(instant, ZoneId.systemDefault())
-            DateFormatters.KOREAN_SHORT_DATE.format(localDateTime)
+            localDateTime.toKoreanShortDate()
         }
     }
 }

--- a/data/diary/src/main/java/com/hilingual/data/diary/repositoryimpl/DiaryRepositoryImpl.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/repositoryimpl/DiaryRepositoryImpl.kt
@@ -17,6 +17,7 @@ package com.hilingual.data.diary.repositoryimpl
 
 import android.net.Uri
 import com.hilingual.core.common.util.suspendRunCatching
+import com.hilingual.core.common.util.toIsoDate
 import com.hilingual.data.diary.datasource.DiaryRemoteDataSource
 import com.hilingual.data.diary.model.BookmarkResult
 import com.hilingual.data.diary.model.DiaryContentModel
@@ -29,10 +30,7 @@ import com.hilingual.data.diary.model.toModel
 import com.hilingual.data.diary.repository.DiaryRepository
 import com.hilingual.data.presigned.repository.FileUploaderRepository
 import java.time.LocalDate
-import java.time.format.DateTimeFormatter
 import javax.inject.Inject
-
-private val DATE_FORMATTER: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE
 
 internal class DiaryRepositoryImpl @Inject constructor(
     private val diaryRemoteDataSource: DiaryRemoteDataSource,
@@ -82,7 +80,7 @@ internal class DiaryRepositoryImpl @Inject constructor(
 
         diaryRemoteDataSource.postDiaryFeedbackCreate(
             originalText = originalText,
-            date = date.format(DATE_FORMATTER),
+            date = date.toIsoDate(),
             fileKey = fileKey
         ).data!!.toModel()
     }

--- a/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/DiaryWriteScreen.kt
+++ b/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/DiaryWriteScreen.kt
@@ -72,6 +72,7 @@ import com.hilingual.core.common.provider.LocalTracker
 import com.hilingual.core.common.trigger.LocalDialogTrigger
 import com.hilingual.core.common.trigger.LocalMessageController
 import com.hilingual.core.common.util.UiState
+import com.hilingual.core.common.util.toKoreanFullDate
 import com.hilingual.core.designsystem.component.button.HilingualButton
 import com.hilingual.core.designsystem.component.textfield.HilingualLongTextField
 import com.hilingual.core.designsystem.theme.HilingualTheme
@@ -542,7 +543,7 @@ private fun DateText(
     val selectedDate = selectedDateProvider()
 
     val formattedDate = remember(selectedDate) {
-        selectedDate.format(DATE_FORMATTER)
+        selectedDate.toKoreanFullDate()
     }
 
     Text(
@@ -551,9 +552,6 @@ private fun DateText(
         color = HilingualTheme.colors.black
     )
 }
-
-private val DATE_FORMATTER: DateTimeFormatter =
-    DateTimeFormatter.ofPattern("M월 d일 EEEE", Locale.KOREAN)
 
 private fun createTempImageFile(context: Context): Pair<Uri, File> {
     val imageFile = File.createTempFile("camera_", ".jpg", context.cacheDir)

--- a/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/DiaryWriteScreen.kt
+++ b/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/DiaryWriteScreen.kt
@@ -100,8 +100,6 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.delay
 import java.io.File
 import java.time.LocalDate
-import java.time.format.DateTimeFormatter
-import java.util.Locale
 import com.hilingual.core.designsystem.R as DesignSystemR
 
 @Composable

--- a/presentation/home/src/main/java/com/hilingual/presentation/home/component/footer/DiaryDateInfo.kt
+++ b/presentation/home/src/main/java/com/hilingual/presentation/home/component/footer/DiaryDateInfo.kt
@@ -26,13 +26,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
+import com.hilingual.core.common.util.toKoreanFullDate
 import com.hilingual.core.designsystem.theme.HilingualTheme
 import java.time.LocalDate
-import java.time.format.DateTimeFormatter
-import java.util.Locale
-
-private val DATE_FORMATTER: DateTimeFormatter =
-    DateTimeFormatter.ofPattern("M월 d일 EEEE", Locale.KOREAN)
 
 @Composable
 internal fun DiaryDateInfo(
@@ -42,7 +38,7 @@ internal fun DiaryDateInfo(
     modifier: Modifier = Modifier
 ) {
     val formattedDate = remember(selectedDate) {
-        selectedDate.format(DATE_FORMATTER)
+        selectedDate.toKoreanFullDate()
     }
 
     val isFuture = remember(selectedDate) {


### PR DESCRIPTION
## PR chekList
- [x] ktLint 포맷을 지킨다.
- [x] indent(인덴트, 들여쓰기) depth를 3이 넘지 않도록 구현한다.
- [x] 함수(또는 메서드)가 한 가지 일만 하도록 최대한 작게 만든다.
- [x] class를 최대한 작게 만든다.
- [x] else를 지양한다(얼리 리턴 사용).

## Related issue 🛠
- closed #628 

## Work Description ✏️
- 곳곳에 흩어져있던 date format 로직을 중앙화 하였습니다.

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
core 모듈의 util 패키지에 DateFormatter를 만들어서 작업했어요! 함수 네이밍을 toKoreanFullDate, toKoreanShortDate로 했는데 혹시 더 괜찮은 네이밍이 있다면 추천 부탁드리겠습니다. 