### PR TITLE
[FEAT/#688] Add release logging tree with Firebase Crashlytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,3 +243,7 @@ fabric.properties
 
 # Fastlane dependencies
 vendor/
+
+# ETC
+conductor/
+GEMINI.md

--- a/app/src/main/java/com/hilingual/App.kt
+++ b/app/src/main/java/com/hilingual/App.kt
@@ -20,11 +20,12 @@ import android.content.Context
 import androidx.appcompat.app.AppCompatDelegate
 import coil3.ImageLoader
 import coil3.SingletonImageLoader
+import com.hilingual.core.common.util.HilingualReleaseTree
 import com.hilingual.core.work.scheduler.HilingualWorkManagerConfigurator
 import dagger.Lazy
 import dagger.hilt.android.HiltAndroidApp
-import javax.inject.Inject
 import timber.log.Timber
+import javax.inject.Inject
 
 @HiltAndroidApp
 class App : Application(), SingletonImageLoader.Factory {
@@ -50,7 +51,8 @@ class App : Application(), SingletonImageLoader.Factory {
     }
 
     private fun initTimber() {
-        if (BuildConfig.DEBUG) Timber.plant(Timber.DebugTree())
+        val tree = if (BuildConfig.DEBUG) Timber.DebugTree() else HilingualReleaseTree()
+        Timber.plant(tree)
     }
 
     private fun initWorkManager() {

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -37,4 +37,8 @@ dependencies {
     implementation(libs.timber)
 
     implementation(libs.androidx.browser)
+
+    // Firebase
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.crashlytics)
 }

--- a/core/common/src/main/java/com/hilingual/core/common/util/HilingualReleaseTree.kt
+++ b/core/common/src/main/java/com/hilingual/core/common/util/HilingualReleaseTree.kt
@@ -1,0 +1,19 @@
+package com.hilingual.core.common.util
+
+import android.util.Log
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import timber.log.Timber
+
+class HilingualReleaseTree : Timber.Tree() {
+    override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+        val isLoggable = priority >= Log.WARN
+        if (isLoggable) {
+            val crashlytics = FirebaseCrashlytics.getInstance()
+
+            val logMessage = if (tag != null) "[$tag] $message" else message
+            crashlytics.log(logMessage)
+
+            if (t != null) crashlytics.recordException(t)
+        }
+    }
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #688 

## Work Description ✏️
- `core:common` 모듈에 릴리즈 전용 로깅 트리인 `HilingualReleaseTree`를 구현
  - `DEBUG`, `INFO` 로그는 무시하고 `WARN` 이상 레벨의 로그만 Crashlytics로 전송
  - `Exception`이 포함된 경우 `recordException`을 호출하여 Non-fatal 이슈로 리포팅
- `App.kt`에서 빌드 타입에 따라 적절한 `Timber.Tree`를 심도록 수정

## Screenshot 📸
<img width="826" height="123" alt="image" src="https://github.com/user-attachments/assets/f522d852-29b4-4bd3-8e22-29addfe703cc" />
<img width="1232" height="441" alt="image" src="https://github.com/user-attachments/assets/6e0e6012-14a9-4c7b-b55e-cade158a55e0" />


## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
릴리즈 빌드에서 크래시리틱스에 로그가 정상적으로 올라오는지 확인했습니다. 스크린샷 참고해주세요!
이제 `onLogFailure` 흐름을 타는 로직은 모두 로깅이 가능합니다ㅎㅎ
