### PR TITLE
[FIX/#704] Include keep.xml resource in raw directory

### DIFF
--- a/app/src/main/res/raw/keep.xml
+++ b/app/src/main/res/raw/keep.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@raw/aboutlibraries" />


### PR DESCRIPTION
## Related issue 🛠
- closed #704

## Work Description ✏️
- 릴리즈 빌드에서 발생하는 AboutLibraries의 크래시 원인을 수정했습니다.

## Screenshot 📸
https://github.com/user-attachments/assets/dd72f422-9ef1-4d83-a9cb-0b028a7fbe4a

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
R8이 json을 삭제시켜서 발생하던 원인이었네요. 근데 여태까지 크래시가 한번도 안났다..?
