### PR TITLE
[REF] Next Gen SDK 정식버전 마이그레이션 및 fatal 이슈 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 # Gradle files
 .gradle/
 build/
+.omc/
 
 # Local configuration file (sdk path, etc)
 local.properties

--- a/core/ads/src/main/java/com/hilingual/core/ads/banner/BannerAdHolder.kt
+++ b/core/ads/src/main/java/com/hilingual/core/ads/banner/BannerAdHolder.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
 import com.google.android.libraries.ads.mobile.sdk.banner.AdSize
 import com.google.android.libraries.ads.mobile.sdk.banner.AdView
@@ -32,6 +33,7 @@ import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdRequest
 import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
 import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
 import com.hilingual.core.ads.utils.screenWidthDp
+import kotlinx.coroutines.launch
 import timber.log.Timber
 
 @ConsistentCopyVisibility
@@ -50,67 +52,37 @@ fun rememberBannerAdView(
     type: BannerAdType,
 ): BannerAdHolder {
     val context = LocalContext.current
-    val activity = LocalActivity.current
     val screenWidth = context.screenWidthDp
 
-    val isLoadedState = remember { mutableStateOf(false) }
-    val isFailedState = remember { mutableStateOf(false) }
+    val isLoadedState = remember(type) { mutableStateOf(false) }
+    val isFailedState = remember(type) { mutableStateOf(false) }
+    val coroutineScope = rememberCoroutineScope()
 
-    val adView = remember {
-        createAndLoadAdView(
-            context = context,
-            activity = activity,
-            adUnitId = type.adUnitId,
-            screenWidth = screenWidth,
-            maxHeight = type.maxHeight,
-            onLoaded = { isLoadedState.value = true },
-            onFailed = { isFailedState.value = true },
-        )
-    }
+    val adView = remember(type, screenWidth) {
+        val size = if (type.maxHeight != null) {
+            AdSize.getInlineAdaptiveBannerAdSize(screenWidth, type.maxHeight)
+        } else {
+            AdSize.getCurrentOrientationInlineAdaptiveBannerAdSize(context, screenWidth)
+        }
 
-    DisposableEffect(type) {
-        onDispose {
-            adView.destroy()
+        AdView(context).apply {
+            val adRequest = BannerAdRequest.Builder(type.adUnitId, size).build()
+            loadAd(adRequest, object : AdLoadCallback<BannerAd> {
+                override fun onAdLoaded(ad: BannerAd) {
+                    coroutineScope.launch {
+                        isLoadedState.value = true
+                    }
+                }
+
+                override fun onAdFailedToLoad(adError: LoadAdError) {
+                    Timber.tag("GMA").e("GMA Next Gen 배너 광고 로드 실패: %s", adError)
+                    coroutineScope.launch {
+                        isFailedState.value = true
+                    }
+                }
+            })
         }
     }
 
-    return remember { BannerAdHolder(adView, isLoadedState, isFailedState) }
-}
-
-private fun createAndLoadAdView(
-    context: Context,
-    activity: Activity?,
-    adUnitId: String,
-    screenWidth: Int,
-    maxHeight: Int?,
-    onLoaded: () -> Unit,
-    onFailed: () -> Unit,
-): AdView = AdView(context).apply {
-    if (activity == null) {
-        Timber.tag("GMA").w("Activity가 null이므로 광고를 로드할 수 없습니다.")
-        return@apply
-    }
-
-    val adSize = getAdSize(context, screenWidth, maxHeight)
-    val adRequest = BannerAdRequest.Builder(adUnitId, adSize).build()
-
-    loadAd(adRequest, createAdLoadCallback(onLoaded, onFailed))
-}
-
-private fun createAdLoadCallback(onLoaded: () -> Unit, onFailed: () -> Unit) = object : AdLoadCallback<BannerAd> {
-    override fun onAdLoaded(ad: BannerAd) {
-        Timber.tag("GMA").d("GMA Next Gen 배너 광고 새로 로드 성공")
-        onLoaded()
-    }
-
-    override fun onAdFailedToLoad(adError: LoadAdError) {
-        Timber.tag("GMA").e("GMA Next Gen 배너 광고 로드 실패: %s", adError)
-        onFailed()
-    }
-}
-
-private fun getAdSize(context: Context, width: Int, maxHeight: Int?): AdSize = if (maxHeight != null) {
-    AdSize.getInlineAdaptiveBannerAdSize(width, maxHeight)
-} else {
-    AdSize.getCurrentOrientationInlineAdaptiveBannerAdSize(context, width)
+    return remember(adView) { BannerAdHolder(adView, isLoadedState, isFailedState) }
 }

--- a/core/ads/src/main/java/com/hilingual/core/ads/banner/BannerAdHolder.kt
+++ b/core/ads/src/main/java/com/hilingual/core/ads/banner/BannerAdHolder.kt
@@ -15,11 +15,7 @@
  */
 package com.hilingual.core.ads.banner
 
-import android.app.Activity
-import android.content.Context
-import androidx.activity.compose.LocalActivity
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
@@ -67,20 +63,23 @@ fun rememberBannerAdView(
 
         AdView(context).apply {
             val adRequest = BannerAdRequest.Builder(type.adUnitId, size).build()
-            loadAd(adRequest, object : AdLoadCallback<BannerAd> {
-                override fun onAdLoaded(ad: BannerAd) {
-                    coroutineScope.launch {
-                        isLoadedState.value = true
+            loadAd(
+                adRequest,
+                object : AdLoadCallback<BannerAd> {
+                    override fun onAdLoaded(ad: BannerAd) {
+                        coroutineScope.launch {
+                            isLoadedState.value = true
+                        }
                     }
-                }
 
-                override fun onAdFailedToLoad(adError: LoadAdError) {
-                    Timber.tag("GMA").e("GMA Next Gen 배너 광고 로드 실패: %s", adError)
-                    coroutineScope.launch {
-                        isFailedState.value = true
+                    override fun onAdFailedToLoad(adError: LoadAdError) {
+                        Timber.tag("GMA").e("GMA Next Gen 배너 광고 로드 실패: %s", adError)
+                        coroutineScope.launch {
+                            isFailedState.value = true
+                        }
                     }
-                }
-            })
+                },
+            )
         }
     }
 

--- a/core/ads/src/main/java/com/hilingual/core/ads/banner/HilingualBannerAd.kt
+++ b/core/ads/src/main/java/com/hilingual/core/ads/banner/HilingualBannerAd.kt
@@ -78,7 +78,7 @@ fun HilingualBannerAd(
                         },
                         onRelease = { adView ->
                             adView.destroy()
-                        }
+                        },
                     )
                 }
             }

