### PR TITLE
[FIX/#700] 온보딩 사일로 추가 수정사항 반영

### DIFF
--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/bottomsheet/HilingualBasicBottomSheet.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/bottomsheet/HilingualBasicBottomSheet.kt
@@ -39,6 +39,7 @@ fun HilingualBasicBottomSheet(
     ),
     properties: ModalBottomSheetProperties = ModalBottomSheetProperties(),
     isDimEnabled: Boolean = true,
+    sheetGesturesEnabled: Boolean = true,
     dragHandle: (@Composable () -> Unit)? = null,
     content: @Composable () -> Unit
 ) {
@@ -59,6 +60,7 @@ fun HilingualBasicBottomSheet(
             scrimColor = if (isDimEnabled) HilingualTheme.colors.dim1 else Color.Transparent,
             shape = RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp),
             dragHandle = dragHandle,
+            sheetGesturesEnabled = sheetGesturesEnabled,
             properties = properties
         ) {
             content()

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/dialog/TwoButtonDialog.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/dialog/TwoButtonDialog.kt
@@ -63,7 +63,7 @@ fun TwoButtonDialog(
             Text(
                 text = description,
                 style = HilingualTheme.typography.bodyR14,
-                color = HilingualTheme.colors.gray400,
+                color = HilingualTheme.colors.gray500,
                 maxLines = 2,
                 textAlign = TextAlign.Center
             )

--- a/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/DiaryWriteScreen.kt
+++ b/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/DiaryWriteScreen.kt
@@ -96,10 +96,10 @@ import com.skydoves.balloon.compose.balloon
 import com.skydoves.balloon.compose.rememberBalloonBuilder
 import com.skydoves.balloon.compose.rememberBalloonState
 import com.skydoves.balloon.compose.setBackgroundColor
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.coroutines.delay
 import java.io.File
 import java.time.LocalDate
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.delay
 import com.hilingual.core.designsystem.R as DesignSystemR
 
 @Composable
@@ -486,25 +486,36 @@ private fun DiaryWriteScreen(
 
         val balloonState = rememberBalloonState(balloonBuilder)
 
-        HilingualButton(
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier
                 .align(Alignment.BottomCenter)
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp)
-                .padding(bottom = 16.dp)
                 .navigationBarsPadding()
-                .balloon(
-                    state = balloonState,
-                    balloonContent = {
-                        WriteGuideTooltip(
-                            text = "10자 이상 작성해야 피드백 요청이 가능해요!"
-                        )
-                    }
-                ),
-            text = "피드백 요청하기",
-            enableProvider = { diaryText.length >= 10 },
-            onClick = onDiaryFeedbackRequestButtonClick
-        )
+        ) {
+            Text(
+                text = "피드백을 요청한 일기는 수정이 불가능해요.",
+                style = HilingualTheme.typography.bodyM14,
+                color = HilingualTheme.colors.gray400
+            )
+
+            HilingualButton(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+                    .balloon(
+                        state = balloonState,
+                        balloonContent = {
+                            WriteGuideTooltip(
+                                text = "10자 이상 작성해야 피드백 요청이 가능해요!"
+                            )
+                        }
+                    ),
+                text = "피드백 요청하기",
+                enableProvider = { diaryText.length >= 10 },
+                onClick = onDiaryFeedbackRequestButtonClick
+            )
+        }
 
         LaunchedEffect(Unit) {
             balloonState.showAlignTop()

--- a/presentation/home/src/main/java/com/hilingual/presentation/home/component/onboarding/HomeOnboardingBottomSheet.kt
+++ b/presentation/home/src/main/java/com/hilingual/presentation/home/component/onboarding/HomeOnboardingBottomSheet.kt
@@ -33,6 +33,7 @@ internal fun HomeOnboardingBottomSheet(
             shouldDismissOnClickOutside = false
         ),
         isDimEnabled = true,
+        sheetGesturesEnabled = false,
         modifier = modifier
     ) {
         Box(


### PR DESCRIPTION
## PR chekList
- [x] ktLint 포맷을 지킨다.
- [x] indent(인덴트, 들여쓰기) depth를 3이 넘지 않도록 구현한다.
- [x] 함수(또는 메서드)가 한 가지 일만 하도록 최대한 작게 만든다.
- [x] class를 최대한 작게 만든다.
- [x] else를 지양한다(얼리 리턴 사용).

## Related issue 🛠
- closed #700 

## Work Description ✏️
- 홈 온보딩 - 스크롤 시에도 바텀시트가 닫히지 않도록 수정
- 일기 작성 - 일기 수정 불가 관련 안내 문구 추가
- 공통 - 다이얼로그 decription 텍스트 색상 수정

## Screenshot 📸
| 항목 | as-is | to-be |
|------|-------|-------|
| 홈 온보딩 | <video src="https://github.com/user-attachments/assets/90ab71a4-6df0-4d10-a8bd-e3ab63dfd525" width=360 /> | <video src="https://github.com/user-attachments/assets/b337460f-aff7-4c57-b37d-3747b0b5f524" width=360 /> |
| 일기 작성 | <img src="https://github.com/user-attachments/assets/e62317ef-ae2e-4ed2-bb22-671d36d7ad6a" width=360 /> | <img src="https://github.com/user-attachments/assets/33f2560b-7ce9-4d3f-a167-2c6ee895d8f9" width=360 /> |
| 다이얼로그 | <img src="https://github.com/user-attachments/assets/4fd44e6d-7aaa-4be9-b229-6e9e141394cf" width=360 /> | <img src="https://github.com/user-attachments/assets/2c446713-5677-4ef4-abf2-eb03eff69da1" width=360 /> |

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
- 홈 온보딩 바텀시트를 스크롤했을 때도 바텀시트가 닫히지 않았으면 좋겠다고 요청해주셔서 sheetGesturesEnabled를 추가했습니다
- 일기 수정과 관련한 문의가 많이 있었어서 피드백 요청 시 한 번 더 안내 문구를 추가했습니다
- 다이얼로그 중 description 부분이 색상이 연해 잘 안 읽힐 수 있다는 의견으로 더 진한 색상으로 수정되었습니다