### PR TITLE
[FIX/#770] Disable click interactions for non-month dates in calendar

### DIFF
--- a/presentation/home/src/main/java/com/hilingual/presentation/home/component/calendar/DayItem.kt
+++ b/presentation/home/src/main/java/com/hilingual/presentation/home/component/calendar/DayItem.kt
@@ -71,7 +71,10 @@ internal fun DayItem(
     Box(
         modifier = modifier
             .aspectRatio(1f)
-            .noRippleClickable(onClick = onClick),
+            .noRippleClickable(
+                enabled = day.position == DayPosition.MonthDate,
+                onClick = onClick,
+            ),
         contentAlignment = Alignment.Center,
     ) {
         when {


### PR DESCRIPTION
## Related issue 🛠
- closed #770 

## Work Description ✏️
- 전월 / 익월 날짜의 경우 Date 선택 불가능 처리

## Screenshot 📸
| Header |
|--------|
| <video src = "https://github.com/user-attachments/assets/ea139dff-83c2-49ad-8690-7eeef3a6f68b"> <video> | 

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
자세한 내용은 `Slack - 전체업무` 스레드 참고해주세요!