--- a/core/ads/src/main/java/com/hilingual/core/ads/banner/HilingualBannerAd.kt
+++ b/core/ads/src/main/java/com/hilingual/core/ads/banner/HilingualBannerAd.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalInspectionMode
@@ -67,10 +68,19 @@ fun HilingualBannerAd(
             }
 
             if (!isPreviewMode && adHolder.isLoaded) {
-                AndroidView(
-                    modifier = Modifier.fillMaxWidth(),
-                    factory = { adHolder.adView },
-                )
+                key(adHolder.adView) {
+                    AndroidView(
+                        modifier = Modifier.fillMaxWidth(),
+                        factory = {
+                            val adView = adHolder.adView
+                            (adView.parent as? android.view.ViewGroup)?.removeView(adView)
+                            adView
+                        },
+                        onRelease = { adView ->
+                            adView.destroy()
+                        }
+                    )
+                }
             }
         }
     }

--- a/core/ads/src/main/java/com/hilingual/core/ads/interstitial/HilingualInterstitialAd.kt
+++ b/core/ads/src/main/java/com/hilingual/core/ads/interstitial/HilingualInterstitialAd.kt
@@ -56,6 +56,7 @@ suspend fun showInterstitialAd(
                 runOnMain(onAdDismissed)
             }
         }
