### PR TITLE
[FIX/#739] Mark delete functionality as deprecated

### DIFF
--- a/data/diary/src/main/java/com/hilingual/data/diary/repository/DiaryRepository.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/repository/DiaryRepository.kt
@@ -50,6 +50,7 @@ interface DiaryRepository {
         diaryId: Long,
     ): Result<Unit>
 
+    @Deprecated("수정 기능이 도입되기 까지 지원 중단입니다.")
     suspend fun deleteDiary(
         diaryId: Long,
     ): Result<Unit>

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
@@ -58,7 +58,6 @@ import com.hilingual.core.designsystem.component.button.HilingualButton
 import com.hilingual.core.designsystem.component.button.HilingualFloatingButton
 import com.hilingual.core.designsystem.component.indicator.HilingualLoadingIndicator
 import com.hilingual.core.designsystem.theme.HilingualTheme
-import com.hilingual.core.ui.component.dialog.diary.DiaryDeleteDialog
 import com.hilingual.core.ui.component.dialog.diary.DiaryPublishDialog
 import com.hilingual.core.ui.component.dialog.diary.DiaryUnpublishDialog
 import com.hilingual.core.ui.component.item.diary.image.ModalImage

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
@@ -174,7 +174,7 @@ internal fun DiaryFeedbackRoute(
             viewModel.toggleIsPublished(isPublished)
         },
         onToggleBookmark = viewModel::toggleBookmark,
-        onDeleteDiary = viewModel::deleteDiary,
+        onDeleteDiary = { /* viewModel::deleteDiary 수정기능 도입까지 삭제 기능 지원중단 */ },
         tracker = tracker,
     )
 }
@@ -369,21 +369,23 @@ private fun DiaryFeedbackScreen(
         )
     }
 
