### PR TITLE
[REF/860] 범용 이벤트 로그 설정

### DIFF
--- a/app/src/main/java/com/hilingual/analytics/AmplitudeTracker.kt
+++ b/app/src/main/java/com/hilingual/analytics/AmplitudeTracker.kt
@@ -62,6 +62,21 @@ class AmplitudeTracker @Inject constructor(
         amplitude?.setUserId(null)
     }
 
+    override fun logEvent(
+        trigger: TriggerType,
+        event: String,
+        properties: Map<String, Any>,
+    ) {
+        val eventName = "${trigger.value}_$event"
+
+        if (BuildConfig.DEBUG) {
+            Timber.tag("AmplitudeTracker").d("Tracking event: $eventName, properties: $properties")
+            return
+        }
+
+        amplitude?.track(eventName, properties.toMutableMap())
+    }
+
     override fun logEvent(trigger: TriggerType, page: Page, event: String) {
         val eventName = "${trigger.value}_${page.pageName}.$event"
 
@@ -80,21 +95,6 @@ class AmplitudeTracker @Inject constructor(
         properties: Map<String, Any>,
     ) {
         val eventName = "${trigger.value}_${page.pageName}.$event"
-
-        if (BuildConfig.DEBUG) {
-            Timber.tag("AmplitudeTracker").d("Tracking event: $eventName, properties: $properties")
-            return
-        }
-
-        amplitude?.track(eventName, properties.toMutableMap())
-    }
-
-    override fun logEvent(
-        trigger: TriggerType,
-        event: String,
-        properties: Map<String, Any>,
-    ) {
-        val eventName = "${trigger.value}_$event"
 
         if (BuildConfig.DEBUG) {
             Timber.tag("AmplitudeTracker").d("Tracking event: $eventName, properties: $properties")

--- a/app/src/main/java/com/hilingual/analytics/AmplitudeTracker.kt
+++ b/app/src/main/java/com/hilingual/analytics/AmplitudeTracker.kt
@@ -88,4 +88,19 @@ class AmplitudeTracker @Inject constructor(
 
         amplitude?.track(eventName, properties.toMutableMap())
     }
+
+    override fun logEvent(
+        trigger: TriggerType,
+        event: String,
+        properties: Map<String, Any>,
+    ) {
+        val eventName = "${trigger.value}_$event"
+
+        if (BuildConfig.DEBUG) {
+            Timber.tag("AmplitudeTracker").d("Tracking event: $eventName, properties: $properties")
+            return
+        }
+
+        amplitude?.track(eventName, properties.toMutableMap())
+    }
 }

--- a/core/common/src/main/java/com/hilingual/core/common/analytics/FakeTracker.kt
+++ b/core/common/src/main/java/com/hilingual/core/common/analytics/FakeTracker.kt
@@ -16,6 +16,7 @@
 package com.hilingual.core.common.analytics
 
 class FakeTracker : Tracker {
+    override fun logEvent(trigger: TriggerType, event: String, properties: Map<String, Any>) {}
     override fun logEvent(trigger: TriggerType, page: Page, event: String) {}
     override fun logEvent(trigger: TriggerType, page: Page, event: String, properties: Map<String, Any>) {}
 }

--- a/core/common/src/main/java/com/hilingual/core/common/analytics/Tracker.kt
+++ b/core/common/src/main/java/com/hilingual/core/common/analytics/Tracker.kt
@@ -16,6 +16,7 @@
 package com.hilingual.core.common.analytics
 
 interface Tracker {
+    fun logEvent(trigger: TriggerType, event: String, properties: Map<String, Any>)
     fun logEvent(trigger: TriggerType, page: Page, event: String)
     fun logEvent(trigger: TriggerType, page: Page, event: String, properties: Map<String, Any>)
 }

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
@@ -129,7 +129,6 @@ internal fun DiaryFeedbackRoute(
                         onAction = {
                             tracker.logEvent(
                                 trigger = TriggerType.CLICK,
-                                page = FEEDBACK,
                                 event = "toast_action",
                                 properties = mapOf(
                                     "toast_id" to "diary_post_success",
@@ -331,7 +330,6 @@ private fun DiaryFeedbackScreen(
                                 onBookmarkClick = { phraseId, isMarked ->
                                     tracker.logEvent(
                                         trigger = TriggerType.CLICK,
-                                        page = FEEDBACK,
                                         event = "bookmark_action",
                                         properties = mapOf(
                                             "entry_id" to diaryId,

--- a/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/DiaryWriteScreen.kt
+++ b/presentation/diarywrite/src/main/java/com/hilingual/presentation/diarywrite/DiaryWriteScreen.kt
@@ -425,11 +425,11 @@ private fun DiaryWriteScreen(
                         dropdownClickCount++
                         tracker.logEvent(
                             trigger = TriggerType.CLICK,
-                            page = WRITE_DIARY,
                             event = "dropdown",
                             properties = mapOf(
                                 "recommen_topic" to "$topicKo/$topicEn",
                                 "dropdown_click_count" to dropdownClickCount,
+                                "page" to WRITE_DIARY.pageName,
                             ),
                         )
                     },

--- a/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/FeedDiaryScreen.kt
+++ b/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/FeedDiaryScreen.kt
@@ -281,8 +281,7 @@ private fun FeedDiaryScreen(
                                 toggleClickCount++
                                 tracker.logEvent(
                                     trigger = TriggerType.CLICK,
-                                    page = Page.FEEDBACK,
-                                    event = "toggle",
+                                    event = "feedback_toggle",
                                     properties = mapOf(
                                         "entry_id" to diaryId,
                                         "toggle_state" to it,


### PR DESCRIPTION
## Related issue 🛠
- closed #860 

## Work Description ✏️
- Amplitude 이벤트 네이밍 규칙 변경에 맞춰 공통 액션 이벤트를 특정 화면 종속 이벤트와 분리했습니다.
- `Tracker`에 page 없이 이벤트를 전송하는 공통 액션용 `logEvent`를 추가했습니다.
- `AmplitudeTracker`에서 공통 액션 이벤트는 `{trigger}_{event}` 형식으로 전송되도록 처리했습니다.
- `toast_action`, `bookmark_action`, `dropdown`, `feedback_toggle` 등 공통 액션 성격의 이벤트 호출부를 신규 규칙에 맞게 조정했습니다.
- 공통 액션 이벤트에서 발생 위치를 추적할 수 있도록 `page` property를 유지/추가했습니다.

## Uncompleted Tasks 😅
- [ ] Amplitude 기획 정리 확정 후 전체 이벤트 네이밍 재검토

## To Reviewers 📢
- 현재는 변경 범위를 줄이기 위해 기존 `Tracker.logEvent` 구조를 유지하면서 공통 액션용 오버로드만 추가했습니다.
- 추후 이벤트 기획 정리가 확정되면 `logPageEvent`, `logCommonEvent`처럼 특정 화면 종속 이벤트와 공통 액션 이벤트를 명시적으로 구분하는 방향으로 대규모 리팩토링해도 좋을 것 같습니다.