### PR TITLE
[REF/#737] Improve padding value application

### DIFF
--- a/core/common/src/main/java/com/hilingual/core/common/extension/ModfierExt.kt
+++ b/core/common/src/main/java/com/hilingual/core/common/extension/ModfierExt.kt
@@ -24,6 +24,8 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -136,3 +138,8 @@ fun Modifier.statusBarColor(backgroundColor: Color): Modifier = composed {
         )
     }
 }
+
+fun Modifier.subScreenPadding(paddingValues: PaddingValues) =
+    this
+        .padding(top = paddingValues.calculateTopPadding())
+        .navigationBarsPadding()

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
@@ -49,6 +49,7 @@ import com.hilingual.core.common.constant.UrlConstant
 import com.hilingual.core.common.extension.collectSideEffect
 import com.hilingual.core.common.extension.launchCustomTabs
 import com.hilingual.core.common.extension.statusBarColor
+import com.hilingual.core.common.extension.subScreenPadding
 import com.hilingual.core.common.model.HilingualMessage
 import com.hilingual.core.common.provider.LocalTracker
 import com.hilingual.core.common.trigger.LocalDialogTrigger
@@ -233,7 +234,7 @@ private fun DiaryFeedbackScreen(
             .fillMaxSize()
             .statusBarColor(HilingualTheme.colors.white)
             .background(HilingualTheme.colors.white)
-            .padding(paddingValues),
+            .subScreenPadding(paddingValues),
     ) {
         BackAndMoreTopAppBar(
             title = "일기장",

--- a/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/DiaryWriteScreen.kt
+++ b/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/DiaryWriteScreen.kt
@@ -67,6 +67,7 @@ import com.hilingual.core.common.extension.advancedImePadding
 import com.hilingual.core.common.extension.collectSideEffect
 import com.hilingual.core.common.extension.noRippleClickable
 import com.hilingual.core.common.extension.statusBarColor
+import com.hilingual.core.common.extension.subScreenPadding
 import com.hilingual.core.common.model.HilingualMessage
 import com.hilingual.core.common.provider.LocalTracker
 import com.hilingual.core.common.trigger.LocalDialogTrigger
@@ -362,7 +363,7 @@ private fun DiaryWriteScreen(
                 .statusBarColor(white)
                 .background(HilingualTheme.colors.white)
                 .fillMaxSize()
-                .padding(paddingValues)
+                .subScreenPadding(paddingValues)
                 .addFocusCleaner(focusManager),
         ) {
             BackTopAppBar(

--- a/presentation/feed/src/main/java/com/hilingual/presentation/feed/search/FeedSearchScreen.kt
+++ b/presentation/feed/src/main/java/com/hilingual/presentation/feed/search/FeedSearchScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hilingual.core.common.extension.subScreenPadding
 import com.hilingual.core.common.util.UiState
 import com.hilingual.core.designsystem.component.indicator.HilingualLoadingIndicator
 import com.hilingual.core.designsystem.theme.HilingualTheme
@@ -89,7 +90,7 @@ private fun FeedSearchScreen(
         modifier = Modifier
             .background(HilingualTheme.colors.white)
             .fillMaxSize()
-            .padding(paddingValues),
+            .subScreenPadding(paddingValues),
     ) {
         FeedSearchHeader(
             searchWord = { searchWord },

--- a/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/FeedDiaryScreen.kt
+++ b/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/FeedDiaryScreen.kt
@@ -47,6 +47,7 @@ import com.hilingual.core.common.analytics.TriggerType
 import com.hilingual.core.common.constant.UrlConstant
 import com.hilingual.core.common.extension.collectSideEffect
 import com.hilingual.core.common.extension.launchCustomTabs
+import com.hilingual.core.common.extension.subScreenPadding
 import com.hilingual.core.common.model.HilingualMessage
 import com.hilingual.core.common.provider.LocalTracker
 import com.hilingual.core.common.trigger.LocalDialogTrigger
@@ -212,7 +213,7 @@ private fun FeedDiaryScreen(
         modifier = Modifier
             .fillMaxSize()
             .background(HilingualTheme.colors.white)
-            .padding(paddingValues),
+            .subScreenPadding(paddingValues),
     ) {
         BackAndMoreTopAppBar(
             onBackClicked = onBackClick,

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/FeedProfileScreen.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/FeedProfileScreen.kt
@@ -53,6 +53,7 @@ import com.hilingual.core.common.analytics.TriggerType
 import com.hilingual.core.common.constant.UrlConstant
 import com.hilingual.core.common.extension.collectSideEffect
 import com.hilingual.core.common.extension.launchCustomTabs
+import com.hilingual.core.common.extension.subScreenPadding
 import com.hilingual.core.common.model.HilingualMessage
 import com.hilingual.core.common.provider.LocalTracker
 import com.hilingual.core.common.trigger.LocalDialogTrigger
@@ -222,7 +223,7 @@ private fun FeedProfileScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(paddingValues),
+                .subScreenPadding(paddingValues),
         ) {
             FeedProfileTopBar(
                 isMine = profile.isMine,

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/follow/FollowListScreen.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/follow/FollowListScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
@@ -35,6 +34,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hilingual.core.common.extension.collectSideEffect
+import com.hilingual.core.common.extension.subScreenPadding
 import com.hilingual.core.common.trigger.LocalDialogTrigger
 import com.hilingual.core.common.util.UiState
 import com.hilingual.core.designsystem.component.indicator.HilingualLoadingIndicator
@@ -110,7 +110,7 @@ private fun FollowListScreen(
         modifier = modifier
             .fillMaxSize()
             .background(HilingualTheme.colors.white)
-            .padding(paddingValues),
+            .subScreenPadding(paddingValues),
     ) {
         BackTopAppBar(
             title = "팔로우",

--- a/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/blockeduser/BlockedUserScreen.kt
+++ b/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/blockeduser/BlockedUserScreen.kt
@@ -45,6 +45,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hilingual.core.common.extension.collectSideEffect
 import com.hilingual.core.common.extension.statusBarColor
+import com.hilingual.core.common.extension.subScreenPadding
 import com.hilingual.core.common.trigger.LocalDialogTrigger
 import com.hilingual.core.common.util.UiState
 import com.hilingual.core.designsystem.R
@@ -103,7 +104,7 @@ private fun BlockedUserScreen(
             .fillMaxSize()
             .statusBarColor(HilingualTheme.colors.white)
             .background(HilingualTheme.colors.white)
-            .padding(paddingValues),
+            .subScreenPadding(paddingValues),
     ) {
         BackTopAppBar(
             title = "차단한 유저",

--- a/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/licenses/OssLicensesScreen.kt
+++ b/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/licenses/OssLicensesScreen.kt
@@ -19,10 +19,10 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import com.hilingual.core.common.extension.subScreenPadding
 import com.hilingual.core.designsystem.theme.HilingualTheme
 import com.hilingual.core.ui.component.topappbar.BackTopAppBar
 import com.mikepenz.aboutlibraries.ui.compose.android.produceLibraries
@@ -39,7 +39,7 @@ fun OssLicensesScreen(
         modifier = Modifier
             .fillMaxSize()
             .background(HilingualTheme.colors.white)
-            .padding(paddingValues),
+            .subScreenPadding(paddingValues),
     ) {
         BackTopAppBar(
             title = "오픈소스 라이선스",

--- a/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/profileedit/ProfileEditScreen.kt
+++ b/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/profileedit/ProfileEditScreen.kt
@@ -43,6 +43,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hilingual.core.common.extension.collectSideEffect
 import com.hilingual.core.common.extension.noRippleClickable
 import com.hilingual.core.common.extension.statusBarColor
+import com.hilingual.core.common.extension.subScreenPadding
 import com.hilingual.core.common.model.HilingualMessage
 import com.hilingual.core.common.provider.LocalAppRestarter
 import com.hilingual.core.common.trigger.LocalDialogTrigger
@@ -117,7 +118,7 @@ private fun ProfileEditScreen(
             .fillMaxSize()
             .statusBarColor(HilingualTheme.colors.white)
             .background(HilingualTheme.colors.white)
-            .padding(paddingValues),
+            .subScreenPadding(paddingValues),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         TitleCenterAlignedTopAppBar(

--- a/presentation/notification/src/main/java/com/hilingual/presentation/notification/main/NotificationScreen.kt
+++ b/presentation/notification/src/main/java/com/hilingual/presentation/notification/main/NotificationScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
@@ -31,6 +30,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hilingual.core.common.extension.subScreenPadding
 import com.hilingual.core.designsystem.theme.HilingualTheme
 import com.hilingual.presentation.notification.main.component.NotificationTapRow
 import com.hilingual.presentation.notification.main.component.NotificationTopAppBar
@@ -110,7 +110,7 @@ private fun NotificationScreen(
         modifier = modifier
             .fillMaxSize()
             .background(HilingualTheme.colors.white)
-            .padding(paddingValues),
+            .subScreenPadding(paddingValues),
     ) {
         NotificationTopAppBar(
             onBackClick = onBackClick,


### PR DESCRIPTION
## Related issue 🛠
- closed #737 

## Work Description ✏️
- 상위의 paddingValue의 top만 적용하는 Modifier 확장함수 구현
- 메인탭, 바텀 네비게이션과 관여되지 않는 화면을 제외하고 모두 적용

## Screenshot 📸
| BEFORE | AFTER |
|--------|--------|
|<video src = "https://github.com/user-attachments/assets/14e39f3c-4954-4ec9-bb86-6b1c66e47fe5"> </video> | <video src = "https://github.com/user-attachments/assets/8dd8c682-a3a2-4908-b203-1b82a777e88e"> </video> | 

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
3가지의 경우에 해당될 경우 제외했습니다.
   1. 바텀바 나타나기 전 화면: Splash, Onboarding, Auth, SignUp 관련 파일들은 수정되지 않았습니다.
   2. 바텀바가 보여야 하는 화면: 메인 탭인 Home, Voca, Feed, MyPage의 메인 스크린들은 기존 padding(paddingValues)를 유지합니다.
   3. 이미 사라진 후의 화면: DiaryFeedbackStatusScreen 등 서브 화면의 서브 화면들은 제외되었습니다. (이미 바텀바가 없는 상태에서 진입하므로 튈 일이 없음)