### PR TITLE
[FEAT/#730] 피드백 확인 전면 광고 구현

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/hilingual/buildlogic/BuildType.kt
+++ b/build-logic/convention/src/main/kotlin/com/hilingual/buildlogic/BuildType.kt
@@ -39,6 +39,11 @@ fun Project.configureBuildTypes(
             "ADMOB_BANNER_UNIT_ID",
             properties.getQuotedProperty("admob.banner.$prefix.id")
         )
+        buildConfigField(
+            "String",
+            "ADMOB_INTERSTITIAL_UNIT_ID",
+            properties.getQuotedProperty("admob.interstitial.$prefix.id")
+        )
     }
 
     commonExtension.apply {

--- a/core/ads/src/main/java/com/hilingual/core/ads/interstitial/HilingualInterstitialAd.kt
+++ b/core/ads/src/main/java/com/hilingual/core/ads/interstitial/HilingualInterstitialAd.kt
@@ -1,0 +1,54 @@
+package com.hilingual.core.ads.interstitial
+
+import android.app.Activity
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
+import com.google.android.libraries.ads.mobile.sdk.common.AdRequest
+import com.google.android.libraries.ads.mobile.sdk.common.FullScreenContentError
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
+import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAd
+import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAdEventCallback
+import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAdPreloader
+import timber.log.Timber
+
+fun showInterstitialAd(
+    activity: Activity,
+    adUnitId: String,
+    onAdDismissed: () -> Unit,
+) {
+    val preloadedAd = InterstitialAdPreloader.pollAd(adUnitId)
+
+    if (preloadedAd != null) {
+        Timber.tag("GMA").d("프리로드된 전면 광고를 표시합니다.")
+        preloadedAd.adEventCallback = createEventCallback(onAdDismissed)
+        preloadedAd.show(activity)
+    } else {
+        Timber.tag("GMA").d("프리로드된 광고 없음, 새로 로드 후 표시합니다.")
+        val adRequest = AdRequest.Builder(adUnitId).build()
+        InterstitialAd.load(
+            adRequest,
+            object : AdLoadCallback<InterstitialAd> {
+                override fun onAdLoaded(ad: InterstitialAd) {
+                    ad.adEventCallback = createEventCallback(onAdDismissed)
+                    ad.show(activity)
+                }
+
+                override fun onAdFailedToLoad(error: LoadAdError) {
+                    Timber.tag("GMA").e("전면 광고 로드 실패: %s", error)
+                    onAdDismissed()
+                }
+            }
+        )
+    }
+}
+
+private fun createEventCallback(onAdDismissed: () -> Unit) = object : InterstitialAdEventCallback {
+    override fun onAdDismissedFullScreenContent() {
+        Timber.tag("GMA").d("전면 광고 닫힘 → 피드백 화면으로 이동")
+        onAdDismissed()
+    }
+
+    override fun onAdFailedToShowFullScreenContent(error: FullScreenContentError) {
+        Timber.tag("GMA").e("전면 광고 표시 실패: %s", error)
+        onAdDismissed()
+    }
+}

--- a/core/ads/src/main/java/com/hilingual/core/ads/interstitial/HilingualInterstitialAd.kt
+++ b/core/ads/src/main/java/com/hilingual/core/ads/interstitial/HilingualInterstitialAd.kt
@@ -28,12 +28,17 @@ fun showInterstitialAd(
             adRequest,
             object : AdLoadCallback<InterstitialAd> {
                 override fun onAdLoaded(ad: InterstitialAd) {
-                    ad.adEventCallback = createEventCallback(onAdDismissed)
-                    ad.show(activity)
+                    if (!activity.isFinishing && !activity.isDestroyed) {
+                        ad.adEventCallback = createEventCallback(onAdDismissed)
+                        ad.show(activity)
+                    } else {
+                        Timber.tag("GMA").w("Activity가 이미 종료 상태라 전면 광고를 표시하지 않습니다.")
+                        onAdDismissed()
+                    }
                 }
 
-                override fun onAdFailedToLoad(error: LoadAdError) {
-                    Timber.tag("GMA").e("전면 광고 로드 실패: %s", error)
+                override fun onAdFailedToLoad(adError: LoadAdError) {
+                    Timber.tag("GMA").e("전면 광고 로드 실패: %s", adError)
                     onAdDismissed()
                 }
             },
@@ -47,8 +52,8 @@ private fun createEventCallback(onAdDismissed: () -> Unit) = object : Interstiti
         onAdDismissed()
     }
 
-    override fun onAdFailedToShowFullScreenContent(error: FullScreenContentError) {
-        Timber.tag("GMA").e("전면 광고 표시 실패: %s", error)
+    override fun onAdFailedToShowFullScreenContent(fullScreenContentError: FullScreenContentError) {
+        Timber.tag("GMA").e("전면 광고 표시 실패: %s", fullScreenContentError)
         onAdDismissed()
     }
 }

--- a/core/ads/src/main/java/com/hilingual/core/ads/interstitial/HilingualInterstitialAd.kt
+++ b/core/ads/src/main/java/com/hilingual/core/ads/interstitial/HilingualInterstitialAd.kt
@@ -36,7 +36,7 @@ fun showInterstitialAd(
                     Timber.tag("GMA").e("전면 광고 로드 실패: %s", error)
                     onAdDismissed()
                 }
-            }
+            },
         )
     }
 }

