### PR TITLE
[FIX] FeedProfile 화면 나갈 때 NavBackStackEntry 파괴 후 ViewModel 접근으로 인한 크래시 수정

### DIFF
--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/navigation/FeedProfileNavigation.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/navigation/FeedProfileNavigation.kt
@@ -20,8 +20,11 @@ import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
@@ -72,16 +75,19 @@ fun NavGraphBuilder.feedProfileNavGraph(
             val parentEntry = remember(backStackEntry) {
                 navController.getBackStackEntry(FeedProfileGraph::class)
             }
-            val viewModel: FeedProfileViewModel = hiltViewModel(parentEntry)
-            FeedProfileRoute(
-                viewModel = viewModel,
-                paddingValues = paddingValues,
-                navigateUp = navigateUp,
-                navigateToMyFeedProfile = navigateToMyFeedProfile,
-                navigateToFollowList = { navController.navigateToFollowList(userId = 0L) },
-                navigateToFeedProfile = navigateToFeedProfile,
-                navigateToFeedDiary = navigateToFeedDiary,
-            )
+            val lifecycleState by parentEntry.lifecycle.currentStateFlow.collectAsStateWithLifecycle()
+            if (lifecycleState != Lifecycle.State.DESTROYED) {
+                val viewModel: FeedProfileViewModel = hiltViewModel(parentEntry)
+                FeedProfileRoute(
+                    viewModel = viewModel,
+                    paddingValues = paddingValues,
+                    navigateUp = navigateUp,
+                    navigateToMyFeedProfile = navigateToMyFeedProfile,
+                    navigateToFollowList = { navController.navigateToFollowList(userId = 0L) },
+                    navigateToFeedProfile = navigateToFeedProfile,
+                    navigateToFeedDiary = navigateToFeedDiary,
+                )
+            }
         }
         composable<FollowList>(
             enterTransition = enterTransition,


### PR DESCRIPTION
## Summary

- `FeedProfileGraph` NavBackStackEntry가 백스택에서 제거된 후 exit 애니메이션 중 recomposition이 발생할 때, 이미 destroyed된 `parentEntry`의 ViewModelStore에 접근하여 `IllegalStateException`이 발생하는 크래시를 수정
- `parentEntry.lifecycle.currentStateFlow`를 `collectAsStateWithLifecycle`로 관찰하여, lifecycle state가 `DESTROYED`인 경우 `hiltViewModel(parentEntry)` 호출 및 화면 렌더링을 건너뜀

## Root Cause

`FeedProfileViewModel`은 `SavedStateHandle`로 graph 인자(`userId`, `showLikedDiaries`)를 읽기 위해 `FeedProfileGraph` NavBackStackEntry에 스코핑되어 있음. 사용자가 뒤로 나가면 graph entry가 DESTROYED되지만, exit 애니메이션 동안 composable이 여전히 composition tree에 남아 있어 recompose 시 destroyed된 entry의 ViewModelStore에 접근하다 크래시 발생.

```
Fatal Exception: java.lang.IllegalStateException
You cannot access the NavBackStackEntry's ViewModels after the NavBackStackEntry is destroyed.
FeedProfileNavigation.kt:152
```

## Fix

```kotlin
val lifecycleState by parentEntry.lifecycle.currentStateFlow.collectAsStateWithLifecycle()
if (lifecycleState != Lifecycle.State.DESTROYED) {
    val viewModel: FeedProfileViewModel = hiltViewModel(parentEntry)
    FeedProfileRoute(...)
}
```