### PR TITLE
[FIX] 기록 살리기 월 사용 제한 폐지

### DIFF
--- a/presentation/home/src/main/java/com/hilingual/presentation/home/HomeUiState.kt
+++ b/presentation/home/src/main/java/com/hilingual/presentation/home/HomeUiState.kt
@@ -23,7 +23,6 @@ import com.hilingual.presentation.home.model.TodayTopicUiModel
 import com.hilingual.presentation.home.model.UserProfileUiModel
 import com.hilingual.presentation.home.type.DiaryCardState
 import java.time.LocalDate
-import java.time.YearMonth
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
@@ -146,7 +145,6 @@ data class HomeDiaryUiState(
         }
 
         val pastState = when {
-            YearMonth.from(selectedDate) != YearMonth.now() -> DiaryCardState.PAST
             recoveryTickets > 0 -> DiaryCardState.RECOVERABLE
             else -> DiaryCardState.RECOVERY_EXHAUSTED
         }


### PR DESCRIPTION
## Related issue 🛠
- closed #이슈넘버

## Work Description ✏️
- 부활권으로 현재월 끊긴날만 살릴 수 있던 제한을 없애고, 과거 어느 월이든 미작성 날짜를 부활권으로 살릴 수 있도록 pastState 분기에서 현재월 비교 제거. 부활권 개수 제한(매월 3개 리셋/차감)은 유지.

## Screenshot 📸

## Uncompleted Tasks 😅

## To Reviewers 📢
QA 통과로 바로 머지 후 배포 합니다