--- a/core/ads/src/main/java/com/hilingual/core/ads/manager/AdsPreloadManager.kt
+++ b/core/ads/src/main/java/com/hilingual/core/ads/manager/AdsPreloadManager.kt
@@ -2,4 +2,5 @@ package com.hilingual.core.ads.manager
 
 interface AdsPreloadManager {
     fun preloadBanner(adUnitId: String, maxHeight: Int? = null)
+    fun  preloadInterstitial(adUnitId: String)
 }

--- a/core/ads/src/main/java/com/hilingual/core/ads/manager/AdsPreloadManager.kt
+++ b/core/ads/src/main/java/com/hilingual/core/ads/manager/AdsPreloadManager.kt
@@ -2,5 +2,5 @@ package com.hilingual.core.ads.manager
 
 interface AdsPreloadManager {
     fun preloadBanner(adUnitId: String, maxHeight: Int? = null)
-    fun  preloadInterstitial(adUnitId: String)
+    fun preloadInterstitial(adUnitId: String)
 }

--- a/core/ads/src/main/java/com/hilingual/core/ads/manager/AdsPreloadManagerImpl.kt
+++ b/core/ads/src/main/java/com/hilingual/core/ads/manager/AdsPreloadManagerImpl.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import com.google.android.libraries.ads.mobile.sdk.banner.AdSize
 import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdPreloader
 import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdRequest
+import com.google.android.libraries.ads.mobile.sdk.common.AdRequest
 import com.google.android.libraries.ads.mobile.sdk.common.PreloadConfiguration
+import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAdPreloader
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -33,6 +35,18 @@ internal class AdsPreloadManagerImpl @Inject constructor(
             Timber.tag("GMA").d("GMA Next Gen 배너 프리로딩 시작: %s", adUnitId)
         } catch (e: Exception) {
             Timber.tag("GMA").e(e, "배너 프리로딩 시작 실패: %s", adUnitId)
+        }
+    }
+
+    override fun preloadInterstitial(adUnitId: String) {
+        try {
+            val adRequest = AdRequest.Builder(adUnitId).build()
+            val preloadConfig = PreloadConfiguration(adRequest)
+
+            InterstitialAdPreloader.start(adUnitId, preloadConfig)
+            Timber.tag("GMA").d("GMA Next Gen 전면 광고 프리로딩 시작: %s", adUnitId)
+        } catch (e: Exception) {
+            Timber.tag("GMA").e(e, "전면 광고 프리로딩 실패: %s", adUnitId)
         }
     }
 }

--- a/data/diary/src/main/java/com/hilingual/data/diary/datasource/DiaryRemoteDataSource.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/datasource/DiaryRemoteDataSource.kt
@@ -57,4 +57,8 @@ interface DiaryRemoteDataSource {
     suspend fun deleteDiary(
         diaryId: Long,
     ): BaseResponse<Unit>
+
+    suspend fun patchAdWatch(
+        diaryId: Long
+    ): BaseResponse<Unit>
 }