+
         is AdLoadResult.Failure -> {
             Timber.tag("GMA").e("전면 광고 로드 실패: %s", result.error)
             runOnMain(onAdDismissed)

--- a/core/ads/src/main/java/com/hilingual/core/ads/interstitial/HilingualInterstitialAd.kt
+++ b/core/ads/src/main/java/com/hilingual/core/ads/interstitial/HilingualInterstitialAd.kt
@@ -16,40 +16,37 @@
 package com.hilingual.core.ads.interstitial
 
 import android.app.Activity
-import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadResult
 import com.google.android.libraries.ads.mobile.sdk.common.AdRequest
 import com.google.android.libraries.ads.mobile.sdk.common.FullScreenContentError
-import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
 import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAd
 import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAdEventCallback
 import timber.log.Timber
 
-fun showInterstitialAd(
+suspend fun showInterstitialAd(
     activity: Activity,
     adUnitId: String,
     onAdDismissed: () -> Unit,
 ) {
     val adRequest = AdRequest.Builder(adUnitId).build()
+    Timber.tag("GMA").d("GMA Next Gen 전면 광고 로드 시작...")
 
-    InterstitialAd.load(
-        adRequest = adRequest,
-        adLoadCallback = object : AdLoadCallback<InterstitialAd> {
-            override fun onAdLoaded(ad: InterstitialAd) {
-                if (!activity.isFinishing && !activity.isDestroyed) {
-                    ad.adEventCallback = createEventCallback(onAdDismissed)
-                    ad.show(activity)
-                } else {
-                    Timber.tag("GMA").w("Activity가 이미 종료 상태라 전면 광고를 표시하지 않습니다.")
-                    onAdDismissed()
-                }
-            }
-
-            override fun onAdFailedToLoad(adError: LoadAdError) {
-                Timber.tag("GMA").e("전면 광고 로드 실패: %s", adError)
+    when (val result = InterstitialAd.load(adRequest)) {
+        is AdLoadResult.Success -> {
+            val ad = result.ad
+            if (!activity.isFinishing && !activity.isDestroyed) {
+                ad.adEventCallback = createEventCallback(onAdDismissed)
+                ad.show(activity)
+            } else {
+                Timber.tag("GMA").w("Activity가 이미 종료 상태라 전면 광고를 표시하지 않습니다.")
                 onAdDismissed()
             }
-        },
-    )
+        }
+        is AdLoadResult.Failure -> {
+            Timber.tag("GMA").e("전면 광고 로드 실패: %s", result.error)
+            onAdDismissed()
+        }
+    }
 }
 
 private fun createEventCallback(onAdDismissed: () -> Unit) = object : InterstitialAdEventCallback {

--- a/core/ads/src/main/java/com/hilingual/core/ads/interstitial/HilingualInterstitialAd.kt
+++ b/core/ads/src/main/java/com/hilingual/core/ads/interstitial/HilingualInterstitialAd.kt
@@ -31,32 +31,34 @@ suspend fun showInterstitialAd(
     val adRequest = AdRequest.Builder(adUnitId).build()
     Timber.tag("GMA").d("GMA Next Gen 전면 광고 로드 시작...")
 
+    val runOnMain: (() -> Unit) -> Unit = { callback ->
+        activity.runOnUiThread { callback() }
+    }
+
     when (val result = InterstitialAd.load(adRequest)) {
         is AdLoadResult.Success -> {
             val ad = result.ad
             if (!activity.isFinishing && !activity.isDestroyed) {
-                ad.adEventCallback = createEventCallback(onAdDismissed)
+                ad.adEventCallback = object : InterstitialAdEventCallback {
+                    override fun onAdDismissedFullScreenContent() {
+                        Timber.tag("GMA").d("전면 광고 닫힘 → 피드백 화면으로 이동")
+                        runOnMain(onAdDismissed)
+                    }
+
+                    override fun onAdFailedToShowFullScreenContent(fullScreenContentError: FullScreenContentError) {
+                        Timber.tag("GMA").e("전면 광고 표시 실패: %s", fullScreenContentError)
+                        runOnMain(onAdDismissed)
+                    }
+                }
                 ad.show(activity)
             } else {
                 Timber.tag("GMA").w("Activity가 이미 종료 상태라 전면 광고를 표시하지 않습니다.")
-                onAdDismissed()
+                runOnMain(onAdDismissed)
             }
         }
         is AdLoadResult.Failure -> {
             Timber.tag("GMA").e("전면 광고 로드 실패: %s", result.error)
-            onAdDismissed()
+            runOnMain(onAdDismissed)
         }
-    }
-}
-
-private fun createEventCallback(onAdDismissed: () -> Unit) = object : InterstitialAdEventCallback {
-    override fun onAdDismissedFullScreenContent() {
-        Timber.tag("GMA").d("전면 광고 닫힘 → 피드백 화면으로 이동")
-        onAdDismissed()
-    }
-
-    override fun onAdFailedToShowFullScreenContent(fullScreenContentError: FullScreenContentError) {
-        Timber.tag("GMA").e("전면 광고 표시 실패: %s", fullScreenContentError)
-        onAdDismissed()
     }
 }

--- a/core/ads/src/main/java/com/hilingual/core/ads/native/HilingualNativeLineAd.kt
+++ b/core/ads/src/main/java/com/hilingual/core/ads/native/HilingualNativeLineAd.kt
@@ -17,6 +17,7 @@ package com.hilingual.core.ads.native
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.tooling.preview.Preview
@@ -38,10 +39,21 @@ fun HilingualNativeLineAd(
             modifier = modifier,
         )
 
-        is NativeAdState.Loaded -> AndroidView(
-            modifier = modifier.fillMaxWidth(),
-            factory = { context -> createNativeAdView(context, state.ad) },
-        )
+        is NativeAdState.Loaded -> {
+            key(state.ad) {
+                AndroidView(
+                    modifier = modifier.fillMaxWidth(),
+                    factory = { context ->
+                        val adView = createNativeAdView(context, state.ad)
+                        (adView.parent as? android.view.ViewGroup)?.removeView(adView)
+                        adView
+                    },
+                    onRelease = { _ ->
+                        state.ad.destroy()
+                    }
+                )
+            }
+        }
 
         NativeAdState.Failed -> {}
     }

--- a/core/ads/src/main/java/com/hilingual/core/ads/native/HilingualNativeLineAd.kt
+++ b/core/ads/src/main/java/com/hilingual/core/ads/native/HilingualNativeLineAd.kt
@@ -50,7 +50,7 @@ fun HilingualNativeLineAd(
                     },
                     onRelease = { _ ->
                         state.ad.destroy()
-                    }
+                    },
                 )
             }
         }

