### PR TITLE
[FEAT/#741] 로그인 / 디바이스 api 구현

### DIFF
--- a/app/src/main/java/com/hilingual/App.kt
+++ b/app/src/main/java/com/hilingual/App.kt
@@ -21,11 +21,15 @@ import androidx.appcompat.app.AppCompatDelegate
 import coil3.ImageLoader
 import coil3.SingletonImageLoader
 import com.hilingual.core.ads.initializer.AdsInitializer
+import com.hilingual.core.common.app.DeviceInfoProvider
 import com.hilingual.core.common.util.HilingualReleaseTree
 import com.hilingual.core.work.scheduler.HilingualWorkManagerConfigurator
 import dagger.Lazy
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import timber.log.Timber
 
 @HiltAndroidApp
@@ -39,6 +43,9 @@ class App : Application(), SingletonImageLoader.Factory {
     @Inject
     lateinit var adsInitializer: AdsInitializer
 
+    @Inject
+    lateinit var deviceInfoProvider: DeviceInfoProvider
+
     override fun onCreate() {
         super.onCreate()
         SingletonImageLoader.setSafe { imageLoader.get() }
@@ -47,6 +54,10 @@ class App : Application(), SingletonImageLoader.Factory {
         initTimber()
         initWorkManager()
         initAds()
+
+        CoroutineScope(Dispatchers.IO).launch {
+            deviceInfoProvider.getUuid()
+        }
     }
 
     override fun newImageLoader(context: Context): ImageLoader = imageLoader.get()

--- a/app/src/main/java/com/hilingual/app/DeviceInfoProviderImpl.kt
+++ b/app/src/main/java/com/hilingual/app/DeviceInfoProviderImpl.kt
@@ -19,12 +19,18 @@ import android.content.Context
 import android.os.Build
 import com.hilingual.core.common.app.DeviceInfoProvider
 import com.hilingual.core.common.extension.appVersionName
+import com.hilingual.data.auth.datasource.DeviceInfoLocalDataSource
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
+import kotlinx.coroutines.runBlocking
 
 internal class DeviceInfoProviderImpl @Inject constructor(
     @ApplicationContext private val context: Context,
+    private val deviceInfoLocalDataSource: DeviceInfoLocalDataSource,
 ) : DeviceInfoProvider {
+
+    @Volatile
+    private var cachedUuid: String? = null
 
     override fun getDeviceName(): String = Build.MODEL
 
@@ -40,4 +46,16 @@ internal class DeviceInfoProviderImpl @Inject constructor(
     override fun getRole(): String = "USER"
 
     override fun getOsType(): String = "Android"
+
+    override fun getUuid(): String {
+        if (cachedUuid != null) return cachedUuid!!
+
+        return synchronized(this) {
+            cachedUuid ?: runBlocking {
+                deviceInfoLocalDataSource.getDeviceUuid().also {
+                    cachedUuid = it
+                }
+            }
+        }
+    }
 }

--- a/core/common/src/main/java/com/hilingual/core/common/app/DeviceInfoProvider.kt
+++ b/core/common/src/main/java/com/hilingual/core/common/app/DeviceInfoProvider.kt
@@ -29,4 +29,6 @@ interface DeviceInfoProvider {
     fun getRole(): String
 
     fun getOsType(): String
+
+    fun getUuid(): String
 }

--- a/data/auth/src/main/java/com/hilingual/data/auth/datasource/DeviceInfoLocalDataSource.kt
+++ b/data/auth/src/main/java/com/hilingual/data/auth/datasource/DeviceInfoLocalDataSource.kt
@@ -1,0 +1,5 @@
+package com.hilingual.data.auth.datasource
+
+interface DeviceInfoLocalDataSource {
+    suspend fun getDeviceUuid(): String
+}

--- a/data/auth/src/main/java/com/hilingual/data/auth/datasourceimpl/DeviceInfoLocalDatasourceImpl.kt
+++ b/data/auth/src/main/java/com/hilingual/data/auth/datasourceimpl/DeviceInfoLocalDatasourceImpl.kt
@@ -1,0 +1,36 @@
+package com.hilingual.data.auth.datasourceimpl
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.hilingual.data.auth.datasource.DeviceInfoLocalDataSource
+import com.hilingual.data.auth.di.qualifier.DeviceInfoDataStore
+import jakarta.inject.Inject
+import java.util.UUID
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+
+class DeviceInfoLocalDatasourceImpl @Inject constructor(
+    @DeviceInfoDataStore private val deviceInfoDataStore: DataStore<Preferences>,
+) : DeviceInfoLocalDataSource {
+    private object DeviceInfoDataStoreKey {
+        val DEVICE_UUID = stringPreferencesKey("device_uuid")
+    }
+
+    override suspend fun getDeviceUuid(): String {
+        val uuid = deviceInfoDataStore.data
+            .map { it[DeviceInfoDataStoreKey.DEVICE_UUID] }
+            .first()
+
+        if (uuid != null) return uuid
+
+        return UUID.randomUUID().toString().also { saveDeviceUuid(it) }
+    }
+
+    private suspend fun saveDeviceUuid(uuid: String) {
+        deviceInfoDataStore.edit { preferences ->
+            preferences[DeviceInfoDataStoreKey.DEVICE_UUID] = uuid
+        }
+    }
+}

--- a/data/auth/src/main/java/com/hilingual/data/auth/di/AuthDataStoreModule.kt
+++ b/data/auth/src/main/java/com/hilingual/data/auth/di/AuthDataStoreModule.kt
@@ -2,7 +2,9 @@ package com.hilingual.data.auth.di
 
 import android.content.Context
 import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
 import com.hilingual.core.localstorage.builder.DataStoreBuilder
+import com.hilingual.data.auth.di.qualifier.DeviceInfoDataStore
 import com.hilingual.data.auth.di.qualifier.TokenDataStore
 import com.hilingual.data.auth.localstorage.model.TokenPreferences
 import dagger.Module
@@ -17,6 +19,7 @@ import javax.inject.Singleton
 object AuthDataStoreModule {
 
     private const val ENCRYPTED_USER_PREFS = "encrypted_user_prefs.bin"
+    private const val DEVICE_INFO_PREFS = "device_info_prefs"
 
     @Provides
     @Singleton
@@ -28,5 +31,15 @@ object AuthDataStoreModule {
         fileName = ENCRYPTED_USER_PREFS,
         kSerializer = TokenPreferences.serializer(),
         defaultValue = TokenPreferences(),
+    )
+
+    @Provides
+    @Singleton
+    @DeviceInfoDataStore
+    fun provideUserInfoDataStore(
+        @ApplicationContext context: Context,
+    ): DataStore<Preferences> = DataStoreBuilder.createPreferencesDataStore(
+        context = context,
+        name = DEVICE_INFO_PREFS,
     )
 }

--- a/data/auth/src/main/java/com/hilingual/data/auth/di/DataSourceModule.kt
+++ b/data/auth/src/main/java/com/hilingual/data/auth/di/DataSourceModule.kt
@@ -20,9 +20,11 @@ import androidx.credentials.CredentialManager
 import com.hilingual.core.network.auth.TokenProvider
 import com.hilingual.data.auth.datasource.AuthLocalDataSource
 import com.hilingual.data.auth.datasource.AuthRemoteDataSource
+import com.hilingual.data.auth.datasource.DeviceInfoLocalDataSource
 import com.hilingual.data.auth.datasource.GoogleAuthDataSource
 import com.hilingual.data.auth.datasourceimpl.AuthLocalDataSourceImpl
 import com.hilingual.data.auth.datasourceimpl.AuthRemoteDataSourceImpl
+import com.hilingual.data.auth.datasourceimpl.DeviceInfoLocalDatasourceImpl
 import com.hilingual.data.auth.datasourceimpl.GoogleAuthDataSourceImpl
 import dagger.Binds
 import dagger.Module
@@ -52,6 +54,12 @@ internal abstract class DataSourceModule {
     abstract fun bindAuthLocalDataSource(
         authLocalDataSourceImpl: AuthLocalDataSourceImpl,
     ): AuthLocalDataSource
+
+    @Binds
+    @Singleton
+    abstract fun bindDeviceInfoLocalDataSource(
+        deviceInfoLocalDatasourceImpl: DeviceInfoLocalDatasourceImpl,
+    ): DeviceInfoLocalDataSource
 
     @Binds
     @Singleton

--- a/data/auth/src/main/java/com/hilingual/data/auth/di/qualifier/DeviceInfoDataStore.kt
+++ b/data/auth/src/main/java/com/hilingual/data/auth/di/qualifier/DeviceInfoDataStore.kt
@@ -1,0 +1,7 @@
+package com.hilingual.data.auth.di.qualifier
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class DeviceInfoDataStore

--- a/data/auth/src/main/java/com/hilingual/data/auth/dto/request/LoginRequestDto.kt
+++ b/data/auth/src/main/java/com/hilingual/data/auth/dto/request/LoginRequestDto.kt
@@ -24,14 +24,6 @@ data class LoginRequestDto(
     val provider: String,
     @SerialName("role")
     val role: String,
-    @SerialName("deviceName")
-    val deviceName: String,
-    @SerialName("deviceType")
-    val deviceType: String,
-    @SerialName("osType")
-    val osType: String,
-    @SerialName("osVersion")
-    val osVersion: String,
-    @SerialName("appVersion")
-    val appVersion: String,
+    @SerialName("deviceUuid")
+    val deviceUuid: String,
 )

--- a/data/auth/src/main/java/com/hilingual/data/auth/repositoryimpl/AuthRepositoryImpl.kt
+++ b/data/auth/src/main/java/com/hilingual/data/auth/repositoryimpl/AuthRepositoryImpl.kt
@@ -69,12 +69,8 @@ internal class AuthRepositoryImpl @Inject constructor(
     }
 
     private fun DeviceInfoProvider.toLoginRequestDto() = LoginRequestDto(
-        provider = this.getProvider(),
-        role = this.getRole(),
-        deviceName = this.getDeviceName(),
-        deviceType = this.getDeviceType(),
-        osType = this.getOsType(),
-        osVersion = this.getOsVersion(),
-        appVersion = this.getAppVersion(),
+        provider = getProvider(),
+        role = getRole(),
+        deviceUuid = getUuid(),
     )
 }

--- a/data/user/src/main/java/com/hilingual/data/user/datasource/UserRemoteDataSource.kt
+++ b/data/user/src/main/java/com/hilingual/data/user/datasource/UserRemoteDataSource.kt
@@ -16,6 +16,7 @@
 package com.hilingual.data.user.datasource
 
 import com.hilingual.core.network.model.BaseResponse
+import com.hilingual.data.user.dto.request.PutDeviceInfoRequestDto
 import com.hilingual.data.user.dto.response.follow.FollowerResponseDto
 import com.hilingual.data.user.dto.response.follow.FollowingResponseDto
 import com.hilingual.data.user.dto.response.notification.NotificationDetailResponseDto
@@ -72,4 +73,6 @@ interface UserRemoteDataSource {
     suspend fun updateNotificationSetting(notiType: String): BaseResponse<NotificationSettingsResponseDto>
 
     suspend fun updateProfileImage(fileKey: String?): BaseResponse<Unit>
+
+    suspend fun putDeviceInfo(putDeviceInfoRequestDto: PutDeviceInfoRequestDto): BaseResponse<Unit>
 }

--- a/data/user/src/main/java/com/hilingual/data/user/datasourceimpl/UserRemoteDataSourceImpl.kt
+++ b/data/user/src/main/java/com/hilingual/data/user/datasourceimpl/UserRemoteDataSourceImpl.kt
@@ -3,6 +3,7 @@ package com.hilingual.data.user.datasourceimpl
 import com.hilingual.core.network.model.BaseResponse
 import com.hilingual.data.user.datasource.UserRemoteDataSource
 import com.hilingual.data.user.dto.request.ImageRequestDto
+import com.hilingual.data.user.dto.request.PutDeviceInfoRequestDto
 import com.hilingual.data.user.dto.request.RegisterProfileRequestDto
 import com.hilingual.data.user.dto.request.UpdateProfileImageRequestDto
 import com.hilingual.data.user.dto.response.follow.FollowerResponseDto
@@ -103,4 +104,7 @@ internal class UserRemoteDataSourceImpl @Inject constructor(
             ),
         )
     }
+
+    override suspend fun putDeviceInfo(putDeviceInfoRequestDto: PutDeviceInfoRequestDto): BaseResponse<Unit> =
+        userService.putDeviceInfo(putDeviceInfoRequestDto)
 }

--- a/data/user/src/main/java/com/hilingual/data/user/dto/request/PutDeviceInfoRequestDto.kt
+++ b/data/user/src/main/java/com/hilingual/data/user/dto/request/PutDeviceInfoRequestDto.kt
@@ -1,0 +1,22 @@
+package com.hilingual.data.user.dto.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PutDeviceInfoRequestDto(
+    @SerialName("timezone")
+    val timezone: String,
+    @SerialName("deviceUuid")
+    val deviceUuid: String,
+    @SerialName("deviceName")
+    val deviceName: String,
+    @SerialName("deviceType")
+    val deviceType: String,
+    @SerialName("osType")
+    val osType: String,
+    @SerialName("osVersion")
+    val osVersion: String,
+    @SerialName("appVersion")
+    val appVersion: String,
+)

--- a/data/user/src/main/java/com/hilingual/data/user/repository/UserRepository.kt
+++ b/data/user/src/main/java/com/hilingual/data/user/repository/UserRepository.kt
@@ -82,4 +82,8 @@ interface UserRepository {
     suspend fun deleteFollow(
         targetUserId: Long,
     ): Result<Unit>
+
+    suspend fun putDeviceInfo(
+        timezone: String,
+    ): Result<Unit>
 }

--- a/data/user/src/main/java/com/hilingual/data/user/repositoryimpl/UserRepositoryImpl.kt
+++ b/data/user/src/main/java/com/hilingual/data/user/repositoryimpl/UserRepositoryImpl.kt
@@ -16,10 +16,12 @@
 package com.hilingual.data.user.repositoryimpl
 
 import android.net.Uri
+import com.hilingual.core.common.app.DeviceInfoProvider
 import com.hilingual.core.common.util.suspendRunCatching
 import com.hilingual.data.presigned.repository.FileUploaderRepository
 import com.hilingual.data.user.datasource.UserLocalDataSource
 import com.hilingual.data.user.datasource.UserRemoteDataSource
+import com.hilingual.data.user.dto.request.PutDeviceInfoRequestDto
 import com.hilingual.data.user.model.follow.FollowUserListResultModel
 import com.hilingual.data.user.model.follow.toModel
 import com.hilingual.data.user.model.notification.NotificationDetailModel
@@ -39,6 +41,7 @@ internal class UserRepositoryImpl @Inject constructor(
     private val userRemoteDataSource: UserRemoteDataSource,
     private val fileUploaderRepository: FileUploaderRepository,
     private val userLocalDataSource: UserLocalDataSource,
+    private val deviceInfoProvider: DeviceInfoProvider,
 ) : UserRepository {
     override suspend fun getNicknameAvailability(nickname: String): Result<NicknameValidationResult> =
         suspendRunCatching {
@@ -166,4 +169,21 @@ internal class UserRepositoryImpl @Inject constructor(
         suspendRunCatching {
             userRemoteDataSource.deleteFollow(targetUserId = targetUserId)
         }
+
+    override suspend fun putDeviceInfo(timezone: String): Result<Unit> =
+        suspendRunCatching {
+            userRemoteDataSource.putDeviceInfo(
+                putDeviceInfoRequestDto = deviceInfoProvider.toPutDeviceInfoRequestDto(timezone),
+            )
+        }
+
+    private fun DeviceInfoProvider.toPutDeviceInfoRequestDto(timezone: String) = PutDeviceInfoRequestDto(
+        timezone = timezone,
+        deviceUuid = getUuid(),
+        deviceName = getDeviceName(),
+        deviceType = getDeviceType(),
+        osType = getOsType(),
+        osVersion = getOsVersion(),
+        appVersion = getAppVersion(),
+    )
 }

--- a/data/user/src/main/java/com/hilingual/data/user/service/UserService.kt
+++ b/data/user/src/main/java/com/hilingual/data/user/service/UserService.kt
@@ -16,6 +16,7 @@
 package com.hilingual.data.user.service
 
 import com.hilingual.core.network.model.BaseResponse
+import com.hilingual.data.user.dto.request.PutDeviceInfoRequestDto
 import com.hilingual.data.user.dto.request.RegisterProfileRequestDto
 import com.hilingual.data.user.dto.request.UpdateProfileImageRequestDto
 import com.hilingual.data.user.dto.response.follow.FollowerResponseDto
@@ -112,5 +113,10 @@ interface UserService {
     @PATCH("/api/v1/users/mypage/profileImg")
     suspend fun updateProfileImage(
         @Body updateProfileImageRequestDto: UpdateProfileImageRequestDto,
+    ): BaseResponse<Unit>
+
+    @PUT("/api/v1/users/device")
+    suspend fun putDeviceInfo(
+        @Body putDeviceInfoRequestDto: PutDeviceInfoRequestDto,
     ): BaseResponse<Unit>
 }

--- a/presentation/auth/src/main/java/com/hilingual/presentation/auth/AuthViewModel.kt
+++ b/presentation/auth/src/main/java/com/hilingual/presentation/auth/AuthViewModel.kt
@@ -21,7 +21,9 @@ import androidx.lifecycle.viewModelScope
 import com.hilingual.core.common.extension.onLogFailure
 import com.hilingual.data.auth.repository.AuthRepository
 import com.hilingual.data.onboarding.repository.OnboardingRepository
+import com.hilingual.data.user.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.util.TimeZone
 import javax.inject.Inject
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -36,6 +38,7 @@ import timber.log.Timber
 class AuthViewModel @Inject constructor(
     private val authRepository: AuthRepository,
     private val onboardingRepository: OnboardingRepository,
+    private val userRepository: UserRepository,
 ) : ViewModel() {
     private val _isLoading = MutableStateFlow(false)
     val isLoading = _isLoading.asStateFlow()
@@ -60,6 +63,7 @@ class AuthViewModel @Inject constructor(
                         .onSuccess { authResult ->
                             val sideEffect = if (authResult.registerStatus) {
                                 updateIsSplashOnboardingCompleted()
+                                putDeviceInfo()
                                 AuthSideEffect.NavigateToHome
                             } else {
                                 AuthSideEffect.NavigateToSignUp
@@ -72,6 +76,13 @@ class AuthViewModel @Inject constructor(
 
             setIsLoading(false)
         }
+    }
+
+    private suspend fun putDeviceInfo() {
+        runCatching {
+            val timezone = TimeZone.getDefault().id
+            userRepository.putDeviceInfo(timezone)
+        }.onLogFailure { }
     }
 
     private suspend fun updateIsSplashOnboardingCompleted() {

--- a/presentation/signup/src/main/java/com/hilingual/presentation/signup/SignUpViewModel.kt
+++ b/presentation/signup/src/main/java/com/hilingual/presentation/signup/SignUpViewModel.kt
@@ -24,6 +24,7 @@ import com.hilingual.data.user.model.user.NicknameValidationResult
 import com.hilingual.data.user.model.user.UserProfileModel
 import com.hilingual.data.user.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.util.TimeZone
 import javax.inject.Inject
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -89,6 +90,7 @@ internal class SignUpViewModel @Inject constructor(
             )
             userRepository.postUserProfile(userProfile)
                 .onSuccess {
+                    putDeviceInfo()
                     userRepository.saveRegisterStatus(true)
                     onboardingRepository.updateIsHomeOnboardingCompleted(false)
                     updateIsSplashOnboardingCompleted()
@@ -185,6 +187,13 @@ internal class SignUpViewModel @Inject constructor(
     private suspend fun updateIsSplashOnboardingCompleted() {
         onboardingRepository.completeSplashOnboarding()
             .onLogFailure { }
+    }
+
+    private suspend fun putDeviceInfo() {
+        runCatching {
+            val timezone = TimeZone.getDefault().id
+            userRepository.putDeviceInfo(timezone)
+        }.onLogFailure { }
     }
 }
 

--- a/presentation/splash/src/main/java/com/hilingual/presentation/splash/SplashViewModel.kt
+++ b/presentation/splash/src/main/java/com/hilingual/presentation/splash/SplashViewModel.kt
@@ -29,6 +29,7 @@ import com.hilingual.presentation.splash.SplashSideEffect.NavigateToAuth
 import com.hilingual.presentation.splash.SplashSideEffect.NavigateToHome
 import com.hilingual.presentation.splash.SplashSideEffect.NavigateToStore
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.util.TimeZone
 import javax.inject.Inject
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.BufferOverflow
@@ -105,10 +106,21 @@ internal class SplashViewModel @Inject constructor(
                 !accessToken.isNullOrEmpty() && !refreshToken.isNullOrEmpty() && isRegistered
             }.getOrElse { false }
 
+            if (isLoggedIn) {
+                putDeviceInfo()
+            }
+
             delay(1400L)
 
             _sideEffect.tryEmit(if (isLoggedIn) NavigateToHome else NavigateToAuth)
         }
+    }
+
+    private suspend fun putDeviceInfo() {
+        runCatching {
+            val timezone = TimeZone.getDefault().id
+            userRepository.putDeviceInfo(timezone)
+        }.onLogFailure { }
     }
 
     fun onUpdateConfirm() {


### PR DESCRIPTION
## PR chekList
- [ ] ktLint 포맷을 지킨다.
- [ ] indent(인덴트, 들여쓰기) depth를 3이 넘지 않도록 구현한다.
- [ ] 함수(또는 메서드)가 한 가지 일만 하도록 최대한 작게 만든다.
- [ ] class를 최대한 작게 만든다.
- [ ] else를 지양한다(얼리 리턴 사용).

## Related issue 🛠
- closed #741 

## Work Description ✏️
- uuid 생성 후 로컬 저장 및 캐싱
- 로그인 api 수정
- 디바이스 api 추가 구현

## Screenshot 📸
N/A

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
dev에서 탈퇴가 안돼서 신규 유저 관련 플로우는 테스트하지 못했습니다..! 탈퇴 성공하면 이 부분 더 꼼꼼히 테스트 해볼게요!

uuid의 경우 ANDROID_ID를 사용할 경우 스토어 정책 상 추가적으로 처리해야 하는 부분이 있어서(개인정보처리방침 수정 등) 앱 내에서 자체적으로 UUID를 생성해서 가지고 있는 방향으로 구현했습니다 지금은 데이터를 삭제하면 uuid도 변경되는데 이 부분 괜찮은지 서버측에 한 번 더 확인해보고 지금의 구현방식이 맞지 않다면 ANDROID_ID에 대해서 다시 검토해보고 전달드리도록 하겠습니다

현재 저희 프로젝트 구조에서는 로컬 스토리지에 접근하는 부분들이 data 모듈에 위치해있는데요 uuid를 로컬에 저장하는 부분에서 새롭게 모듈을 생성하는 것은 내부 로직에 비해 너무 과하다는 판단을 했고, 기존 data 모듈 중에서는 auth가 제일 잘 어울리는 것 같아서 여기로 보냈습니다만 확신이 드는 방향은 아니라서 혹시 이견이 있으시다면 편하게 말씀해주시면 감사하겠습니다

앱 최초 실행 시 한 번은 uuid 초기화를 해줘야 해서 app단에서 CoroutineScope을 사용해서 uuid에 대해 접근을 해주었는데 이 부분도 한 번씩 검토 부탁드립니다!! 원래 의도는 uuid가 있으면 해당 값을 반환 / 없으면 생성해서 로컬에 저장 후 반환 이었어서 getUuid 함수 내에서 초기화까지 해주고 있는데 크래시가 발생할 가능성이 있어보여서 app단에서 한 번 더 초기화를 하게 되었어요..

# 구현 방향이 바뀔 예정이라 잠시 DRAFT 걸어두도록 하겠습니다! #