### PR TITLE
[FIX/#826] feed profile blank screen on back

### DIFF
--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/navigation/FeedProfileNavigation.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/navigation/FeedProfileNavigation.kt
@@ -71,23 +71,30 @@ fun NavGraphBuilder.feedProfileNavGraph(
         exitTransition = { ExitTransition.None },
         popEnterTransition = { EnterTransition.None },
     ) {
-        composable<FeedProfile> { backStackEntry ->
+        composable<FeedProfile>(
+            enterTransition = enterTransition,
+            exitTransition = { ExitTransition.None },
+            popEnterTransition = { EnterTransition.None },
+            popExitTransition = popExitTransition,
+        ) { backStackEntry ->
             val parentEntry = remember(backStackEntry) {
                 navController.getBackStackEntry(FeedProfileGraph::class)
             }
             val lifecycleState by parentEntry.lifecycle.currentStateFlow.collectAsStateWithLifecycle()
-            if (lifecycleState != Lifecycle.State.DESTROYED) {
-                val viewModel: FeedProfileViewModel = hiltViewModel(parentEntry)
-                FeedProfileRoute(
-                    viewModel = viewModel,
-                    paddingValues = paddingValues,
-                    navigateUp = navigateUp,
-                    navigateToMyFeedProfile = navigateToMyFeedProfile,
-                    navigateToFollowList = { navController.navigateToFollowList(userId = 0L) },
-                    navigateToFeedProfile = navigateToFeedProfile,
-                    navigateToFeedDiary = navigateToFeedDiary,
-                )
-            }
+
+            if (lifecycleState == Lifecycle.State.DESTROYED) return@composable
+
+            val viewModel: FeedProfileViewModel = hiltViewModel(parentEntry)
+
+            FeedProfileRoute(
+                viewModel = viewModel,
+                paddingValues = paddingValues,
+                navigateUp = navigateUp,
+                navigateToMyFeedProfile = navigateToMyFeedProfile,
+                navigateToFollowList = { navController.navigateToFollowList(userId = 0L) },
+                navigateToFeedProfile = navigateToFeedProfile,
+                navigateToFeedDiary = navigateToFeedDiary,
+            )
         }
         composable<FollowList>(
             enterTransition = enterTransition,

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/navigation/FeedProfileNavigation.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/navigation/FeedProfileNavigation.kt
@@ -23,7 +23,6 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/navigation/FeedProfileNavigation.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/navigation/FeedProfileNavigation.kt
@@ -15,13 +15,13 @@
  */
 package com.hilingual.presentation.feedprofile.navigation
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -84,24 +84,24 @@ fun NavGraphBuilder.feedProfileNavGraph(
             }
             val lifecycleState by parentEntry.lifecycle.currentStateFlow.collectAsStateWithLifecycle()
 
-            var cachedViewModel by remember(parentEntry) { mutableStateOf<FeedProfileViewModel?>(null) }
-
-            if (lifecycleState != Lifecycle.State.DESTROYED) {
-                cachedViewModel = hiltViewModel(parentEntry)
+            BackHandler {
+                navigateUp()
             }
 
-            val viewModel = cachedViewModel ?: return@composable
-
-            FeedProfileRoute(
-                viewModel = viewModel,
-                paddingValues = paddingValues,
-                navigateUp = navigateUp,
-                navigateToMyFeedProfile = navigateToMyFeedProfile,
-                navigateToFollowList = { navController.navigateToFollowList(userId = 0L) },
-                navigateToFeedProfile = navigateToFeedProfile,
-                navigateToFeedDiary = navigateToFeedDiary,
-            )
+            if (lifecycleState != Lifecycle.State.DESTROYED) {
+                val viewModel: FeedProfileViewModel = hiltViewModel(parentEntry)
+                FeedProfileRoute(
+                    viewModel = viewModel,
+                    paddingValues = paddingValues,
+                    navigateUp = navigateUp,
+                    navigateToMyFeedProfile = navigateToMyFeedProfile,
+                    navigateToFollowList = { navController.navigateToFollowList(userId = 0L) },
+                    navigateToFeedProfile = navigateToFeedProfile,
+                    navigateToFeedDiary = navigateToFeedDiary,
+                )
+            }
         }
+
         composable<FollowList>(
             enterTransition = enterTransition,
             exitTransition = { ExitTransition.None },

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/navigation/FeedProfileNavigation.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/navigation/FeedProfileNavigation.kt
@@ -21,7 +21,9 @@ import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -82,9 +84,13 @@ fun NavGraphBuilder.feedProfileNavGraph(
             }
             val lifecycleState by parentEntry.lifecycle.currentStateFlow.collectAsStateWithLifecycle()
 
-            if (lifecycleState == Lifecycle.State.DESTROYED) return@composable
+            var cachedViewModel by remember(parentEntry) { mutableStateOf<FeedProfileViewModel?>(null) }
 
-            val viewModel: FeedProfileViewModel = hiltViewModel(parentEntry)
+            if (lifecycleState != Lifecycle.State.DESTROYED) {
+                cachedViewModel = hiltViewModel(parentEntry)
+            }
+
+            val viewModel = cachedViewModel ?: return@composable
 
             FeedProfileRoute(
                 viewModel = viewModel,


### PR DESCRIPTION
## 증상
관련 이슈 - closed #826 
프로필 화면을 연속으로 진입한 뒤 **안드로이드 기기의 스와이프 뒤로가기(Predictive Back Gesture)** 를
사용하면 빈 화면이 나타납니다. 앱 내 뒤로가기 버튼에서는 재현되지 않습니다.

## 원인

일반 뒤로가기와 Predictive Back Gesture의 lifecycle 전환 타이밍이 다릅니다.

```
일반 뒤로가기:    [화면 표시] ──→ pop 완료 ──→ DESTROYED ──→ 렌더링 중단  ← 정상
Predictive Back: [화면 표시] ──→ DESTROYED ──→ 렌더링 중단 ──→ 빈 화면 ──→ pop 완료  ← 문제
```

Predictive Back은 스와이프 미리보기 애니메이션이 시작되는 시점에 Navigation이 대상 entry의 lifecycle을 `DESTROYED`로 전환합니다.
기존 크래시 수정 코드(`lifecycleState != DESTROYED`일 때만 렌더링)가
이 타이밍에 렌더링을 중단시키기 때문에, pop이 완료되기 전부터 화면이 비어버립니다.

## 수정

```kotlin
// before: DESTROYED가 되는 순간 렌더링 중단 → Predictive Back 중 빈 화면
if (lifecycleState != Lifecycle.State.DESTROYED) {
    val viewModel: FeedProfileViewModel = hiltViewModel(parentEntry)
    FeedProfileRoute(...)
}

// after: DESTROYED 이전에 획득한 ViewModel 인스턴스를 캐싱하여 화면 유지
var cachedViewModel by remember(parentEntry) { mutableStateOf<FeedProfileViewModel?>(null) }

if (lifecycleState != Lifecycle.State.DESTROYED) {
    cachedViewModel = hiltViewModel(parentEntry)
}

val viewModel = cachedViewModel ?: return@composable

FeedProfileRoute(viewModel = viewModel, ...)
```

`remember(parentEntry)`로 초기화된 `cachedViewModel`은 lifecycle이 살아있는 첫 recompose에서 ViewModel 인스턴스를 획득해 보존합니다.
이후 Predictive Back으로 `DESTROYED`가 되어도 캐싱된 인스턴스를 그대로 사용하므로 pop이 완료될 때까지 화면이 유지됩니다.
