### PR TITLE
[FIX/#834] 공지 상세 화면 UI 개선

### DIFF
--- a/presentation/notification/src/main/java/com/hilingual/presentation/notification/detail/component/NotificationDetailContent.kt
+++ b/presentation/notification/src/main/java/com/hilingual/presentation/notification/detail/component/NotificationDetailContent.kt
@@ -34,6 +34,9 @@ import com.hilingual.core.designsystem.theme.HilingualTheme
 import com.mohamedrejeb.richeditor.model.rememberRichTextState
 import com.mohamedrejeb.richeditor.ui.material3.RichText
 
+private const val NON_BREAKING_SPACE = ' '
+private val ORDERED_LIST_MARKER_REGEX = Regex("""(?m)^([ \t]*)(\d+)\. """)
+
 @Composable
 internal fun NotificationDetailContent(
     title: String,
@@ -47,7 +50,7 @@ internal fun NotificationDetailContent(
     LaunchedEffect(content) {
         textState.config.linkColor = colors.black
         textState.config.linkTextDecoration = TextDecoration.None
-        textState.setMarkdown(content)
+        textState.setMarkdown(content.escapeOrderedListMarkers())
     }
 
     Column(
@@ -85,6 +88,11 @@ internal fun NotificationDetailContent(
         )
     }
 }
+
+private fun String.escapeOrderedListMarkers(): String =
+    ORDERED_LIST_MARKER_REGEX.replace(this) { match ->
+        "${match.groupValues[1]}${match.groupValues[2]}.${NON_BREAKING_SPACE}"
+    }
 
 @Preview(showBackground = true)
 @Composable

--- a/presentation/notification/src/main/java/com/hilingual/presentation/notification/detail/component/NotificationDetailContent.kt
+++ b/presentation/notification/src/main/java/com/hilingual/presentation/notification/detail/component/NotificationDetailContent.kt
@@ -34,7 +34,7 @@ import com.hilingual.core.designsystem.theme.HilingualTheme
 import com.mohamedrejeb.richeditor.model.rememberRichTextState
 import com.mohamedrejeb.richeditor.ui.material3.RichText
 
-private const val NON_BREAKING_SPACE = ' '
+private const val NON_BREAKING_SPACE = '\u00A0'
 private val ORDERED_LIST_MARKER_REGEX = Regex("""(?m)^([ \t]*)(\d+)\. """)
 
 @Composable

--- a/presentation/notification/src/main/java/com/hilingual/presentation/notification/detail/component/NotificationDetailContent.kt
+++ b/presentation/notification/src/main/java/com/hilingual/presentation/notification/detail/component/NotificationDetailContent.kt
@@ -48,8 +48,8 @@ internal fun NotificationDetailContent(
     val colors = HilingualTheme.colors
 
     LaunchedEffect(content) {
-        textState.config.linkColor = colors.black
-        textState.config.linkTextDecoration = TextDecoration.None
+        textState.config.linkColor = colors.hilingualBlue
+        textState.config.linkTextDecoration = TextDecoration.Underline
         textState.setMarkdown(content.escapeOrderedListMarkers())
     }
 

--- a/presentation/notification/src/main/java/com/hilingual/presentation/notification/detail/component/NotificationDetailContent.kt
+++ b/presentation/notification/src/main/java/com/hilingual/presentation/notification/detail/component/NotificationDetailContent.kt
@@ -20,6 +20,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -50,7 +52,8 @@ internal fun NotificationDetailContent(
 
     Column(
         modifier = modifier
-            .background(HilingualTheme.colors.white),
+            .background(HilingualTheme.colors.white)
+            .verticalScroll(rememberScrollState()),
     ) {
         Column(
             modifier = Modifier


### PR DESCRIPTION
## Related issue 🛠
- closed #834

## Work Description ✏️
#### 1. 공지사항 스크롤이 안되던 문제
- 공지 상세(NotificationDetailContent) 화면에 세로 스크롤을 추가해, 내용이 길어도 끝까지 볼 수 있도록 수정했습니다.

#### 2. 마크다운 순서 리스트 번호가 모두 `1.`로 초기화되던 버그

원인)
`1.` `2.` `3.` 항목 사이에 일반 설명 문단이 끼면 CommonMark 파서가 각 항목을 "단일 아이템짜리 별도 리스트"로 끊고, `compose-rich-editor`가 리스트 시작 번호를 보존하지 않아 매번 1부터 렌더링됩니다.

해결)
줄 시작 `N. ` 마커의 점 뒤 공백을 비분리 공백(U+00A0)으로 치환해, 순서 리스트로 파싱되지 않고 작성자가 쓴 번호 그대로 표시되도록 했습니다.

예시 문장)
```
1. 48시간 내의 일기만 작성할 수 있어요
매일 일기 작성할 수 있는 습관을 기를 수 있도록 시간 제한을 두고 있습니다.
어제와 오늘, 이틀 동안만 일기를 작성할 수 있어요.

2. 임시저장은 일자 당 하나만 가능해요
3. 삭제 후 재작성은 불가능해요
```

| AS-IS | TO-BE |
|:--:|:--:|
<img width="394" src="https://github.com/user-attachments/assets/5ca96783-76d1-447a-a09a-6469035fd04d" /> | <img width="394" alt="image" src="https://github.com/user-attachments/assets/683d1b7d-5f1b-453e-bb70-2da07170249a" />

## To Reviewers 📢
리스트 번호 이슈는 RichText 라이브러리가 리스트의 `start` 번호를 지원하지 않아, 마커를 일반 텍스트로 렌더링하는 방식(비분리 공백 치환)으로 우회했습니다.
따라서 리스트 들여쓰기 스타일은 적용되지 않고, 번호+본문이 일반 문단으로 표시됩니다.