### PR TITLE
[Feat/#773] Add timezone header interceptor for network requests

### DIFF
--- a/core/network/src/main/java/com/hilingual/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/hilingual/core/network/di/NetworkModule.kt
@@ -22,6 +22,7 @@ import com.hilingual.core.network.auth.TokenAuthenticator
 import com.hilingual.core.network.di.qualifier.LongTimeoutClient
 import com.hilingual.core.network.di.qualifier.NoAuthClient
 import com.hilingual.core.network.di.qualifier.RefreshClient
+import com.hilingual.core.network.timezone.TimezoneInterceptor
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -87,10 +88,12 @@ object NetworkModule {
     fun provideDefaultOkHttpClient(
         loggingInterceptor: HttpLoggingInterceptor,
         authInterceptor: AuthInterceptor,
+        timezoneInterceptor: TimezoneInterceptor,
         tokenAuthenticator: TokenAuthenticator,
     ): OkHttpClient = OkHttpClient.Builder()
         .addInterceptor(loggingInterceptor)
         .addInterceptor(authInterceptor)
+        .addInterceptor(timezoneInterceptor)
         .authenticator(tokenAuthenticator)
         .build()
 
@@ -99,8 +102,10 @@ object NetworkModule {
     @NoAuthClient
     fun provideLoginOkHttpClient(
         loggingInterceptor: HttpLoggingInterceptor,
+        timezoneInterceptor: TimezoneInterceptor,
     ): OkHttpClient = OkHttpClient.Builder()
         .addInterceptor(loggingInterceptor)
+        .addInterceptor(timezoneInterceptor)
         .build()
 
     @Provides
@@ -108,8 +113,10 @@ object NetworkModule {
     @RefreshClient
     fun provideRefreshOkHttpClient(
         loggingInterceptor: HttpLoggingInterceptor,
+        timezoneInterceptor: TimezoneInterceptor,
     ): OkHttpClient = OkHttpClient.Builder()
         .addInterceptor(loggingInterceptor)
+        .addInterceptor(timezoneInterceptor)
         .build()
 
     @Provides
@@ -118,10 +125,12 @@ object NetworkModule {
     fun provideLongTimeoutOkHttpClient(
         loggingInterceptor: HttpLoggingInterceptor,
         authInterceptor: AuthInterceptor,
+        timezoneInterceptor: TimezoneInterceptor,
         tokenAuthenticator: TokenAuthenticator,
     ): OkHttpClient = OkHttpClient.Builder()
         .addInterceptor(loggingInterceptor)
         .addInterceptor(authInterceptor)
+        .addInterceptor(timezoneInterceptor)
         .authenticator(tokenAuthenticator)
         .connectTimeout(60.seconds)
         .readTimeout(60.seconds)

--- a/core/network/src/main/java/com/hilingual/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/hilingual/core/network/di/NetworkModule.kt
@@ -91,9 +91,9 @@ object NetworkModule {
         timezoneInterceptor: TimezoneInterceptor,
         tokenAuthenticator: TokenAuthenticator,
     ): OkHttpClient = OkHttpClient.Builder()
-        .addInterceptor(loggingInterceptor)
         .addInterceptor(authInterceptor)
         .addInterceptor(timezoneInterceptor)
+        .addInterceptor(loggingInterceptor)
         .authenticator(tokenAuthenticator)
         .build()
 
@@ -104,8 +104,8 @@ object NetworkModule {
         loggingInterceptor: HttpLoggingInterceptor,
         timezoneInterceptor: TimezoneInterceptor,
     ): OkHttpClient = OkHttpClient.Builder()
-        .addInterceptor(loggingInterceptor)
         .addInterceptor(timezoneInterceptor)
+        .addInterceptor(loggingInterceptor)
         .build()
 
     @Provides
@@ -115,8 +115,8 @@ object NetworkModule {
         loggingInterceptor: HttpLoggingInterceptor,
         timezoneInterceptor: TimezoneInterceptor,
     ): OkHttpClient = OkHttpClient.Builder()
-        .addInterceptor(loggingInterceptor)
         .addInterceptor(timezoneInterceptor)
+        .addInterceptor(loggingInterceptor)
         .build()
 
     @Provides
@@ -128,9 +128,9 @@ object NetworkModule {
         timezoneInterceptor: TimezoneInterceptor,
         tokenAuthenticator: TokenAuthenticator,
     ): OkHttpClient = OkHttpClient.Builder()
-        .addInterceptor(loggingInterceptor)
         .addInterceptor(authInterceptor)
         .addInterceptor(timezoneInterceptor)
+        .addInterceptor(loggingInterceptor)
         .authenticator(tokenAuthenticator)
         .connectTimeout(60.seconds)
         .readTimeout(60.seconds)

--- a/core/network/src/main/java/com/hilingual/core/network/timezone/TimezoneInterceptor.kt
+++ b/core/network/src/main/java/com/hilingual/core/network/timezone/TimezoneInterceptor.kt
@@ -21,13 +21,18 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import okhttp3.Interceptor
 import okhttp3.Response
+import timber.log.Timber
 
 @Singleton
 class TimezoneInterceptor @Inject constructor() : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
+        val timezoneId = TimeZone.getDefault().id
+        Timber.d("X_TIMEZONE: $timezoneId")
+
         val request = chain.request().newBuilder()
-            .header(X_TIMEZONE, TimeZone.getDefault().id)
+            .header(X_TIMEZONE, timezoneId)
             .build()
+
         return chain.proceed(request)
     }
 }

--- a/core/network/src/main/java/com/hilingual/core/network/timezone/TimezoneInterceptor.kt
+++ b/core/network/src/main/java/com/hilingual/core/network/timezone/TimezoneInterceptor.kt
@@ -26,11 +26,8 @@ import timber.log.Timber
 @Singleton
 class TimezoneInterceptor @Inject constructor() : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
-        val timezoneId = TimeZone.getDefault().id
-        Timber.d("X_TIMEZONE: $timezoneId")
-
         val request = chain.request().newBuilder()
-            .header(X_TIMEZONE, timezoneId)
+            .header(X_TIMEZONE, TimeZone.getDefault().id)
             .build()
 
         return chain.proceed(request)

--- a/core/network/src/main/java/com/hilingual/core/network/timezone/TimezoneInterceptor.kt
+++ b/core/network/src/main/java/com/hilingual/core/network/timezone/TimezoneInterceptor.kt
@@ -13,9 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hilingual.core.network.constant
+package com.hilingual.core.network.timezone
 
-const val AUTHORIZATION = "Authorization"
-const val PROVIDER_TOKEN = "Provider-Token"
-const val BEARER = "Bearer"
-const val X_TIMEZONE = "X-Timezone"
+import com.hilingual.core.network.constant.X_TIMEZONE
+import java.util.TimeZone
+import javax.inject.Inject
+import javax.inject.Singleton
+import okhttp3.Interceptor
+import okhttp3.Response
+
+@Singleton
+class TimezoneInterceptor @Inject constructor() : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request().newBuilder()
+            .header(X_TIMEZONE, TimeZone.getDefault().id)
+            .build()
+        return chain.proceed(request)
+    }
+}

--- a/core/network/src/main/java/com/hilingual/core/network/timezone/TimezoneInterceptor.kt
+++ b/core/network/src/main/java/com/hilingual/core/network/timezone/TimezoneInterceptor.kt
@@ -1,18 +1,3 @@
-/*
- * Copyright 2025 The Hilingual Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.hilingual.core.network.timezone
 
 import com.hilingual.core.network.constant.X_TIMEZONE
@@ -21,7 +6,6 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import okhttp3.Interceptor
 import okhttp3.Response
-import timber.log.Timber
 
 @Singleton
 class TimezoneInterceptor @Inject constructor() : Interceptor {


### PR DESCRIPTION
## Related issue 🛠
- closed #773

## Work Description ✏️
- `TimezoneInterceptor` 추가 — 모든 API 요청에 `X-Timezone` 헤더로 기기 타임존(`TimeZone.getDefault().id`) 자동 첨부
- `HeaderConstants`에 `X_TIMEZONE` 상수 추가                                                                                                                                  
- `NetworkModule`의 모든 OkHttpClient(`Default`, `NoAuth`, `Refresh`, `LongTimeout`)에 `TimezoneInterceptor` 적용

## Screenshot 📸
<img width="737" height="316" alt="image" src="https://github.com/user-attachments/assets/e84dda5e-a3fb-4a4e-9ad3-4e7d68aeba35" />

갤럭시 폰에서 설정 > 날짜 및 시간 > 시간대 설정으로 국가 시간을 변경하고 본 모습입니다.

예)
1. 대한민국 > 서울
2. 미국 > 시카고
3. 멕시코 > 마사틀란


## To Reviewers 📢
- 서버 부하 줄이기 + 타임존 정확성 높이기를 목적으로 모든 API의 헤더에 일괄적으로 타임존을 추가하게 되었습니다.