--- a/data/diary/src/main/java/com/hilingual/data/diary/datasource/DiaryRemoteDataSource.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/datasource/DiaryRemoteDataSource.kt
@@ -59,6 +59,6 @@ interface DiaryRemoteDataSource {
     ): BaseResponse<Unit>
 
     suspend fun patchAdWatch(
-        diaryId: Long
+        diaryId: Long,
     ): BaseResponse<Unit>
 }

--- a/data/diary/src/main/java/com/hilingual/data/diary/datasourceimpl/DiaryRemoteDataSourceImpl.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/datasourceimpl/DiaryRemoteDataSourceImpl.kt
@@ -81,4 +81,7 @@ internal class DiaryRemoteDataSourceImpl @Inject constructor(
 
     override suspend fun deleteDiary(diaryId: Long): BaseResponse<Unit> =
         diaryService.deleteDiary(diaryId)
+
+    override suspend fun patchAdWatch(diaryId: Long): BaseResponse<Unit> =
+        diaryService.patchAdWatch(diaryId)
 }

--- a/data/diary/src/main/java/com/hilingual/data/diary/dto/response/DiaryContentResponseDto.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/dto/response/DiaryContentResponseDto.kt
@@ -32,6 +32,7 @@ data class DiaryContentResponseDto(
     val imageUrl: String?,
     @SerialName("isPublished")
     val isPublished: Boolean,
+    /*TODO:: isAdWatched — 서버 연결 시 추가*/
 )
 
 @Serializable

--- a/data/diary/src/main/java/com/hilingual/data/diary/model/DiaryModel.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/model/DiaryModel.kt
@@ -42,5 +42,5 @@ internal fun DiaryContentResponseDto.toModel() = DiaryContentModel(
         )
     },
     isPublished = this.isPublished,
-    isAdWatched = false //TODO:: 서버 연결 시 this.isAdWatched로 교체
+    isAdWatched = false, // TODO:: 서버 연결 시 this.isAdWatched로 교체
 )

--- a/data/diary/src/main/java/com/hilingual/data/diary/model/DiaryModel.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/model/DiaryModel.kt
@@ -24,6 +24,7 @@ data class DiaryContentModel(
     val diffRanges: List<DiaryContentFeedback>,
     val imageUrl: String?,
     val isPublished: Boolean,
+    val isAdWatched: Boolean,
 )
 
 data class DiaryContentFeedback(
@@ -41,4 +42,5 @@ internal fun DiaryContentResponseDto.toModel() = DiaryContentModel(
         )
     },
     isPublished = this.isPublished,
+    isAdWatched = false //TODO:: 서버 연결 시 this.isAdWatched로 교체
 )

--- a/data/diary/src/main/java/com/hilingual/data/diary/repository/DiaryRepository.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/repository/DiaryRepository.kt
@@ -55,6 +55,6 @@ interface DiaryRepository {
     ): Result<Unit>
 
     suspend fun patchAdWatch(
-        diaryId: Long
+        diaryId: Long,
     ): Result<Unit>
 }

--- a/data/diary/src/main/java/com/hilingual/data/diary/repository/DiaryRepository.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/repository/DiaryRepository.kt
@@ -53,4 +53,8 @@ interface DiaryRepository {
     suspend fun deleteDiary(
         diaryId: Long,
     ): Result<Unit>
+
+    suspend fun patchAdWatch(
+        diaryId: Long
+    ): Result<Unit>
 }

--- a/data/diary/src/main/java/com/hilingual/data/diary/repositoryimpl/DiaryRepositoryImpl.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/repositoryimpl/DiaryRepositoryImpl.kt
@@ -99,4 +99,9 @@ internal class DiaryRepositoryImpl @Inject constructor(
         suspendRunCatching {
             diaryRemoteDataSource.deleteDiary(diaryId)
         }
+
+    override suspend fun patchAdWatch(diaryId: Long): Result<Unit> =
+        suspendRunCatching {
+            diaryRemoteDataSource.patchAdWatch(diaryId)
+        }
 }

