### PR TITLE
[FEAT/#854] 피드백 토글 UI 수정

### DIFF
--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/button/HilingualSegmentedButton.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/button/HilingualSegmentedButton.kt
@@ -45,8 +45,6 @@ fun HilingualSegmentedButton(
     activeContentColor: Color = HilingualTheme.colors.hilingualOrange,
     inactiveContentColor: Color = HilingualTheme.colors.gray500,
 ) {
-    if (options.isEmpty()) return
-
     val coercedSelectedIndex = selectedIndex.coerceIn(0, options.lastIndex)
     val animatedIndex by animateFloatAsState(
         targetValue = coercedSelectedIndex.toFloat(),

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/button/HilingualSegmentedButton.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/button/HilingualSegmentedButton.kt
@@ -31,28 +31,6 @@ import com.hilingual.core.designsystem.theme.HilingualTheme
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
-data class SegmentedButtonColors(
-    val backgroundColor: Color,
-    val thumbColor: Color,
-    val activeContentColor: Color,
-    val inactiveContentColor: Color,
-) {
-    companion object {
-        @Composable
-        fun defaults(
-            backgroundColor: Color = HilingualTheme.colors.gray200,
-            thumbColor: Color = HilingualTheme.colors.white,
-            activeContentColor: Color = HilingualTheme.colors.hilingualOrange,
-            inactiveContentColor: Color = HilingualTheme.colors.gray500,
-        ): SegmentedButtonColors = SegmentedButtonColors(
-            backgroundColor = backgroundColor,
-            thumbColor = thumbColor,
-            activeContentColor = activeContentColor,
-            inactiveContentColor = inactiveContentColor,
-        )
-    }
-}
-
 @Composable
 fun HilingualSegmentedButton(
     options: ImmutableList<String>,
@@ -128,6 +106,28 @@ fun HilingualSegmentedButton(
                 }
             }
         }
+    }
+}
+
+data class SegmentedButtonColors(
+    val backgroundColor: Color,
+    val thumbColor: Color,
+    val activeContentColor: Color,
+    val inactiveContentColor: Color,
+) {
+    companion object {
+        @Composable
+        fun defaults(
+            backgroundColor: Color = HilingualTheme.colors.gray200,
+            thumbColor: Color = HilingualTheme.colors.white,
+            activeContentColor: Color = HilingualTheme.colors.hilingualOrange,
+            inactiveContentColor: Color = HilingualTheme.colors.gray500,
+        ): SegmentedButtonColors = SegmentedButtonColors(
+            backgroundColor = backgroundColor,
+            thumbColor = thumbColor,
+            activeContentColor = activeContentColor,
+            inactiveContentColor = inactiveContentColor,
+        )
     }
 }
 

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/button/HilingualSegmentedButton.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/button/HilingualSegmentedButton.kt
@@ -59,7 +59,7 @@ fun HilingualSegmentedButton(
             .background(colors.backgroundColor)
             .padding(contentPadding),
     ) {
-        Box( // thumb
+        Box(  // Sliding thumb: visual indicator that moves horizontally based on selected index
             modifier = Modifier
                 .matchParentSize()
                 .layout { measurable, constraints ->

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/button/HilingualSegmentedButton.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/button/HilingualSegmentedButton.kt
@@ -43,7 +43,7 @@ fun HilingualSegmentedButton(
     backgroundColor: Color = HilingualTheme.colors.gray200,
     thumbColor: Color = HilingualTheme.colors.white,
     activeContentColor: Color = HilingualTheme.colors.hilingualOrange,
-    inactiveContentColor: Color = HilingualTheme.colors.gray500
+    inactiveContentColor: Color = HilingualTheme.colors.gray500,
 ) {
     if (options.isEmpty()) return
 
@@ -73,7 +73,7 @@ fun HilingualSegmentedButton(
                         constraints.copy(
                             minWidth = thumbWidthPx,
                             maxWidth = thumbWidthPx,
-                        )
+                        ),
                     )
                     layout(constraints.maxWidth, placeable.height) {
                         val x = (animatedIndex * (thumbWidthPx + itemSpacingPx)).toInt()
@@ -123,7 +123,7 @@ fun HilingualSegmentedButtonPreview() {
         HilingualSegmentedButton(
             options = persistentListOf("교정본", "원본"),
             selectedIndex = isSelected,
-            onSelect = { isSelected = it }
+            onSelect = { isSelected = it },
         )
     }
 }

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/button/HilingualSegmentedButton.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/button/HilingualSegmentedButton.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -133,7 +134,7 @@ data class SegmentedButtonColors(
 
 @Preview
 @Composable
-fun HilingualSegmentedButtonPreview() {
+private fun HilingualSegmentedButtonPreview() {
     HilingualTheme {
         var isSelected by remember { mutableIntStateOf(0) }
 

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/button/HilingualSegmentedButton.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/button/HilingualSegmentedButton.kt
@@ -31,6 +31,28 @@ import com.hilingual.core.designsystem.theme.HilingualTheme
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
+data class SegmentedButtonColors(
+    val backgroundColor: Color,
+    val thumbColor: Color,
+    val activeContentColor: Color,
+    val inactiveContentColor: Color,
+) {
+    companion object {
+        @Composable
+        fun defaults(
+            backgroundColor: Color = HilingualTheme.colors.gray200,
+            thumbColor: Color = HilingualTheme.colors.white,
+            activeContentColor: Color = HilingualTheme.colors.hilingualOrange,
+            inactiveContentColor: Color = HilingualTheme.colors.gray500,
+        ): SegmentedButtonColors = SegmentedButtonColors(
+            backgroundColor = backgroundColor,
+            thumbColor = thumbColor,
+            activeContentColor = activeContentColor,
+            inactiveContentColor = inactiveContentColor,
+        )
+    }
+}
+
 @Composable
 fun HilingualSegmentedButton(
     options: ImmutableList<String>,
@@ -40,10 +62,7 @@ fun HilingualSegmentedButton(
     thumbWidth: Dp = 62.dp,
     itemSpacing: Dp = 3.dp,
     contentPadding: PaddingValues = PaddingValues(3.dp),
-    backgroundColor: Color = HilingualTheme.colors.gray200,
-    thumbColor: Color = HilingualTheme.colors.white,
-    activeContentColor: Color = HilingualTheme.colors.hilingualOrange,
-    inactiveContentColor: Color = HilingualTheme.colors.gray500,
+    colors: SegmentedButtonColors = SegmentedButtonColors.defaults(),
 ) {
     val coercedSelectedIndex = selectedIndex.coerceIn(0, options.lastIndex)
     val animatedIndex by animateFloatAsState(
@@ -58,7 +77,7 @@ fun HilingualSegmentedButton(
     Box(
         modifier = modifier
             .clip(CircleShape)
-            .background(backgroundColor)
+            .background(colors.backgroundColor)
             .padding(contentPadding),
     ) {
         Box( // thumb
@@ -79,7 +98,7 @@ fun HilingualSegmentedButton(
                     }
                 }
                 .clip(CircleShape)
-                .background(thumbColor),
+                .background(colors.thumbColor),
         )
 
         Row {
@@ -99,7 +118,7 @@ fun HilingualSegmentedButton(
                         modifier = Modifier
                             .widthIn(min = 46.dp),
                         textAlign = TextAlign.Center,
-                        color = if (selected) activeContentColor else inactiveContentColor,
+                        color = if (selected) colors.activeContentColor else colors.inactiveContentColor,
                         style = if (selected) HilingualTheme.typography.bodyM14 else HilingualTheme.typography.bodyR14,
                     )
                 }

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/button/HilingualSegmentedButton.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/button/HilingualSegmentedButton.kt
@@ -42,9 +42,9 @@ fun HilingualSegmentedButton(
     contentPadding: PaddingValues = PaddingValues(3.dp),
     colors: SegmentedButtonColors = SegmentedButtonColors.defaults(),
 ) {
-    val coercedSelectedIndex = selectedIndex.coerceIn(0, options.lastIndex)
+    val coercedSelectedIndex = selectedIndex.takeIf { it in options.indices }
     val animatedIndex by animateFloatAsState(
-        targetValue = coercedSelectedIndex.toFloat(),
+        targetValue = coercedSelectedIndex?.toFloat() ?: 0f,
         animationSpec = spring(
             dampingRatio = 0.8f,
             stiffness = 380f,
@@ -58,26 +58,28 @@ fun HilingualSegmentedButton(
             .background(colors.backgroundColor)
             .padding(contentPadding),
     ) {
-        Box( // Sliding thumb: visual indicator that moves horizontally based on selected index
-            modifier = Modifier
-                .matchParentSize()
-                .layout { measurable, constraints ->
-                    val thumbWidthPx = thumbWidth.roundToPx()
-                    val itemSpacingPx = itemSpacing.roundToPx()
-                    val placeable = measurable.measure(
-                        constraints.copy(
-                            minWidth = thumbWidthPx,
-                            maxWidth = thumbWidthPx,
-                        ),
-                    )
-                    layout(constraints.maxWidth, placeable.height) {
-                        val x = (animatedIndex * (thumbWidthPx + itemSpacingPx)).toInt()
-                        placeable.placeRelative(x, 0)
+        coercedSelectedIndex?.let {
+            Box( // Sliding thumb: visual indicator that moves horizontally based on selected index
+                modifier = Modifier
+                    .matchParentSize()
+                    .layout { measurable, constraints ->
+                        val thumbWidthPx = thumbWidth.roundToPx()
+                        val itemSpacingPx = itemSpacing.roundToPx()
+                        val placeable = measurable.measure(
+                            constraints.copy(
+                                minWidth = thumbWidthPx,
+                                maxWidth = thumbWidthPx,
+                            ),
+                        )
+                        layout(constraints.maxWidth, placeable.height) {
+                            val x = (animatedIndex * (thumbWidthPx + itemSpacingPx)).toInt()
+                            placeable.placeRelative(x, 0)
+                        }
                     }
-                }
-                .clip(CircleShape)
-                .background(colors.thumbColor),
-        )
+                    .clip(CircleShape)
+                    .background(colors.thumbColor),
+            )
+        }
 
         Row {
             options.forEachIndexed { index, label ->

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/button/HilingualSegmentedButton.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/button/HilingualSegmentedButton.kt
@@ -1,4 +1,4 @@
-package com.hilingual.core.designsystem.component.toggle
+package com.hilingual.core.designsystem.component.button
 
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
@@ -32,7 +32,7 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
 @Composable
-fun HilingualSegmentedToggle(
+fun HilingualSegmentedButton(
     options: ImmutableList<String>,
     selectedIndex: Int,
     onSelect: (Int) -> Unit,
@@ -116,11 +116,11 @@ fun HilingualSegmentedToggle(
 
 @Preview
 @Composable
-fun HilingualSegmentedTogglePreview() {
+fun HilingualSegmentedButtonPreview() {
     HilingualTheme {
         var isSelected by remember { mutableIntStateOf(0) }
 
-        HilingualSegmentedToggle(
+        HilingualSegmentedButton(
             options = persistentListOf("교정본", "원본"),
             selectedIndex = isSelected,
             onSelect = { isSelected = it }

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/button/HilingualSegmentedButton.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/button/HilingualSegmentedButton.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -59,7 +58,7 @@ fun HilingualSegmentedButton(
             .background(colors.backgroundColor)
             .padding(contentPadding),
     ) {
-        Box(  // Sliding thumb: visual indicator that moves horizontally based on selected index
+        Box( // Sliding thumb: visual indicator that moves horizontally based on selected index
             modifier = Modifier
                 .matchParentSize()
                 .layout { measurable, constraints ->

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/toggle/HilingualSegmentedToggle.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/toggle/HilingualSegmentedToggle.kt
@@ -3,13 +3,10 @@ package com.hilingual.core.designsystem.component.toggle
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
@@ -27,7 +24,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.hilingual.core.common.extension.noRippleClickable
 import com.hilingual.core.designsystem.theme.HilingualTheme
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
@@ -38,14 +37,19 @@ fun HilingualSegmentedToggle(
     selectedIndex: Int,
     onSelect: (Int) -> Unit,
     modifier: Modifier = Modifier,
+    thumbWidth: Dp = 62.dp,
+    itemSpacing: Dp = 3.dp,
     contentPadding: PaddingValues = PaddingValues(3.dp),
     backgroundColor: Color = HilingualTheme.colors.gray200,
     thumbColor: Color = HilingualTheme.colors.white,
     activeContentColor: Color = HilingualTheme.colors.hilingualOrange,
     inactiveContentColor: Color = HilingualTheme.colors.gray500
 ) {
+    if (options.isEmpty()) return
+
+    val coercedSelectedIndex = selectedIndex.coerceIn(0, options.lastIndex)
     val animatedIndex by animateFloatAsState(
-        targetValue = selectedIndex.toFloat(),
+        targetValue = coercedSelectedIndex.toFloat(),
         animationSpec = spring(
             dampingRatio = 0.8f,
             stiffness = 380f,
@@ -59,21 +63,20 @@ fun HilingualSegmentedToggle(
             .background(backgroundColor)
             .padding(contentPadding),
     ) {
-        val count = options.size
-
-        Box(
+        Box( // thumb
             modifier = Modifier
                 .matchParentSize()
                 .layout { measurable, constraints ->
-                    val thumbWidth = constraints.maxWidth / count
+                    val thumbWidthPx = thumbWidth.roundToPx()
+                    val itemSpacingPx = itemSpacing.roundToPx()
                     val placeable = measurable.measure(
                         constraints.copy(
-                            minWidth = thumbWidth,
-                            maxWidth = thumbWidth,
+                            minWidth = thumbWidthPx,
+                            maxWidth = thumbWidthPx,
                         )
                     )
                     layout(constraints.maxWidth, placeable.height) {
-                        val x = (animatedIndex * thumbWidth).toInt()
+                        val x = (animatedIndex * (thumbWidthPx + itemSpacingPx)).toInt()
                         placeable.placeRelative(x, 0)
                     }
                 }
@@ -81,22 +84,22 @@ fun HilingualSegmentedToggle(
                 .background(thumbColor),
         )
 
-        Row(Modifier.fillMaxWidth()) {
+        Row {
             options.forEachIndexed { index, label ->
-                val selected = index == selectedIndex
+                val selected = index == coercedSelectedIndex
                 Box(
                     modifier = Modifier
-                        .weight(1f)
-                        .padding(horizontal = 8.dp, vertical = 4.dp)
-                        .clickable(
-                            interactionSource = remember { MutableInteractionSource() },
-                            indication = null,
-                        ) { onSelect(index) },
+                        .width(thumbWidth)
+                        .noRippleClickable(
+                            onClick = { onSelect(index) },
+                        )
+                        .padding(PaddingValues(horizontal = 8.dp, vertical = 4.dp)),
                     contentAlignment = Alignment.Center,
                 ) {
                     Text(
                         text = label,
-                        modifier = Modifier.widthIn(min = 40.dp),
+                        modifier = Modifier
+                            .widthIn(min = 46.dp),
                         textAlign = TextAlign.Center,
                         color = if (selected) activeContentColor else inactiveContentColor,
                         style = if (selected) HilingualTheme.typography.bodyM14 else HilingualTheme.typography.bodyR14,
@@ -104,7 +107,7 @@ fun HilingualSegmentedToggle(
                 }
 
                 if (index != options.lastIndex) {
-                    Spacer(modifier = Modifier.width(4.dp))
+                    Spacer(modifier = Modifier.width(itemSpacing))
                 }
             }
         }
@@ -120,9 +123,7 @@ fun HilingualSegmentedTogglePreview() {
         HilingualSegmentedToggle(
             options = persistentListOf("교정본", "원본"),
             selectedIndex = isSelected,
-            onSelect = { isSelected = it },
-            modifier = Modifier
-                .width(133.dp),
+            onSelect = { isSelected = it }
         )
     }
 }

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/toggle/HilingualSegmentedToggle.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/toggle/HilingualSegmentedToggle.kt
@@ -6,13 +6,14 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -22,33 +23,31 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.layout
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.hilingual.core.designsystem.theme.HilingualTheme
-
-// 색상 토큰 (이미지 기준)
-private val TrackColor = Color(0xFFE3E3E3)      // 바깥 트랙(연한 회색)
-private val ThumbColor = Color(0xFFFFFFFF)      // 선택된 칸(흰색)
-private val SelectedText = Color(0xFFF26B2A)    // 주황 텍스트
-private val UnselectedText = Color(0xFF8A8A8A)  // 회색 텍스트
-private val ThumbWidth = 42.dp
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 fun HilingualSegmentedToggle(
-    options: List<String>,
+    options: ImmutableList<String>,
     selectedIndex: Int,
     onSelect: (Int) -> Unit,
     modifier: Modifier = Modifier,
-    padding: Dp = 3.dp,
+    contentPadding: PaddingValues = PaddingValues(3.dp),
+    backgroundColor: Color = HilingualTheme.colors.gray200,
+    thumbColor: Color = HilingualTheme.colors.white,
+    activeContentColor: Color = HilingualTheme.colors.hilingualOrange,
+    inactiveContentColor: Color = HilingualTheme.colors.gray500
 ) {
     val animatedIndex by animateFloatAsState(
         targetValue = selectedIndex.toFloat(),
         animationSpec = spring(
-            dampingRatio = 0.8f,   // 살짝 통통 튀는 느낌
+            dampingRatio = 0.8f,
             stiffness = 380f,
         ),
         label = "thumbOffset",
@@ -56,16 +55,14 @@ fun HilingualSegmentedToggle(
 
     Box(
         modifier = modifier
-            .clip(RoundedCornerShape(percent = 50))
-            .background(TrackColor)
-            .padding(padding),
+            .clip(CircleShape)
+            .background(backgroundColor)
+            .padding(contentPadding),
     ) {
         val count = options.size
 
-        // 움직이는 흰색 thumb
         Box(
             modifier = Modifier
-                .width(ThumbWidth)
                 .matchParentSize()
                 .layout { measurable, constraints ->
                     val thumbWidth = constraints.maxWidth / count
@@ -80,12 +77,10 @@ fun HilingualSegmentedToggle(
                         placeable.placeRelative(x, 0)
                     }
                 }
-                .shadow(4.dp, RoundedCornerShape(percent = 50))
-                .clip(RoundedCornerShape(percent = 50))
-                .background(ThumbColor),
+                .clip(CircleShape)
+                .background(thumbColor),
         )
 
-        // 텍스트 라벨 (thumb 위에 균등 분할로 올림)
         Row(Modifier.fillMaxWidth()) {
             options.forEachIndexed { index, label ->
                 val selected = index == selectedIndex
@@ -93,7 +88,6 @@ fun HilingualSegmentedToggle(
                     modifier = Modifier
                         .weight(1f)
                         .padding(horizontal = 8.dp, vertical = 4.dp)
-                        .clip(RoundedCornerShape(percent = 50))
                         .clickable(
                             interactionSource = remember { MutableInteractionSource() },
                             indication = null,
@@ -102,16 +96,20 @@ fun HilingualSegmentedToggle(
                 ) {
                     Text(
                         text = label,
-                        modifier = Modifier.width(40.dp),
-                        color = if (selected) SelectedText else UnselectedText,
+                        modifier = Modifier.widthIn(min = 40.dp),
+                        textAlign = TextAlign.Center,
+                        color = if (selected) activeContentColor else inactiveContentColor,
                         style = if (selected) HilingualTheme.typography.bodyM14 else HilingualTheme.typography.bodyR14,
                     )
+                }
+
+                if (index != options.lastIndex) {
+                    Spacer(modifier = Modifier.width(4.dp))
                 }
             }
         }
     }
 }
-
 
 @Preview
 @Composable
@@ -120,12 +118,11 @@ fun HilingualSegmentedTogglePreview() {
         var isSelected by remember { mutableIntStateOf(0) }
 
         HilingualSegmentedToggle(
-            options = listOf("교정본", "원본"),
+            options = persistentListOf("교정본", "원본"),
             selectedIndex = isSelected,
             onSelect = { isSelected = it },
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(24.dp),
+                .width(133.dp),
         )
     }
 }

--- a/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/toggle/HilingualSegmentedToggle.kt
+++ b/core/designsystem/src/main/java/com/hilingual/core/designsystem/component/toggle/HilingualSegmentedToggle.kt
@@ -1,0 +1,131 @@
+package com.hilingual.core.designsystem.component.toggle
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.hilingual.core.designsystem.theme.HilingualTheme
+
+// 색상 토큰 (이미지 기준)
+private val TrackColor = Color(0xFFE3E3E3)      // 바깥 트랙(연한 회색)
+private val ThumbColor = Color(0xFFFFFFFF)      // 선택된 칸(흰색)
+private val SelectedText = Color(0xFFF26B2A)    // 주황 텍스트
+private val UnselectedText = Color(0xFF8A8A8A)  // 회색 텍스트
+private val ThumbWidth = 42.dp
+
+@Composable
+fun HilingualSegmentedToggle(
+    options: List<String>,
+    selectedIndex: Int,
+    onSelect: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+    padding: Dp = 3.dp,
+) {
+    val animatedIndex by animateFloatAsState(
+        targetValue = selectedIndex.toFloat(),
+        animationSpec = spring(
+            dampingRatio = 0.8f,   // 살짝 통통 튀는 느낌
+            stiffness = 380f,
+        ),
+        label = "thumbOffset",
+    )
+
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(percent = 50))
+            .background(TrackColor)
+            .padding(padding),
+    ) {
+        val count = options.size
+
+        // 움직이는 흰색 thumb
+        Box(
+            modifier = Modifier
+                .width(ThumbWidth)
+                .matchParentSize()
+                .layout { measurable, constraints ->
+                    val thumbWidth = constraints.maxWidth / count
+                    val placeable = measurable.measure(
+                        constraints.copy(
+                            minWidth = thumbWidth,
+                            maxWidth = thumbWidth,
+                        )
+                    )
+                    layout(constraints.maxWidth, placeable.height) {
+                        val x = (animatedIndex * thumbWidth).toInt()
+                        placeable.placeRelative(x, 0)
+                    }
+                }
+                .shadow(4.dp, RoundedCornerShape(percent = 50))
+                .clip(RoundedCornerShape(percent = 50))
+                .background(ThumbColor),
+        )
+
+        // 텍스트 라벨 (thumb 위에 균등 분할로 올림)
+        Row(Modifier.fillMaxWidth()) {
+            options.forEachIndexed { index, label ->
+                val selected = index == selectedIndex
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(horizontal = 8.dp, vertical = 4.dp)
+                        .clip(RoundedCornerShape(percent = 50))
+                        .clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null,
+                        ) { onSelect(index) },
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = label,
+                        modifier = Modifier.width(40.dp),
+                        color = if (selected) SelectedText else UnselectedText,
+                        style = if (selected) HilingualTheme.typography.bodyM14 else HilingualTheme.typography.bodyR14,
+                    )
+                }
+            }
+        }
+    }
+}
+
+
+@Preview
+@Composable
+fun HilingualSegmentedTogglePreview() {
+    HilingualTheme {
+        var isSelected by remember { mutableIntStateOf(0) }
+
+        HilingualSegmentedToggle(
+            options = listOf("교정본", "원본"),
+            selectedIndex = isSelected,
+            onSelect = { isSelected = it },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(24.dp),
+        )
+    }
+}

--- a/core/ui/src/main/java/com/hilingual/core/ui/component/item/diary/card/FeedbackCard.kt
+++ b/core/ui/src/main/java/com/hilingual/core/ui/component/item/diary/card/FeedbackCard.kt
@@ -41,7 +41,7 @@ import com.hilingual.core.designsystem.theme.HilingualTheme
 @Composable
 internal fun FeedbackCard(
     originalText: String,
-    feedbackText: String,
+    correctedText: String,
     explain: String,
     modifier: Modifier = Modifier,
 ) {
@@ -54,7 +54,7 @@ internal fun FeedbackCard(
     ) {
         FeedbackTopContent(
             originalText = originalText,
-            feedbackText = feedbackText,
+            correctedText = correctedText,
         )
 
         HorizontalDivider(
@@ -73,7 +73,7 @@ internal fun FeedbackCard(
 @Composable
 private fun FeedbackTopContent(
     originalText: String,
-    feedbackText: String,
+    correctedText: String,
 ) {
     Column(
         verticalArrangement = Arrangement.spacedBy(2.dp),
@@ -84,7 +84,7 @@ private fun FeedbackTopContent(
         )
 
         FeedbackSentence(
-            text = feedbackText,
+            text = correctedText,
             isFeedback = true,
         )
     }
@@ -135,12 +135,12 @@ private fun FeedbackCardPreview() {
         ) {
             FeedbackCard(
                 originalText = "i’m drinking milk because I easily get stomachache",
-                feedbackText = "I’m drinking milk because I get stomachaches easily",
+                correctedText = "I’m drinking milk because I get stomachaches easily",
                 explain = "a stomachache처럼 가산명사는 ~게 작성하는게 맞는 표현이에요. ‘easily’의 어순을 문장 마지막에 작성하여 더 정확해졌어요.",
             )
             FeedbackCard(
                 originalText = "I was planning to arrive it here around 13:30",
-                feedbackText = "I was planning to arrive here around 1:30 p.m",
+                correctedText = "I was planning to arrive here around 1:30 p.m",
                 explain = "arrive는 자동사이기 때문에 직접 목적어 ‘it’을 쓸 수 없어요. " +
                     "‘arrive at the station’, ‘arrive here’처럼 써야 맞는 표현이에요!",
             )

--- a/core/ui/src/main/java/com/hilingual/core/ui/component/item/diary/card/diarycard/DiaryCard.kt
+++ b/core/ui/src/main/java/com/hilingual/core/ui/component/item/diary/card/diarycard/DiaryCard.kt
@@ -41,29 +41,29 @@ import com.hilingual.core.designsystem.theme.PretendardMedium
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
-private const val MAX_AI = 1500
+private const val MAX_CORRECTED = 1500
 private const val MAX_ORIGINAL = 1000
 
 @Composable
 internal fun DiaryCard(
-    isAIWritten: Boolean,
+    isShowCorrectedDiary: Boolean,
     diaryContent: String,
     onImageClick: () -> Unit,
     modifier: Modifier = Modifier,
     diffRanges: ImmutableList<Pair<Int, Int>> = persistentListOf(),
     imageUrl: String? = null,
 ) {
-    val maxContentLength = if (isAIWritten) MAX_AI else MAX_ORIGINAL
+    val maxContentLength = if (isShowCorrectedDiary) MAX_CORRECTED else MAX_ORIGINAL
     val content = diaryContent.take(maxContentLength)
 
     val ttsController = rememberTtsController()
     val textLayoutResult = remember { mutableStateOf<TextLayoutResult?>(null) }
 
-    LaunchedEffect(isAIWritten) {
-        if (!isAIWritten) ttsController.stop()
+    LaunchedEffect(isShowCorrectedDiary) {
+        if (!isShowCorrectedDiary) ttsController.stop()
     }
 
-    val displayText = if (isAIWritten) {
+    val displayText = if (isShowCorrectedDiary) {
         buildDiaryAnnotatedString(
             content = content,
             diffRanges = diffRanges,
@@ -103,7 +103,7 @@ internal fun DiaryCard(
             modifier = Modifier
                 .fillMaxWidth()
                 .then(
-                    if (isAIWritten) {
+                    if (isShowCorrectedDiary) {
                         Modifier.pointerInput(content) {
                             detectTapGestures { tapOffset ->
                                 val charOffset = textLayoutResult.value
@@ -123,7 +123,7 @@ internal fun DiaryCard(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.Bottom,
         ) {
-            if (isAIWritten) {
+            if (isShowCorrectedDiary) {
                 TtsPlayButton(
                     isPlaying = ttsController.isPlaying,
                     onClick = { ttsController.toggle(content) },
@@ -197,7 +197,7 @@ private fun buildDiaryAnnotatedString(
 }
 
 private data class DiaryCardPreviewState(
-    val isAIDiary: Boolean,
+    val isShowCorrectedDiary: Boolean,
     val imageUrl: String?,
     val content: String,
     val diffRanges: ImmutableList<Pair<Int, Int>>,
@@ -207,19 +207,19 @@ private class DiaryContentCardPreviewProvider :
     PreviewParameterProvider<DiaryCardPreviewState> {
     override val values = sequenceOf(
         DiaryCardPreviewState(
-            isAIDiary = false,
+            isShowCorrectedDiary = false,
             imageUrl = "",
             content = "이미지 & 텍스트",
             diffRanges = persistentListOf(),
         ),
         DiaryCardPreviewState(
-            isAIDiary = false,
+            isShowCorrectedDiary = false,
             imageUrl = null,
             content = "I want to become a teacher future. Because I like child.",
             diffRanges = persistentListOf(),
         ),
         DiaryCardPreviewState(
-            isAIDiary = true,
+            isShowCorrectedDiary = true,
             imageUrl = null,
             content =
             "Today I went to the cafe Conhas in Yeonnam to meet my teammates.\n " +
@@ -254,7 +254,7 @@ private fun DiaryCardPreview(
 ) {
     HilingualTheme {
         DiaryCard(
-            isAIWritten = state.isAIDiary,
+            isShowCorrectedDiary = state.isShowCorrectedDiary,
             diaryContent = state.content,
             imageUrl = state.imageUrl,
             diffRanges = state.diffRanges,

--- a/core/ui/src/main/java/com/hilingual/core/ui/component/item/diary/tab/GrammarSpellingTab.kt
+++ b/core/ui/src/main/java/com/hilingual/core/ui/component/item/diary/tab/GrammarSpellingTab.kt
@@ -32,8 +32,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.AnnotatedString
@@ -51,6 +51,7 @@ import com.hilingual.core.ui.component.dropdown.Topics
 import com.hilingual.core.ui.component.item.diary.card.FeedbackCard
 import com.hilingual.core.ui.component.item.diary.card.FeedbackEmptyCard
 import com.hilingual.core.ui.component.item.diary.card.diarycard.DiaryCard
+import com.hilingual.core.ui.component.item.diary.toggle.DiaryViewMode
 import com.hilingual.core.ui.component.item.diary.toggle.DiaryViewModeToggle
 import com.hilingual.core.ui.model.diary.DiaryContent
 import com.hilingual.core.ui.model.diary.FeedbackContent
@@ -64,13 +65,13 @@ fun GrammarSpellingTab(
     topics: Topics,
     diaryContent: DiaryContent,
     feedbackList: ImmutableList<FeedbackContent>,
-    isAIWrittenDiary: Boolean,
     onImageClick: () -> Unit,
     onToggleViewMode: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
     isAdVisible: Boolean = false,
 ) {
     val adHolder = if (isAdVisible) rememberBannerAdView(INLINE_BANNER) else null
+    var diaryViewMode by rememberSaveable { mutableStateOf(DiaryViewMode.CORRECTED) }
 
     LazyColumn(
         state = listState,
@@ -93,8 +94,11 @@ fun GrammarSpellingTab(
                     color = HilingualTheme.colors.gray700,
                 )
                 DiaryViewModeToggle(
-                    isAIWritten = isAIWrittenDiary,
-                    onToggle = onToggleViewMode,
+                    viewMode = diaryViewMode,
+                    onToggleDiaryViewMode = {
+                        diaryViewMode = it
+                        onToggleViewMode(it.isAIWritten)
+                    },
                 )
             }
             Spacer(Modifier.height(12.dp))
@@ -111,8 +115,8 @@ fun GrammarSpellingTab(
         item {
             with(diaryContent) {
                 DiaryCard(
-                    isAIWritten = isAIWrittenDiary,
-                    diaryContent = if (isAIWrittenDiary) aiText else originalText,
+                    isAIWritten = diaryViewMode.isAIWritten,
+                    diaryContent = if (diaryViewMode.isAIWritten) aiText else originalText,
                     diffRanges = diffRanges,
                     imageUrl = imageUrl,
                     onImageClick = onImageClick,
@@ -195,7 +199,6 @@ private fun getFeedbackTitleAnnotatedString(
 @Preview(showBackground = true)
 @Composable
 private fun GrammarSpellingTabPreview() {
-    var isAIWritten by remember { mutableStateOf(true) }
     HilingualTheme {
         GrammarSpellingTab(
             listState = rememberLazyListState(),
@@ -203,9 +206,8 @@ private fun GrammarSpellingTabPreview() {
             diaryContent = DiaryContent(),
             topics = Topics(),
             feedbackList = persistentListOf(),
-            isAIWrittenDiary = isAIWritten,
             onImageClick = {},
-            onToggleViewMode = { isAIWritten = it },
+            onToggleViewMode = {},
         )
     }
 }

--- a/core/ui/src/main/java/com/hilingual/core/ui/component/item/diary/tab/GrammarSpellingTab.kt
+++ b/core/ui/src/main/java/com/hilingual/core/ui/component/item/diary/tab/GrammarSpellingTab.kt
@@ -60,9 +60,9 @@ fun GrammarSpellingTab(
     topics: Topics,
     diaryContent: DiaryContent,
     feedbackList: ImmutableList<FeedbackContent>,
-    isAIWritten: Boolean,
+    isShowCorrectedDiary: Boolean,
     onImageClick: () -> Unit,
-    onToggleViewMode: (Boolean) -> Unit,
+    onToggleDiaryViewMode: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
     isAdVisible: Boolean = false,
 ) {
@@ -89,8 +89,8 @@ fun GrammarSpellingTab(
                     color = HilingualTheme.colors.gray700,
                 )
                 DiaryViewModeToggle(
-                    isAIWritten = isAIWritten,
-                    onToggleViewMode = onToggleViewMode,
+                    isShowCorrectedDiary = isShowCorrectedDiary,
+                    onToggleViewMode = onToggleDiaryViewMode,
                 )
             }
             Spacer(Modifier.height(12.dp))
@@ -107,8 +107,8 @@ fun GrammarSpellingTab(
         item {
             with(diaryContent) {
                 DiaryCard(
-                    isAIWritten = isAIWritten,
-                    diaryContent = if (isAIWritten) aiText else originalText,
+                    isShowCorrectedDiary = isShowCorrectedDiary,
+                    diaryContent = if (isShowCorrectedDiary) correctedText else originalText,
                     diffRanges = diffRanges,
                     imageUrl = imageUrl,
                     onImageClick = onImageClick,
@@ -138,7 +138,7 @@ fun GrammarSpellingTab(
                 with(content) {
                     FeedbackCard(
                         originalText = originalText,
-                        feedbackText = feedbackText,
+                        correctedText = correctedText,
                         explain = explain,
                         modifier = Modifier
                             .fillMaxWidth()
@@ -196,9 +196,9 @@ private fun GrammarSpellingTabPreview() {
             diaryContent = DiaryContent(),
             topics = Topics(),
             feedbackList = persistentListOf(),
-            isAIWritten = true,
+            isShowCorrectedDiary = true,
             onImageClick = {},
-            onToggleViewMode = {},
+            onToggleDiaryViewMode = {},
         )
     }
 }

--- a/core/ui/src/main/java/com/hilingual/core/ui/component/item/diary/tab/GrammarSpellingTab.kt
+++ b/core/ui/src/main/java/com/hilingual/core/ui/component/item/diary/tab/GrammarSpellingTab.kt
@@ -32,8 +32,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.AnnotatedString

--- a/core/ui/src/main/java/com/hilingual/core/ui/component/item/diary/tab/GrammarSpellingTab.kt
+++ b/core/ui/src/main/java/com/hilingual/core/ui/component/item/diary/tab/GrammarSpellingTab.kt
@@ -51,7 +51,6 @@ import com.hilingual.core.ui.component.dropdown.Topics
 import com.hilingual.core.ui.component.item.diary.card.FeedbackCard
 import com.hilingual.core.ui.component.item.diary.card.FeedbackEmptyCard
 import com.hilingual.core.ui.component.item.diary.card.diarycard.DiaryCard
-import com.hilingual.core.ui.component.item.diary.toggle.DiaryViewMode
 import com.hilingual.core.ui.component.item.diary.toggle.DiaryViewModeToggle
 import com.hilingual.core.ui.model.diary.DiaryContent
 import com.hilingual.core.ui.model.diary.FeedbackContent
@@ -71,7 +70,7 @@ fun GrammarSpellingTab(
     isAdVisible: Boolean = false,
 ) {
     val adHolder = if (isAdVisible) rememberBannerAdView(INLINE_BANNER) else null
-    var diaryViewMode by rememberSaveable { mutableStateOf(DiaryViewMode.CORRECTED) }
+    var isAIWritten by rememberSaveable { mutableStateOf(true) }
 
     LazyColumn(
         state = listState,
@@ -94,10 +93,10 @@ fun GrammarSpellingTab(
                     color = HilingualTheme.colors.gray700,
                 )
                 DiaryViewModeToggle(
-                    viewMode = diaryViewMode,
-                    onToggleDiaryViewMode = {
-                        diaryViewMode = it
-                        onToggleViewMode(it.isAIWritten)
+                    isAIWritten = isAIWritten,
+                    onToggleViewMode = {
+                        isAIWritten = it
+                        onToggleViewMode(it)
                     },
                 )
             }
@@ -115,8 +114,8 @@ fun GrammarSpellingTab(
         item {
             with(diaryContent) {
                 DiaryCard(
-                    isAIWritten = diaryViewMode.isAIWritten,
-                    diaryContent = if (diaryViewMode.isAIWritten) aiText else originalText,
+                    isAIWritten = isAIWritten,
+                    diaryContent = if (isAIWritten) aiText else originalText,
                     diffRanges = diffRanges,
                     imageUrl = imageUrl,
                     onImageClick = onImageClick,

--- a/core/ui/src/main/java/com/hilingual/core/ui/component/item/diary/tab/GrammarSpellingTab.kt
+++ b/core/ui/src/main/java/com/hilingual/core/ui/component/item/diary/tab/GrammarSpellingTab.kt
@@ -30,10 +30,6 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.AnnotatedString
@@ -64,13 +60,13 @@ fun GrammarSpellingTab(
     topics: Topics,
     diaryContent: DiaryContent,
     feedbackList: ImmutableList<FeedbackContent>,
+    isAIWritten: Boolean,
     onImageClick: () -> Unit,
     onToggleViewMode: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
     isAdVisible: Boolean = false,
 ) {
     val adHolder = if (isAdVisible) rememberBannerAdView(INLINE_BANNER) else null
-    var isAIWritten by rememberSaveable { mutableStateOf(true) }
 
     LazyColumn(
         state = listState,
@@ -94,10 +90,7 @@ fun GrammarSpellingTab(
                 )
                 DiaryViewModeToggle(
                     isAIWritten = isAIWritten,
-                    onToggleViewMode = {
-                        isAIWritten = it
-                        onToggleViewMode(it)
-                    },
+                    onToggleViewMode = onToggleViewMode,
                 )
             }
             Spacer(Modifier.height(12.dp))
@@ -171,9 +164,7 @@ private fun FeedbackTitle(
     modifier: Modifier = Modifier,
 ) {
     Text(
-        text = if (feedbackSize ==
-            0
-        ) {
+        text = if (feedbackSize == 0) {
             AnnotatedString("일기에서 발견된 피드백 알려드릴게요!")
         } else {
             getFeedbackTitleAnnotatedString(feedbackSize)
@@ -205,6 +196,7 @@ private fun GrammarSpellingTabPreview() {
             diaryContent = DiaryContent(),
             topics = Topics(),
             feedbackList = persistentListOf(),
+            isAIWritten = true,
             onImageClick = {},
             onToggleViewMode = {},
         )

--- a/core/ui/src/main/java/com/hilingual/core/ui/component/item/diary/toggle/DiaryViewModeToggle.kt
+++ b/core/ui/src/main/java/com/hilingual/core/ui/component/item/diary/toggle/DiaryViewModeToggle.kt
@@ -22,7 +22,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import com.hilingual.core.designsystem.component.toggle.HilingualSegmentedToggle
+import com.hilingual.core.designsystem.component.button.HilingualSegmentedButton
 import com.hilingual.core.designsystem.theme.HilingualTheme
 import kotlinx.collections.immutable.toImmutableList
 
@@ -39,7 +39,7 @@ internal fun DiaryViewModeToggle(
     onToggleDiaryViewMode: (DiaryViewMode) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    HilingualSegmentedToggle(
+    HilingualSegmentedButton(
         options = DiaryViewMode.entries.map { it.text }.toImmutableList(),
         selectedIndex = viewMode.ordinal,
         onSelect = { selectedIndex ->

--- a/core/ui/src/main/java/com/hilingual/core/ui/component/item/diary/toggle/DiaryViewModeToggle.kt
+++ b/core/ui/src/main/java/com/hilingual/core/ui/component/item/diary/toggle/DiaryViewModeToggle.kt
@@ -24,28 +24,24 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.hilingual.core.designsystem.component.button.HilingualSegmentedButton
 import com.hilingual.core.designsystem.theme.HilingualTheme
-import kotlinx.collections.immutable.toImmutableList
-
-internal enum class DiaryViewMode(val text: String) {
-    CORRECTED("교정본"), ORIGINAL("원본");
-
-    val isAIWritten
-        get() = this == CORRECTED
-}
+import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 internal fun DiaryViewModeToggle(
-    viewMode: DiaryViewMode,
-    onToggleDiaryViewMode: (DiaryViewMode) -> Unit,
+    isAIWritten: Boolean,
+    onToggleViewMode: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     HilingualSegmentedButton(
-        options = DiaryViewMode.entries.map { it.text }.toImmutableList(),
-        selectedIndex = viewMode.ordinal,
+        options = persistentListOf("교정본", "원본"),
+        selectedIndex = if (isAIWritten) 0 else 1,
         onSelect = { selectedIndex ->
-            onToggleDiaryViewMode(DiaryViewMode.entries[selectedIndex])
+            val selectedIsAIWritten = selectedIndex == 0
+            if (selectedIsAIWritten != isAIWritten) {
+                onToggleViewMode(selectedIsAIWritten)
+            }
         },
-        modifier = modifier
+        modifier = modifier,
     )
 }
 
@@ -53,11 +49,11 @@ internal fun DiaryViewModeToggle(
 @Composable
 private fun DiaryViewModeTogglePreview() {
     HilingualTheme {
-        var viewMode by remember { mutableStateOf(DiaryViewMode.CORRECTED) }
+        var isAIWritten by remember { mutableStateOf(true) }
 
         DiaryViewModeToggle(
-            viewMode = viewMode,
-            onToggleDiaryViewMode = { viewMode = it },
+            isAIWritten = isAIWritten,
+            onToggleViewMode = { isAIWritten = it },
         )
     }
 }

--- a/core/ui/src/main/java/com/hilingual/core/ui/component/item/diary/toggle/DiaryViewModeToggle.kt
+++ b/core/ui/src/main/java/com/hilingual/core/ui/component/item/diary/toggle/DiaryViewModeToggle.kt
@@ -15,7 +15,6 @@
  */
 package com.hilingual.core.ui.component.item.diary.toggle
 
-import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -23,39 +22,42 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import com.hilingual.core.designsystem.component.toggle.HilingualSegmentedToggle
 import com.hilingual.core.designsystem.theme.HilingualTheme
+import kotlinx.collections.immutable.toImmutableList
 
-internal enum class DiaryViewMode(val index: Int) {
-    CORRECTED(0), ORIGINAL(1)
+internal enum class DiaryViewMode(val text: String) {
+    CORRECTED("교정본"), ORIGINAL("원본");
+
+    val isAIWritten
+        get() = this == CORRECTED
 }
 
 @Composable
 internal fun DiaryViewModeToggle(
-    isAIWritten: Boolean,
-    onToggle: (Boolean) -> Unit,
+    viewMode: DiaryViewMode,
+    onToggleDiaryViewMode: (DiaryViewMode) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     HilingualSegmentedToggle(
-        options = listOf("교정본", "원본"),
-        selectedIndex = if (isAIWritten) DiaryViewMode.CORRECTED.index else DiaryViewMode.ORIGINAL.index,
+        options = DiaryViewMode.entries.map { it.text }.toImmutableList(),
+        selectedIndex = viewMode.ordinal,
         onSelect = { selectedIndex ->
-            onToggle(selectedIndex == DiaryViewMode.CORRECTED.index)
+            onToggleDiaryViewMode(DiaryViewMode.entries[selectedIndex])
         },
-        modifier = modifier.width(133.dp),
+        modifier = modifier
     )
 }
 
 @Preview
 @Composable
-private fun AIDiaryTogglePreview() {
+private fun DiaryViewModeTogglePreview() {
     HilingualTheme {
-        var isAI by remember { mutableStateOf(true) }
+        var viewMode by remember { mutableStateOf(DiaryViewMode.CORRECTED) }
 
         DiaryViewModeToggle(
-            isAIWritten = isAI,
-            onToggle = { isAI = it },
+            viewMode = viewMode,
+            onToggleDiaryViewMode = { viewMode = it },
         )
     }
 }

--- a/core/ui/src/main/java/com/hilingual/core/ui/component/item/diary/toggle/DiaryViewModeToggle.kt
+++ b/core/ui/src/main/java/com/hilingual/core/ui/component/item/diary/toggle/DiaryViewModeToggle.kt
@@ -36,10 +36,7 @@ internal fun DiaryViewModeToggle(
         options = persistentListOf("교정본", "원본"),
         selectedIndex = if (isAIWritten) 0 else 1,
         onSelect = { selectedIndex ->
-            val selectedIsAIWritten = selectedIndex == 0
-            if (selectedIsAIWritten != isAIWritten) {
-                onToggleViewMode(selectedIsAIWritten)
-            }
+            onToggleViewMode(selectedIndex == 0)
         },
         modifier = modifier,
     )

--- a/core/ui/src/main/java/com/hilingual/core/ui/component/item/diary/toggle/DiaryViewModeToggle.kt
+++ b/core/ui/src/main/java/com/hilingual/core/ui/component/item/diary/toggle/DiaryViewModeToggle.kt
@@ -28,13 +28,13 @@ import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 internal fun DiaryViewModeToggle(
-    isAIWritten: Boolean,
+    isShowCorrectedDiary: Boolean,
     onToggleViewMode: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     HilingualSegmentedButton(
         options = persistentListOf("교정본", "원본"),
-        selectedIndex = if (isAIWritten) 0 else 1,
+        selectedIndex = if (isShowCorrectedDiary) 0 else 1,
         onSelect = { selectedIndex ->
             onToggleViewMode(selectedIndex == 0)
         },
@@ -46,11 +46,11 @@ internal fun DiaryViewModeToggle(
 @Composable
 private fun DiaryViewModeTogglePreview() {
     HilingualTheme {
-        var isAIWritten by remember { mutableStateOf(true) }
+        var isShowCorrectedDiary by remember { mutableStateOf(true) }
 
         DiaryViewModeToggle(
-            isAIWritten = isAIWritten,
-            onToggleViewMode = { isAIWritten = it },
+            isShowCorrectedDiary = isShowCorrectedDiary,
+            onToggleViewMode = { isShowCorrectedDiary = it },
         )
     }
 }

--- a/core/ui/src/main/java/com/hilingual/core/ui/component/item/diary/toggle/DiaryViewModeToggle.kt
+++ b/core/ui/src/main/java/com/hilingual/core/ui/component/item/diary/toggle/DiaryViewModeToggle.kt
@@ -15,20 +15,21 @@
  */
 package com.hilingual.core.ui.component.item.diary.toggle
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
-import androidx.compose.material3.Text
+import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.hilingual.core.designsystem.component.toggle.HilingualBasicToggleSwitch
+import com.hilingual.core.designsystem.component.toggle.HilingualSegmentedToggle
 import com.hilingual.core.designsystem.theme.HilingualTheme
+
+internal enum class DiaryViewMode(val index: Int) {
+    CORRECTED(0), ORIGINAL(1)
+}
 
 @Composable
 internal fun DiaryViewModeToggle(
@@ -36,24 +37,17 @@ internal fun DiaryViewModeToggle(
     onToggle: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
-        modifier = modifier,
-    ) {
-        Text(
-            text = "교정된 일기",
-            style = HilingualTheme.typography.bodyR14,
-            color = HilingualTheme.colors.gray500,
-        )
-        HilingualBasicToggleSwitch(
-            isChecked = isAIWritten,
-            onCheckedChange = onToggle,
-        )
-    }
+    HilingualSegmentedToggle(
+        options = listOf("교정본", "원본"),
+        selectedIndex = if (isAIWritten) DiaryViewMode.CORRECTED.index else DiaryViewMode.ORIGINAL.index,
+        onSelect = { selectedIndex ->
+            onToggle(selectedIndex == DiaryViewMode.CORRECTED.index)
+        },
+        modifier = modifier.width(133.dp),
+    )
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 private fun AIDiaryTogglePreview() {
     HilingualTheme {

--- a/core/ui/src/main/java/com/hilingual/core/ui/model/diary/DiaryContent.kt
+++ b/core/ui/src/main/java/com/hilingual/core/ui/model/diary/DiaryContent.kt
@@ -22,7 +22,7 @@ import kotlinx.collections.immutable.persistentListOf
 @Immutable
 data class DiaryContent(
     val originalText: String = "",
-    val aiText: String = "",
+    val correctedText: String = "",
     val diffRanges: ImmutableList<Pair<Int, Int>> = persistentListOf(),
     val imageUrl: String? = null,
     val isPublished: Boolean = false,

--- a/core/ui/src/main/java/com/hilingual/core/ui/model/diary/FeedbackContent.kt
+++ b/core/ui/src/main/java/com/hilingual/core/ui/model/diary/FeedbackContent.kt
@@ -20,6 +20,6 @@ import androidx.compose.runtime.Immutable
 @Immutable
 data class FeedbackContent(
     val originalText: String,
-    val feedbackText: String,
+    val correctedText: String,
     val explain: String,
 )

--- a/data/diary/src/main/java/com/hilingual/data/diary/model/DiaryFeedbackModel.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/model/DiaryFeedbackModel.kt
@@ -21,12 +21,12 @@ import javax.annotation.concurrent.Immutable
 @Immutable
 data class DiaryFeedbackModel(
     val originalText: String,
-    val rewriteText: String,
+    val correctedText: String,
     val explain: String,
 )
 
 internal fun FeedbackContent.toModel() = DiaryFeedbackModel(
     originalText = this.original,
-    rewriteText = this.rewrite,
+    correctedText = this.rewrite,
     explain = this.explain,
 )

--- a/data/diary/src/main/java/com/hilingual/data/diary/model/DiaryModel.kt
+++ b/data/diary/src/main/java/com/hilingual/data/diary/model/DiaryModel.kt
@@ -22,7 +22,7 @@ import java.time.LocalDate
 data class DiaryContentModel(
     val writtenDate: LocalDate?,
     val originalText: String,
-    val rewriteText: String,
+    val correctedText: String,
     val diffRanges: List<DiaryContentFeedback>,
     val imageUrl: String?,
     val isPublished: Boolean,
@@ -36,7 +36,7 @@ data class DiaryContentFeedback(
 internal fun DiaryContentResponseDto.toModel() = DiaryContentModel(
     writtenDate = this.date.toLocalDateOrNull(),
     originalText = this.originalText,
-    rewriteText = this.rewriteText,
+    correctedText = this.rewriteText,
     imageUrl = this.imageUrl,
     diffRanges = this.diffRanges.map {
         DiaryContentFeedback(

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
@@ -315,6 +315,7 @@ private fun DiaryFeedbackScreen(
                                             "entry_id" to diaryId,
                                             "toggle_state" to it,
                                             "toggle_click_count" to toggleClickCount,
+                                            "page" to FEEDBACK.pageName,
                                         ),
                                     )
                                 },

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
@@ -234,7 +234,7 @@ private fun DiaryFeedbackScreen(
     var isReportDialogVisible by remember { mutableStateOf(false) }
 
     var toggleClickCount by remember { mutableIntStateOf(0) }
-    var isAIWritten by remember { mutableStateOf(true) }
+    var isShowCorrectedDiary by remember { mutableStateOf(true) }
 
     val coroutineScope = rememberCoroutineScope()
     val pagerState = rememberPagerState(pageCount = { 2 })
@@ -305,10 +305,10 @@ private fun DiaryFeedbackScreen(
                                 topics = data.topics,
                                 diaryContent = data.diaryContent,
                                 feedbackList = data.feedbackList,
-                                isAIWritten = isAIWritten,
+                                isShowCorrectedDiary = isShowCorrectedDiary,
                                 onImageClick = onChangeImageDetailVisible,
-                                onToggleViewMode = {
-                                    isAIWritten = it
+                                onToggleDiaryViewMode = {
+                                    isShowCorrectedDiary = it
                                     toggleClickCount++
                                     tracker.logEvent(
                                         trigger = TriggerType.CLICK,

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
@@ -233,7 +233,6 @@ private fun DiaryFeedbackScreen(
     var isReportBottomSheetVisible by remember { mutableStateOf(false) }
     var isReportDialogVisible by remember { mutableStateOf(false) }
 
-    var isAIWrittenDiary by remember { mutableStateOf(true) }
     var toggleClickCount by remember { mutableIntStateOf(0) }
 
     val coroutineScope = rememberCoroutineScope()
@@ -305,10 +304,8 @@ private fun DiaryFeedbackScreen(
                                 topics = data.topics,
                                 diaryContent = data.diaryContent,
                                 feedbackList = data.feedbackList,
-                                isAIWrittenDiary = isAIWrittenDiary,
                                 onImageClick = onChangeImageDetailVisible,
                                 onToggleViewMode = {
-                                    isAIWrittenDiary = it
                                     toggleClickCount++
                                     tracker.logEvent(
                                         trigger = TriggerType.CLICK,

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
@@ -234,6 +234,7 @@ private fun DiaryFeedbackScreen(
     var isReportDialogVisible by remember { mutableStateOf(false) }
 
     var toggleClickCount by remember { mutableIntStateOf(0) }
+    var isAIWritten by remember { mutableStateOf(true) }
 
     val coroutineScope = rememberCoroutineScope()
     val pagerState = rememberPagerState(pageCount = { 2 })
@@ -304,8 +305,10 @@ private fun DiaryFeedbackScreen(
                                 topics = data.topics,
                                 diaryContent = data.diaryContent,
                                 feedbackList = data.feedbackList,
+                                isAIWritten = isAIWritten,
                                 onImageClick = onChangeImageDetailVisible,
                                 onToggleViewMode = {
+                                    isAIWritten = it
                                     toggleClickCount++
                                     tracker.logEvent(
                                         trigger = TriggerType.CLICK,

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackUiState.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackUiState.kt
@@ -50,7 +50,7 @@ internal data class DiaryFeedbackUiState(
                     "but I forgot to replying her. I apolozied to her. " +
                     "We promissed to playing when our university exams are all done. " +
                     "I hope that it’s be done fastly.",
-                aiText = "Today my friend called me. She sent a message a few days ago, " +
+                correctedText = "Today my friend called me. She sent a message a few days ago, " +
                     "but I forgot to reply to her. I apologized to her. " +
                     "We promised to play when our university exams are all done. " +
                     "I hope that it’s done quickly.",
@@ -101,7 +101,7 @@ internal fun TopicModel.toState() = Topics(
 
 internal fun DiaryContentModel.toState() = DiaryContent(
     originalText = this.originalText,
-    aiText = this.rewriteText,
+    correctedText = this.correctedText,
     diffRanges = this.diffRanges.map {
         it.diffRange.first to it.diffRange.second
     }.toImmutableList(),
@@ -111,7 +111,7 @@ internal fun DiaryContentModel.toState() = DiaryContent(
 
 internal fun DiaryFeedbackModel.toState() = FeedbackContent(
     originalText = this.originalText,
-    feedbackText = this.rewriteText,
+    correctedText = this.correctedText,
     explain = this.explain,
 )
 

--- a/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/FeedDiaryScreen.kt
+++ b/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/FeedDiaryScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -180,6 +181,7 @@ private fun FeedDiaryScreen(
     var isReportBottomSheetVisible by remember { mutableStateOf(false) }
     var isReportConfirmDialogVisible by remember { mutableStateOf(false) }
     var isBlockConfirmBottomSheetVisible by remember { mutableStateOf(false) }
+    var toggleClickCount by remember { mutableIntStateOf(0) }
 
     val coroutineScope = rememberCoroutineScope()
     val pagerState = rememberPagerState(pageCount = { 2 })
@@ -272,7 +274,20 @@ private fun FeedDiaryScreen(
                             topics = topics,
                             onImageClick = onChangeImageDetailVisible,
                             isAdVisible = true,
-                            onToggleViewMode = {},
+                            onToggleViewMode = {
+                                toggleClickCount++
+                                tracker.logEvent(
+                                    trigger = TriggerType.CLICK,
+                                    page = Page.FEEDBACK,
+                                    event = "toggle",
+                                    properties = mapOf(
+                                        "entry_id" to diaryId,
+                                        "toggle_state" to it,
+                                        "toggle_click_count" to toggleClickCount,
+                                        "page" to Page.POSTED_DIARY.pageName,
+                                    ),
+                                )
+                            },
                         )
 
                         1 -> RecommendExpressionTab(

--- a/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/FeedDiaryScreen.kt
+++ b/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/FeedDiaryScreen.kt
@@ -182,7 +182,7 @@ private fun FeedDiaryScreen(
     var isReportConfirmDialogVisible by remember { mutableStateOf(false) }
     var isBlockConfirmBottomSheetVisible by remember { mutableStateOf(false) }
     var toggleClickCount by remember { mutableIntStateOf(0) }
-    var isAIWritten by remember { mutableStateOf(true) }
+    var isShowCorrectedDiary by remember { mutableStateOf(true) }
 
     val coroutineScope = rememberCoroutineScope()
     val pagerState = rememberPagerState(pageCount = { 2 })
@@ -273,11 +273,11 @@ private fun FeedDiaryScreen(
                             diaryContent = diaryContent,
                             feedbackList = feedbackList,
                             topics = topics,
-                            isAIWritten = isAIWritten,
+                            isShowCorrectedDiary = isShowCorrectedDiary,
                             onImageClick = onChangeImageDetailVisible,
                             isAdVisible = true,
-                            onToggleViewMode = {
-                                isAIWritten = it
+                            onToggleDiaryViewMode = {
+                                isShowCorrectedDiary = it
                                 toggleClickCount++
                                 tracker.logEvent(
                                     trigger = TriggerType.CLICK,

--- a/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/FeedDiaryScreen.kt
+++ b/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/FeedDiaryScreen.kt
@@ -182,6 +182,7 @@ private fun FeedDiaryScreen(
     var isReportConfirmDialogVisible by remember { mutableStateOf(false) }
     var isBlockConfirmBottomSheetVisible by remember { mutableStateOf(false) }
     var toggleClickCount by remember { mutableIntStateOf(0) }
+    var isAIWritten by remember { mutableStateOf(true) }
 
     val coroutineScope = rememberCoroutineScope()
     val pagerState = rememberPagerState(pageCount = { 2 })
@@ -272,9 +273,11 @@ private fun FeedDiaryScreen(
                             diaryContent = diaryContent,
                             feedbackList = feedbackList,
                             topics = topics,
+                            isAIWritten = isAIWritten,
                             onImageClick = onChangeImageDetailVisible,
                             isAdVisible = true,
                             onToggleViewMode = {
+                                isAIWritten = it
                                 toggleClickCount++
                                 tracker.logEvent(
                                     trigger = TriggerType.CLICK,

--- a/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/FeedDiaryScreen.kt
+++ b/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/FeedDiaryScreen.kt
@@ -181,8 +181,6 @@ private fun FeedDiaryScreen(
     var isReportConfirmDialogVisible by remember { mutableStateOf(false) }
     var isBlockConfirmBottomSheetVisible by remember { mutableStateOf(false) }
 
-    var isAIWrittenDiary by remember { mutableStateOf(true) }
-
     val coroutineScope = rememberCoroutineScope()
     val pagerState = rememberPagerState(pageCount = { 2 })
     val grammarListState = rememberLazyListState()
@@ -272,10 +270,9 @@ private fun FeedDiaryScreen(
                             diaryContent = diaryContent,
                             feedbackList = feedbackList,
                             topics = topics,
-                            isAIWrittenDiary = isAIWrittenDiary,
                             onImageClick = onChangeImageDetailVisible,
-                            onToggleViewMode = { isAIWrittenDiary = it },
                             isAdVisible = true,
+                            onToggleViewMode = {},
                         )
 
                         1 -> RecommendExpressionTab(

--- a/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/FeedDiaryUiState.kt
+++ b/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/FeedDiaryUiState.kt
@@ -60,7 +60,7 @@ internal data class FeedDiaryUiState(
             feedbackList = persistentListOf(
                 FeedbackContent(
                     originalText = "Today my friend called to me.",
-                    feedbackText = "Today my friend called me.",
+                    correctedText = "Today my friend called me.",
                     explain = "'call'은 전화하다라는 의미일 때 'to' 없이 바로 목적어를 씁니다. " +
                         "'called to me'는 '나를 불렀다'라는 의미가 되어 전화 상황에서는 어색합니다.",
                 ),
@@ -70,7 +70,7 @@ internal data class FeedDiaryUiState(
                     "but I forgot to replying her. I apolozied to her. " +
                     "We promissed to playing when our university exams are all done. " +
                     "I hope that it’s be done fastly.",
-                aiText = "Today my friend called me. She sent a message a few days ago, " +
+                correctedText = "Today my friend called me. She sent a message a few days ago, " +
                     "but I forgot to reply to her. I apologized to her. " +
                     "We promised to play when our university exams are all done. " +
                     "I hope that it’s done quickly.",
@@ -131,7 +131,7 @@ internal fun TopicModel.toState() = Topics(
 
 internal fun DiaryContentModel.toState() = DiaryContent(
     originalText = this.originalText,
-    aiText = this.rewriteText,
+    correctedText = this.correctedText,
     diffRanges = this.diffRanges.map {
         it.diffRange.first to it.diffRange.second
     }.toImmutableList(),
@@ -141,7 +141,7 @@ internal fun DiaryContentModel.toState() = DiaryContent(
 
 internal fun DiaryFeedbackModel.toState() = FeedbackContent(
     originalText = this.originalText,
-    feedbackText = this.rewriteText,
+    correctedText = this.correctedText,
     explain = this.explain,
 )
 


### PR DESCRIPTION
## Related issue 🛠
- closed #854

## Work Description ✏️
- 디자인시스템에 `HilingualSegmentedButton`를 추가했습니다.
- `DiaryViewModeToggle`을 `HilingualSegmentedButton` 기반으로 변경했습니다.
- `GrammarSpellingTab`에서 토글 상태를 `rememberSaveable`로 내부 관리하도록 수정했습니다.
- `DiaryFeedbackScreen`, `FeedDiaryScreen` 양쪽에서 토글 클릭 이벤트를 전달하도록 수정했습니다.
- 토글 이벤트 property에 `page`를 추가했습니다.
  - 피드백 상세: `feedback`
  - 피드 일기 상세: `posted_diary`
- `toggle_state`는 클릭 후 상태 기준으로 전달되도록 정리했습니다.
  - 교정본 -> 원본: `false`
  - 원본 -> 교정본: `true`
  
## Screenshot 📸

https://github.com/user-attachments/assets/262a1948-3902-4b87-b2c2-cb3fd88bffc1



## To Reviewers 📢
[명칭]
- 새로운 토글 UI의 명칭을 고민했는데, Material의 `SingleChoiceSegmentedButtonRow` 컴포넌트를 생각해 패키지는 `button`으로 넣고, 명칭은 `HilingualSegmentedButton`으로 설정했습니다!

[토글 상태 관리 방식]
- 처음에는 토글 관리 방식을 `교정본 / 원본`이라는 선택지를 명확하게 표현하기 위해 enum(`DiaryViewMode`)으로 관리하는 방향도 고려했습니다.
- 다만 해당 토글은 앞으로도 2가지 상태만 가지는 구조이고, Amplitude 이벤트의 `toggle_state`가 Boolean 값으로 수집되고 있기에 컴포넌트 명칭도 `Toggle`로 유지하기로 했습니다. (`HilingualSegmentedButton`을 래핑해 사용하지만, 용도를 생각해 교정본/원본 버튼은 `DiaryViewModeToggle`이라고 명칭)