### PR TITLE
[FIX/#698] 피드 스크롤 시 토스트가 간혈적으로 표시되지 않던 이슈 해결

### DIFF
--- a/presentation/feed/src/main/java/com/hilingual/presentation/feed/FeedScreen.kt
+++ b/presentation/feed/src/main/java/com/hilingual/presentation/feed/FeedScreen.kt
@@ -207,28 +207,17 @@ private fun FeedScreen(
 
     val isAtBottom by remember(pagerState.currentPage) {
         derivedStateOf {
-            val feedListState = when (pagerState.currentPage) {
-                0 -> recommendFeedList
-                else -> followingFeedList
+            val layoutInfo = currentListState.layoutInfo
+            val visibleItemsInfo = layoutInfo.visibleItemsInfo
+
+            if (layoutInfo.totalItemsCount == 0 || visibleItemsInfo.isEmpty()) {
+                return@derivedStateOf false
             }
 
-            when (feedListState) {
-                is UiState.Success -> {
-                    val feedList = feedListState.data
-                    val layoutInfo = currentListState.layoutInfo
-                    val visibleItemsInfo = layoutInfo.visibleItemsInfo
-
-                    if (feedList.isEmpty() || layoutInfo.totalItemsCount == 0) return@derivedStateOf false
-
-                    val lastVisibleItem = visibleItemsInfo.last()
-                    val viewportHeight =
-                        layoutInfo.viewportEndOffset + layoutInfo.viewportStartOffset
-                    (lastVisibleItem.index == layoutInfo.totalItemsCount - 1) &&
-                        (lastVisibleItem.offset + lastVisibleItem.size <= viewportHeight)
-                }
-
-                else -> false
-            }
+            val lastVisibleItem = visibleItemsInfo.last()
+            val viewportHeight = layoutInfo.viewportEndOffset + layoutInfo.viewportStartOffset
+            (lastVisibleItem.index == layoutInfo.totalItemsCount - 1) &&
+                (lastVisibleItem.offset + lastVisibleItem.size <= viewportHeight)
         }
     }
 
@@ -239,13 +228,15 @@ private fun FeedScreen(
             FeedScrollState(
                 itemIndex = currentListState.firstVisibleItemIndex,
                 scrollOffset = currentListState.firstVisibleItemScrollOffset,
+                isAtBottom = isAtBottom,
+                isScrollInProgress = currentListState.isScrollInProgress,
             )
         }
             .pairwise()
             .collect { (previous, current) ->
-                if (currentListState.isScrollInProgress &&
+                if (current.isScrollInProgress &&
                     current.isScrollingDownFrom(previous) &&
-                    isAtBottom
+                    current.isAtBottom
                 ) {
                     latestReadAllFeed()
                 }
@@ -355,6 +346,8 @@ private fun FeedScreenPreview() {
 private data class FeedScrollState(
     val itemIndex: Int,
     val scrollOffset: Int,
+    val isAtBottom: Boolean = false,
+    val isScrollInProgress: Boolean = false,
 ) {
     fun isScrollingDownFrom(previous: FeedScrollState?): Boolean {
         if (previous == null) return false


### PR DESCRIPTION
## PR chekList
- [x] ktLint 포맷을 지킨다.
- [x] indent(인덴트, 들여쓰기) depth를 3이 넘지 않도록 구현한다.
- [x] 함수(또는 메서드)가 한 가지 일만 하도록 최대한 작게 만든다.
- [x] class를 최대한 작게 만든다.
- [x] else를 지양한다(얼리 리턴 사용).

## Related issue 🛠
- closed #698 

## Work Description ✏️
[문제 원인]
isAtBottom의 derivedStateOf 내에서 recommendFeedList와 followingFeedList를 참조하는데, 이들은 Composable 파라미터이지 Compose State가 아닙니다.                                                                                                               
derivedStateOf는 Compose State 객체의 변화만 추적합니다

1. 처음 진입 시 recommendFeedList가 UiState.Loading → isAtBottom = false                                                                                                      
2. 이후 UiState.Success로 변경되어도 derivedStateOf가 이 변화를 감지하지 못함                                                                                                 
3. 탭 전환하면 remember의 key가 바뀌어 새로운 derivedStateOf가 생성되면서 정상 동작

> 요약:  derivedStateOf 내에서 recommendFeedList/followingFeedList (Composable 파라미터)를 참조하고 있어, State 변화 감지 불가한 문제가 존재

[해결]
- UiState 체크 제거하고 layoutInfo만 사용 -> LazyListState의 State 프로퍼티라 정상 추적

## Screenshot 📸

https://github.com/user-attachments/assets/974ff607-41c0-42b6-8b3e-bb64c2790fc3


## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
- 이제 탭 진입 후 스크롤을 내려 바닥에 도달하면 토스트가 정상적으로 표시됩니다!