### PR TITLE
[FIX] 시스템 글자 크기 변경에 따른 TextField 잘림 현상 수정

### DIFF
--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/textfield/HilingualBasicTextField.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/textfield/HilingualBasicTextField.kt
@@ -79,7 +79,7 @@ fun HilingualBasicTextField(
     backgroundColor: Color = HilingualTheme.colors.gray100,
     borderColor: Color = Color.Unspecified,
     paddingValues: PaddingValues = PaddingValues(12.dp),
-    decorationBoxHeight: Dp = 22.dp,
+    decorationBoxHeight: Dp = Dp.Unspecified,
     leadingIcon: @Composable () -> Unit = {},
     trailingIcon: @Composable () -> Unit = {},
 ) {


### PR DESCRIPTION
## Related issue 🛠
- closed #832 

## Work Description ✏️
`HilingualSearchTextField`, `HilingualShortTextField`에서 기기 글자 크기를 키웠을 때 TextField 내부 텍스트가 세로로 잘리는 문제가 발생했습니다.

```
// before: 기본 높이가 22.dp로 고정되어 font scale 증가 시 텍스트가 잘림
decorationBoxHeight: Dp = 22.dp

// after: 기본 높이를 지정하지 않아 텍스트 높이에 맞게 자연스럽게 측정
decorationBoxHeight: Dp = Dp.Unspecified
```

## Screenshot 📸
|  | Before | After |
| --- | --- | --- |
| HilingualSearchTextField | <img src="https://github.com/user-attachments/assets/99e3e998-b547-41b5-bfaf-63a5cb7afe0b" width="360"/> | <img src="https://github.com/user-attachments/assets/96b9b7b9-0079-43df-8cb6-fe1693a9c6cd" width="360"/> |
| HilingualShortTextField | <img src="https://github.com/user-attachments/assets/63c40a26-3428-4c87-b139-4d8b45b678d7" width="360"/> | <img src="https://github.com/user-attachments/assets/1eb0879b-be27-4d70-ac59-93f2d34ee452" width="360"/> |

## To Reviewers 📢
- 한줄짜리 가벼운 변경사항입니다ㅎㅎ