-    DiaryDeleteDialog(
-        isVisible = isDeleteDialogVisible,
-        onDismiss = { isDeleteDialogVisible = false },
-        onDeleteClick = {
-            isDeleteDialogVisible = false
-            onDeleteDiary()
-        },
-    )
+//    수정기능 도입까지 삭제 기능 지원중단
+//    DiaryDeleteDialog(
+//        isVisible = isDeleteDialogVisible,
+//        onDismiss = { isDeleteDialogVisible = false },
+//        onDeleteClick = {
+//            isDeleteDialogVisible = false
+//            onDeleteDiary()
+//        },
+//    )
 
     FeedbackMenuBottomSheet(
         isVisible = isReportBottomSheetVisible,
         onDismiss = { isReportBottomSheetVisible = false },
         onDeleteClick = {
-            isReportBottomSheetVisible = false
-            isDeleteDialogVisible = true
+//            수정기능 도입까지 삭제 기능 지원중단
+//            isReportBottomSheetVisible = false
+//            isDeleteDialogVisible = true
         },
         onReportClick = {
             isReportBottomSheetVisible = false

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackViewModel.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackViewModel.kt
@@ -121,6 +121,7 @@ internal class DiaryFeedbackViewModel @Inject constructor(
         }
     }
 
+    @Deprecated("수정 기능이 도입되기 까지 지원 중단입니다.")
     fun deleteDiary() {
         viewModelScope.launch {
             diaryRepository.deleteDiary(diaryId = diaryId).onSuccess {

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/component/FeedbackMenuBottomSheet.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/component/FeedbackMenuBottomSheet.kt
@@ -42,12 +42,13 @@ internal fun FeedbackMenuBottomSheet(
         onDismiss = onDismiss,
         modifier = modifier,
     ) {
-        HilingualMenuBottomSheetItem(
-            text = "삭제하기",
-            iconResId = DesignSystemR.drawable.ic_delete_24,
-            onClick = onDeleteClick,
-            textColor = HilingualTheme.colors.alertRed,
-        )
+//        수정기능 도입까지 삭제 기능 지원중단
+//        HilingualMenuBottomSheetItem(
+//            text = "삭제하기",
+//            iconResId = DesignSystemR.drawable.ic_delete_24,
+//            onClick = onDeleteClick,
+//            textColor = HilingualTheme.colors.alertRed,
+//        )
 
         HilingualMenuBottomSheetItem(
             text = "AI 피드백 신고하기",

--- a/presentation/home/src/main/java/com/hilingual/presentation/home/HomeScreen.kt
+++ b/presentation/home/src/main/java/com/hilingual/presentation/home/HomeScreen.kt
@@ -188,7 +188,7 @@ internal fun HomeRoute(
                     )
                     navigateToDiaryFeedback(diaryId)
                 },
-                onDeleteClick = viewModel::deleteDiary,
+                onDeleteClick = { /* viewModel::deleteDiary 수정기능 도입까지 삭제 기능 지원중단 */ },
                 onPublishClick = viewModel::publishDiary,
                 onUnpublishClick = viewModel::unpublishDiary,
                 tracker = tracker,
@@ -322,7 +322,7 @@ private fun HomeScreen(
                                         homeState.hideMoreMenu()
                                     }
                                 },
-                                onDeleteClick = { onDeleteClick(diary.diaryId) },
+                                onDeleteClick = { /* onDeleteClick(diary.diaryId) 수정기능 도입까지 삭제 기능 지원중단 */ },
                                 onPublishClick = { onPublishClick(diary.diaryId) },
                                 onUnpublishClick = { onUnpublishClick(diary.diaryId) },
                             )

--- a/presentation/home/src/main/java/com/hilingual/presentation/home/HomeViewModel.kt
+++ b/presentation/home/src/main/java/com/hilingual/presentation/home/HomeViewModel.kt
@@ -264,6 +264,7 @@ class HomeViewModel @Inject constructor(
         }
     }
 
+    @Deprecated("수정 기능이 도입되기 까지 지원 중단입니다.")
     fun deleteDiary(diaryId: Long) {
         val currentState = uiState.value
         if (currentState !is UiState.Success) return

--- a/presentation/home/src/main/java/com/hilingual/presentation/home/component/footer/HomeDropDownMenu.kt
+++ b/presentation/home/src/main/java/com/hilingual/presentation/home/component/footer/HomeDropDownMenu.kt
@@ -69,15 +69,17 @@ internal fun HomeDropDownMenu(
             thickness = 1.dp,
             color = HilingualTheme.colors.gray200,
         )
-        HilingualDropdownMenuItem(
-            text = "삭제하기",
-            iconResId = R.drawable.ic_delete_24,
-            onClick = {
-                deleteDialogVisible = true
-                onExpandedChange(false)
-            },
-            textColor = HilingualTheme.colors.alertRed,
-        )
+
+//        수정기능 도입까지 삭제 기능 지원중단
+//        HilingualDropdownMenuItem(
+//            text = "삭제하기",
+//            iconResId = R.drawable.ic_delete_24,
+//            onClick = {
+//                deleteDialogVisible = true
+//                onExpandedChange(false)
+//            },
+//            textColor = HilingualTheme.colors.alertRed,
+//        )
     }
 
     when {

--- a/presentation/home/src/main/java/com/hilingual/presentation/home/component/onboarding/HomeOnboardingContent.kt
+++ b/presentation/home/src/main/java/com/hilingual/presentation/home/component/onboarding/HomeOnboardingContent.kt
@@ -50,10 +50,11 @@ private val onboardingPages = persistentListOf(
         "오늘의 일기는\n48시간 동안 작성할 수 있어요.",
         R.drawable.img_onboarding_bottomsheet_1,
     ),
-    HomeOnboarding(
-        "일기를 삭제 한 날에는\n다시 일기를 작성할 수 없어요.",
-        R.drawable.img_onboarding_bottomsheet_2,
-    ),
+//    수정기능 도입까지 삭제 기능 지원중단
+//    HomeOnboarding(
+//        "일기를 삭제 한 날에는\n다시 일기를 작성할 수 없어요.",
+//        R.drawable.img_onboarding_bottomsheet_2,
+//    ),
     HomeOnboarding(
         "작성한 일기는\n커뮤니티에 공유할 수 있어요.",
         R.drawable.img_onboarding_bottomsheet_3,


### PR DESCRIPTION
## Related issue 🛠
- closed #739

## Work Description ✏️
- DiaryRepository의 `deleteDiary()` 함수 Deprecated 처리
- 관련된 삭제 로직과 UI 주석처리
- 홈 온보딩에서 삭제 관련 정보 주석처리

## Screenshot 📸
| 홈 온보딩 | 삭제 플로우 |
|--------|--------|
| <video src  = "https://github.com/user-attachments/assets/d9c457ca-1306-4f75-ac73-47e192445a5c"> </video> | <video src="https://github.com/user-attachments/assets/30438e95-807a-437e-bda5-5a31af933c33"></video> | 

## To Reviewers 📢
자세한 논의는 회의 스레드 참고 바랍니다👍🏻