--- a/core/ads/src/main/java/com/hilingual/core/ads/native/RememberNativeAd.kt
+++ b/core/ads/src/main/java/com/hilingual/core/ads/native/RememberNativeAd.kt
@@ -17,14 +17,13 @@ package com.hilingual.core.ads.native
 
 import android.content.Context
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.ComposeView
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAd
-import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoader
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoadResult
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoader
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdRequest
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdView
 import com.hilingual.core.ads.native.component.NativeLineAdContent
@@ -45,6 +44,7 @@ internal fun rememberNativeAdState(adUnitId: String): NativeAdState {
             is NativeAdLoadResult.NativeAdSuccess -> {
                 state.value = NativeAdState.Loaded(result.ad)
             }
+
             else -> {
                 if (result is NativeAdLoadResult.Failure) {
                     Timber.tag("GMA").e("GMA Next Gen 네이티브 광고 로드 실패: %s", result.error)

--- a/core/ads/src/main/java/com/hilingual/core/ads/native/RememberNativeAd.kt
+++ b/core/ads/src/main/java/com/hilingual/core/ads/native/RememberNativeAd.kt
@@ -54,16 +54,6 @@ internal fun rememberNativeAdState(adUnitId: String): NativeAdState {
         }
     }
 
-    DisposableEffect(adUnitId) {
-        onDispose {
-            val currentState = state.value
-            if (currentState is NativeAdState.Loaded) {
-                currentState.ad.destroy()
-            }
-            state.value = NativeAdState.Loading
-        }
-    }
-
     return state.value
 }
 

--- a/core/ads/src/main/java/com/hilingual/core/ads/native/RememberNativeAd.kt
+++ b/core/ads/src/main/java/com/hilingual/core/ads/native/RememberNativeAd.kt
@@ -18,15 +18,13 @@ package com.hilingual.core.ads.native
 import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.ComposeView
-import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAd
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoader
-import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoaderCallback
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoadResult
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdRequest
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdView
 import com.hilingual.core.ads.native.component.NativeLineAdContent
@@ -34,37 +32,39 @@ import timber.log.Timber
 
 @Composable
 internal fun rememberNativeAdState(adUnitId: String): NativeAdState {
-    var state by remember { mutableStateOf<NativeAdState>(NativeAdState.Loading) }
+    val state = remember { mutableStateOf<NativeAdState>(NativeAdState.Loading) }
 
-    DisposableEffect(adUnitId) {
-        var isDisposed = false
-
+    LaunchedEffect(adUnitId) {
+        state.value = NativeAdState.Loading
         val adRequest = NativeAdRequest.Builder(
             adUnitId = adUnitId,
             nativeAdTypes = listOf(NativeAd.NativeAdType.NATIVE),
         ).build()
 
-        val adCallback = object : NativeAdLoaderCallback {
-            override fun onNativeAdLoaded(nativeAd: NativeAd) {
-                if (isDisposed) nativeAd.destroy() else state = NativeAdState.Loaded(nativeAd)
+        when (val result = NativeAdLoader.load(adRequest)) {
+            is NativeAdLoadResult.NativeAdSuccess -> {
+                state.value = NativeAdState.Loaded(result.ad)
             }
-
-            override fun onAdFailedToLoad(adError: LoadAdError) {
-                Timber.tag("GMA").e("GMA Next Gen 네이티브 광고 로드 실패: %s", adError)
-                if (!isDisposed) state = NativeAdState.Failed
+            else -> {
+                if (result is NativeAdLoadResult.Failure) {
+                    Timber.tag("GMA").e("GMA Next Gen 네이티브 광고 로드 실패: %s", result.error)
+                }
+                state.value = NativeAdState.Failed
             }
-        }
-
-        NativeAdLoader.load(adRequest, adCallback)
-
-        onDispose {
-            isDisposed = true
-            (state as? NativeAdState.Loaded)?.ad?.destroy()
-            state = NativeAdState.Loading
         }
     }
 
-    return state
+    DisposableEffect(adUnitId) {
+        onDispose {
+            val currentState = state.value
+            if (currentState is NativeAdState.Loaded) {
+                currentState.ad.destroy()
+            }
+            state.value = NativeAdState.Loading
+        }
+    }
+
+    return state.value
 }
 
 internal fun createNativeAdView(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,7 +61,7 @@ ktlint = "14.2.0"
 pebble = "0.1.0"
 balloonCompose = "1.7.6"
 richeditorCompose = "1.0.0-rc14"
-gmaAds = "1.1.0"
+gmaAds = "1.0.1"
 
 # Firebase
 firebaseBom = "34.13.0"


### PR DESCRIPTION
## Work Description ✏️
- **AdMob Next-Gen SDK 정식 버전(`1.1.0`) 마이그레이션**
  - 기존 베타 버전의 코드를 코루틴 `suspend` 기반 신규 공식 API 패턴으로 최신화
  - 불필요한 광고 프리로딩 로직을 비활성화하여 리소스 낭비 차단
- **Compose 환경에서의 광고 안정성 확보 및 크래시 예방**
  - 목록 스크롤 프리페치 시 뷰가 중복 부착되어 발생하던 뷰그룹 Fatal 크래시 수정
  - 수동으로 자원을 해제하던 `DisposableEffect` 구조를 제거하고, 컴포즈 공식 `onRelease` 수명주기 콜백으로 광고 자원 정리 일원화
  - 백그라운드 콜백을 코루틴 스코프 내에서 통제하여 UI 스레드 위반 크래시 방지

## Screenshot 📸
- N/A

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
- AOSP의 `AndroidView` 동작 방식을 참고하여, 광고 뷰의 릴리즈 주기를 Compose 수명주기와 완전히 일치시켰습니다. 