--- a/data/diary/src/main/java/com/hilingual/data/diary/service/DiaryService.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/service/DiaryService.kt
@@ -70,4 +70,9 @@ interface DiaryService {
     suspend fun deleteDiary(
         @Path("diaryId") diaryId: Long,
     ): BaseResponse<Unit>
+
+    @PATCH("/api/v1/diaries/{diaryId}/ad-watch")
+    suspend fun patchAdWatch(
+        @Path("diaryId") diaryId: Long,
+    ): BaseResponse<Unit>
 }

--- a/presentation/diaryfeedback/build.gradle.kts
+++ b/presentation/diaryfeedback/build.gradle.kts
@@ -24,6 +24,6 @@ android {
 }
 
 dependencies {
-    implementation(projects.data.diary)
     implementation(projects.core.ads)
+    implementation(projects.data.diary)
 }

--- a/presentation/diaryfeedback/build.gradle.kts
+++ b/presentation/diaryfeedback/build.gradle.kts
@@ -25,4 +25,5 @@ android {
 
 dependencies {
     implementation(projects.data.diary)
+    implementation(projects.core.ads)
 }

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
@@ -199,7 +199,9 @@ internal fun DiaryFeedbackRoute(
             )
         }
 
-        else -> Unit
+        is UiState.Loading -> HilingualLoadingIndicator()
+
+        else -> {}
     }
 }
 

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
@@ -111,7 +111,7 @@ internal fun DiaryFeedbackRoute(
                     showInterstitialAd(
                         activity = activity,
                         adUnitId = BuildConfig.ADMOB_INTERSTITIAL_UNIT_ID,
-                        onAdDismissed = { viewModel.fetchAdWatched() },
+                        onAdDismissed = viewModel::fetchAdWatched,
                     )
                 } else {
                     viewModel.fetchAdWatched()

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
@@ -16,6 +16,7 @@
 package com.hilingual.presentation.diaryfeedback
 
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -41,6 +42,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hilingual.core.ads.BuildConfig
+import com.hilingual.core.ads.interstitial.showInterstitialAd
 import com.hilingual.core.common.analytics.FakeTracker
 import com.hilingual.core.common.analytics.Page.FEEDBACK
 import com.hilingual.core.common.analytics.Tracker
@@ -80,6 +83,7 @@ internal fun DiaryFeedbackRoute(
     viewModel: DiaryFeedbackViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
+    val activity = LocalActivity.current
 
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     var isImageDetailVisible by remember { mutableStateOf(false) }
@@ -98,7 +102,20 @@ internal fun DiaryFeedbackRoute(
 
     viewModel.sideEffect.collectSideEffect {
         when (it) {
-            is DiaryFeedbackSideEffect.ShowErrorDialog -> dialogTrigger.show(onClick = navigateUp)
+            is DiaryFeedbackSideEffect.ShowInterstitialAd -> {
+                if (activity != null) {
+                    showInterstitialAd(
+                        activity = activity,
+                        adUnitId = BuildConfig.ADMOB_INTERSTITIAL_UNIT_ID,
+                        onAdDismissed = { viewModel.onAdWatched() },
+                    )
+                } else {
+                    viewModel.onAdWatched()
+                }
+            }
+
+            is DiaryFeedbackSideEffect.ShowErrorDialog ->
+                dialogTrigger.show(onClick = navigateUp)
 
             is DiaryFeedbackSideEffect.ShowDiaryPublishSnackbar -> {
                 messageController(
@@ -143,40 +160,47 @@ internal fun DiaryFeedbackRoute(
         tracker.logEvent(trigger = TriggerType.VIEW, page = FEEDBACK, event = "page")
     }
 
-    DiaryFeedbackScreen(
-        paddingValues = paddingValues,
-        uiState = state,
-        diaryId = viewModel.diaryId,
-        onBackClick = {
-            tracker.logEvent(
-                trigger = TriggerType.CLICK,
-                page = FEEDBACK,
-                event = "back_feedback",
-                properties = mapOf(
-                    "entry_id" to viewModel.diaryId,
-                    "back_source" to "ui_button",
-                ),
+    when (val currentState = state) {
+        is UiState.Success -> {
+            if (!currentState.data.isAdWatched) return
+            DiaryFeedbackScreen(
+                paddingValues = paddingValues,
+                uiState = currentState,
+                diaryId = viewModel.diaryId,
+                onBackClick = {
+                    tracker.logEvent(
+                        trigger = TriggerType.CLICK,
+                        page = FEEDBACK,
+                        event = "back_feedback",
+                        properties = mapOf(
+                            "entry_id" to viewModel.diaryId,
+                            "back_source" to "ui_button",
+                        ),
+                    )
+                    navigateUp()
+                },
+                onReportClick = { context.launchCustomTabs(UrlConstant.FEEDBACK_REPORT) },
+                isImageDetailVisible = isImageDetailVisible,
+                onChangeImageDetailVisible = { isImageDetailVisible = !isImageDetailVisible },
+                onToggleIsPublished = { isPublished ->
+                    if (isPublished) {
+                        tracker.logEvent(
+                            trigger = TriggerType.CLICK,
+                            page = FEEDBACK,
+                            event = "submitted_post_diary",
+                            properties = mapOf("entry_id" to viewModel.diaryId),
+                        )
+                    }
+                    viewModel.toggleIsPublished(isPublished)
+                },
+                onToggleBookmark = viewModel::toggleBookmark,
+                onDeleteDiary = viewModel::deleteDiary,
+                tracker = tracker,
             )
-            navigateUp()
-        },
-        onReportClick = { context.launchCustomTabs(UrlConstant.FEEDBACK_REPORT) },
-        isImageDetailVisible = isImageDetailVisible,
-        onChangeImageDetailVisible = { isImageDetailVisible = !isImageDetailVisible },
-        onToggleIsPublished = { isPublished ->
-            if (isPublished) {
-                tracker.logEvent(
-                    trigger = TriggerType.CLICK,
-                    page = FEEDBACK,
-                    event = "submitted_post_diary",
-                    properties = mapOf("entry_id" to viewModel.diaryId),
-                )
-            }
-            viewModel.toggleIsPublished(isPublished)
-        },
-        onToggleBookmark = viewModel::toggleBookmark,
-        onDeleteDiary = viewModel::deleteDiary,
-        tracker = tracker,
-    )
+        }
+
+        else -> Unit
+    }
 }
 
 @Composable

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
@@ -92,6 +92,10 @@ internal fun DiaryFeedbackRoute(
     val messageController = LocalMessageController.current
     val tracker = LocalTracker.current
 
+    LaunchedEffect(Unit) {
+        viewModel.loadInitialData()
+    }
+
     BackHandler {
         if (isImageDetailVisible) {
             isImageDetailVisible = false
@@ -107,10 +111,10 @@ internal fun DiaryFeedbackRoute(
                     showInterstitialAd(
                         activity = activity,
                         adUnitId = BuildConfig.ADMOB_INTERSTITIAL_UNIT_ID,
-                        onAdDismissed = { viewModel.onAdWatched() },
+                        onAdDismissed = { viewModel.fetchAdWatched() },
                     )
                 } else {
-                    viewModel.onAdWatched()
+                    viewModel.fetchAdWatched()
                 }
             }
 
@@ -162,41 +166,44 @@ internal fun DiaryFeedbackRoute(
 
     when (val currentState = state) {
         is UiState.Success -> {
-            if (!currentState.data.isAdWatched) return
-            DiaryFeedbackScreen(
-                paddingValues = paddingValues,
-                uiState = currentState,
-                diaryId = viewModel.diaryId,
-                onBackClick = {
-                    tracker.logEvent(
-                        trigger = TriggerType.CLICK,
-                        page = FEEDBACK,
-                        event = "back_feedback",
-                        properties = mapOf(
-                            "entry_id" to viewModel.diaryId,
-                            "back_source" to "ui_button",
-                        ),
-                    )
-                    navigateUp()
-                },
-                onReportClick = { context.launchCustomTabs(UrlConstant.FEEDBACK_REPORT) },
-                isImageDetailVisible = isImageDetailVisible,
-                onChangeImageDetailVisible = { isImageDetailVisible = !isImageDetailVisible },
-                onToggleIsPublished = { isPublished ->
-                    if (isPublished) {
+            if (!currentState.data.isAdWatched) {
+                HilingualLoadingIndicator()
+            } else {
+                DiaryFeedbackScreen(
+                    paddingValues = paddingValues,
+                    uiState = currentState,
+                    diaryId = viewModel.diaryId,
+                    onBackClick = {
                         tracker.logEvent(
                             trigger = TriggerType.CLICK,
                             page = FEEDBACK,
-                            event = "submitted_post_diary",
-                            properties = mapOf("entry_id" to viewModel.diaryId),
+                            event = "back_feedback",
+                            properties = mapOf(
+                                "entry_id" to viewModel.diaryId,
+                                "back_source" to "ui_button",
+                            ),
                         )
-                    }
-                    viewModel.toggleIsPublished(isPublished)
-                },
-                onToggleBookmark = viewModel::toggleBookmark,
-                onDeleteDiary = viewModel::deleteDiary,
-                tracker = tracker,
-            )
+                        navigateUp()
+                    },
+                    onReportClick = { context.launchCustomTabs(UrlConstant.FEEDBACK_REPORT) },
+                    isImageDetailVisible = isImageDetailVisible,
+                    onChangeImageDetailVisible = { isImageDetailVisible = !isImageDetailVisible },
+                    onToggleIsPublished = { isPublished ->
+                        if (isPublished) {
+                            tracker.logEvent(
+                                trigger = TriggerType.CLICK,
+                                page = FEEDBACK,
+                                event = "submitted_post_diary",
+                                properties = mapOf("entry_id" to viewModel.diaryId),
+                            )
+                        }
+                        viewModel.toggleIsPublished(isPublished)
+                    },
+                    onToggleBookmark = viewModel::toggleBookmark,
+                    onDeleteDiary = viewModel::deleteDiary,
+                    tracker = tracker,
+                )
+            }
         }
 
         is UiState.Loading -> HilingualLoadingIndicator()

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackUiState.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackUiState.kt
@@ -30,6 +30,7 @@ import kotlinx.collections.immutable.toImmutableList
 internal data class DiaryFeedbackUiState(
     val writtenDate: String = "",
     val isPublished: Boolean = false,
+    val isAdWatched: Boolean = false,
     val diaryContent: DiaryContent = DiaryContent(),
     val feedbackList: ImmutableList<FeedbackContent> = persistentListOf(),
     val recommendExpressionList: ImmutableList<RecommendExpression> = persistentListOf(),

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackViewModel.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackViewModel.kt
@@ -19,6 +19,8 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
+import com.hilingual.core.ads.BuildConfig
+import com.hilingual.core.ads.manager.AdsPreloadManager
 import com.hilingual.core.common.extension.onLogFailure
 import com.hilingual.core.common.extension.updateSuccess
 import com.hilingual.core.common.util.UiState
@@ -45,6 +47,7 @@ import kotlinx.coroutines.launch
 internal class DiaryFeedbackViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val diaryRepository: DiaryRepository,
+    adsPreloadManager: AdsPreloadManager,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow<UiState<DiaryFeedbackUiState>>(UiState.Loading)
     val uiState: StateFlow<UiState<DiaryFeedbackUiState>> = _uiState.asStateFlow()
@@ -56,6 +59,7 @@ internal class DiaryFeedbackViewModel @Inject constructor(
 
     init {
         loadInitialData()
+        adsPreloadManager.preloadInterstitial(BuildConfig.ADMOB_INTERSTITIAL_UNIT_ID)
     }
 
     private fun loadInitialData() {
@@ -64,6 +68,9 @@ internal class DiaryFeedbackViewModel @Inject constructor(
                 requestDiaryFeedbackData()
             }.onSuccess { newUiState ->
                 _uiState.update { UiState.Success(newUiState) }
+                if (!newUiState.isAdWatched) {
+                    _sideEffect.emit(DiaryFeedbackSideEffect.ShowInterstitialAd)
+                }
             }.onLogFailure {
                 _uiState.update { UiState.Failure }
                 _sideEffect.emit(
@@ -85,12 +92,25 @@ internal class DiaryFeedbackViewModel @Inject constructor(
 
             DiaryFeedbackUiState(
                 isPublished = diaryResult.isPublished,
+                isAdWatched = diaryResult.isAdWatched,
                 writtenDate = diaryResult.writtenDate,
                 diaryContent = diaryResult.toState(),
                 feedbackList = feedbacksResult.map { it.toState() }.toImmutableList(),
                 recommendExpressionList = recommendExpressionsResult.map { it.toState() }.toImmutableList(),
             )
         }
+
+    fun onAdWatched() {
+        viewModelScope.launch {
+            diaryRepository.patchAdWatch(diaryId)
+                .onSuccess {
+                    _uiState.updateSuccess { it.copy(isAdWatched = true) }
+                }
+                .onLogFailure {
+                    _uiState.updateSuccess { it.copy(isAdWatched = true) }
+                }
+        }
+    }
 
     fun toggleIsPublished(isPublished: Boolean) {
         val currentState = _uiState.value
@@ -190,6 +210,7 @@ internal class DiaryFeedbackViewModel @Inject constructor(
 sealed interface DiaryFeedbackSideEffect {
     data object NavigateToHome : DiaryFeedbackSideEffect
     data object ShowErrorDialog : DiaryFeedbackSideEffect
+    data object ShowInterstitialAd : DiaryFeedbackSideEffect
     data class ShowDiaryPublishSnackbar(val message: String, val actionLabel: String) : DiaryFeedbackSideEffect
     data class ShowVocaOverflowSnackbar(val message: String, val actionLabel: String) : DiaryFeedbackSideEffect
     data class ShowToast(val message: String) : DiaryFeedbackSideEffect

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackViewModel.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackViewModel.kt
@@ -19,8 +19,6 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
-import com.hilingual.core.ads.BuildConfig
-import com.hilingual.core.ads.manager.AdsPreloadManager
 import com.hilingual.core.common.extension.onLogFailure
 import com.hilingual.core.common.extension.updateSuccess
 import com.hilingual.core.common.util.UiState
@@ -47,7 +45,6 @@ import kotlinx.coroutines.launch
 internal class DiaryFeedbackViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val diaryRepository: DiaryRepository,
-    adsPreloadManager: AdsPreloadManager,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow<UiState<DiaryFeedbackUiState>>(UiState.Loading)
     val uiState: StateFlow<UiState<DiaryFeedbackUiState>> = _uiState.asStateFlow()
@@ -57,12 +54,7 @@ internal class DiaryFeedbackViewModel @Inject constructor(
     private val _sideEffect = MutableSharedFlow<DiaryFeedbackSideEffect>()
     val sideEffect: SharedFlow<DiaryFeedbackSideEffect> = _sideEffect.asSharedFlow()
 
-    init {
-        loadInitialData()
-        adsPreloadManager.preloadInterstitial(BuildConfig.ADMOB_INTERSTITIAL_UNIT_ID)
-    }
-
-    private fun loadInitialData() {
+    fun loadInitialData() {
         viewModelScope.launch {
             suspendRunCatching {
                 requestDiaryFeedbackData()
@@ -100,14 +92,16 @@ internal class DiaryFeedbackViewModel @Inject constructor(
             )
         }
 
-    fun onAdWatched() {
+    fun fetchAdWatched() {
+        _uiState.updateSuccess { it.copy(isAdWatched = true) }
+
         viewModelScope.launch {
             diaryRepository.patchAdWatch(diaryId)
-                .onSuccess {
-                    _uiState.updateSuccess { it.copy(isAdWatched = true) }
-                }
                 .onLogFailure {
                     _uiState.updateSuccess { it.copy(isAdWatched = true) }
+                     /*TODO: 서버 동기화 실패 처리
+                     patchAdWatch API 실패 시 서버는 여전히 isAdWatched = false 상태입니다.
+                     WorkManager로 Sync 필요*/
                 }
         }
     }

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackViewModel.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackViewModel.kt
@@ -99,9 +99,11 @@ internal class DiaryFeedbackViewModel @Inject constructor(
             diaryRepository.patchAdWatch(diaryId)
                 .onLogFailure {
                     _uiState.updateSuccess { it.copy(isAdWatched = true) }
-                     /*TODO: 서버 동기화 실패 처리
-                     patchAdWatch API 실패 시 서버는 여전히 isAdWatched = false 상태입니다.
-                     WorkManager로 Sync 필요*/
+                    /*
+                     * TODO:: 서버 동기화 실패 처리
+                     * patchAdWatch API 실패 시 서버는 여전히 isAdWatched = false 상태입니다.
+                     * WorkManager로 Sync 필요
+                     */
                 }
         }
     }

--- a/presentation/diarywrite/build.gradle.kts
+++ b/presentation/diarywrite/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     implementation(libs.balloon.compose)
     implementation(projects.data.calendar)
     implementation(projects.data.diary)
+    implementation(projects.core.ads)
 
     implementation(libs.lottie)
 }

--- a/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/DiaryWriteViewModel.kt
+++ b/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/DiaryWriteViewModel.kt
@@ -51,7 +51,7 @@ internal class DiaryWriteViewModel @Inject constructor(
     private val diaryRepository: DiaryRepository,
     private val diaryLocalRepository: DiaryLocalRepository,
     private val textRecognitionRepository: TextRecognitionRepository,
-    adsPreloadManager: AdsPreloadManager
+    adsPreloadManager: AdsPreloadManager,
 ) : ViewModel() {
     private val route: DiaryWrite = savedStateHandle.toRoute<DiaryWrite>()
 

--- a/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/DiaryWriteViewModel.kt
+++ b/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/DiaryWriteViewModel.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
+import com.hilingual.core.ads.manager.AdsPreloadManager
 import com.hilingual.core.common.extension.onLogFailure
 import com.hilingual.core.common.util.UiState
 import com.hilingual.core.navigation.DiaryWriteMode
@@ -50,6 +51,7 @@ internal class DiaryWriteViewModel @Inject constructor(
     private val diaryRepository: DiaryRepository,
     private val diaryLocalRepository: DiaryLocalRepository,
     private val textRecognitionRepository: TextRecognitionRepository,
+    adsPreloadManager: AdsPreloadManager
 ) : ViewModel() {
     private val route: DiaryWrite = savedStateHandle.toRoute<DiaryWrite>()
 
@@ -68,6 +70,7 @@ internal class DiaryWriteViewModel @Inject constructor(
 
     init {
         getTopic(route.selectedDate)
+        adsPreloadManager.preloadInterstitial(BuildConfig.ADMOB_INTERSTITIAL_UNIT_ID)
 
         when (route.mode) {
             DiaryWriteMode.DEFAULT -> loadDiaryTemp()


### PR DESCRIPTION
## Related issue 🛠
- closed #730 

## Work Description ✏️

**:core:ads — 전면광고 인프라 구축**

- `AdsPreloadManager`에 `preloadInterstitial()` 추가
- `HilingualInterstitialAd.kt` 신규 생성 — 프리로드 캐시 hit 시 즉시 노출, miss 시 새로 로드 후 노출하는 폴백 로직 포함
- 광고 로드/표시 실패 시에도 `onAdFailed()`로 피드백 화면이 반드시 노출되도록 방어 처리

**data 레이어 — 서버 연동 준비**

- `DiaryContentModel`, `DiaryContentResponseDto`에 `isAdWatched` 필드 추가
- PATCH `/api/v1/diaries/{diaryId}/ad-watch` API 전 레이어 연결 완료
- 서버 미완성 상태이므로 `DiaryContentResponseDto.toModel()`에서 `isAdWatched = false`로 임시 고정

**DiaryFeedbackViewModel — 광고 상태 관리**

- 데이터 로드 완료 후 `isAdWatched == false`이면 `ShowInterstitialAd` SideEffect 발행
- `onAdWatched()` — 광고 정상 시청 시 patchAdWatch API 호출 후 `isAdWatched = true`로 업데이트

## Screenshot 📸

https://github.com/user-attachments/assets/903fc387-43e4-4574-8ce1-920403e91d62

## Uncompleted Tasks 😅
- [ ] 서버 연결 

## To Reviewers 📢
전면 광고 작업 완료했습니다! 광고 작업은 처음이라 더 좋은 방법 있다면 리뷰 남겨주세요! 그리고 프리로드는 피드백 Funnel의 진입점인 `DiaryWriteViewModel.init`에서 프리로드를 시작했습니다. 일기 작성 화면 진입 시점부터 백그라운드에서 광고를 미리 준비해두어 피드백 화면 진입 시 딜레이를 최소화하도록 해보았습니다!