### PR TITLE
[CHORE] 의존성 버전 일괄 업데이트 (Renovate PR 9건 통합)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,8 +16,8 @@ versionName = "2.5.0"
 
 # Kotlin
 kotlin = "2.4.0"
-kotlinxImmutable = "0.5.0"
-ksp = "2.3.9"
+kotlinxImmutable = "0.5.1"
+ksp = "2.3.10"
 
 # AndroidX
 coreKtx = "1.19.0"
@@ -26,7 +26,7 @@ androidxAppCompat = "1.7.1"
 lifecycleRuntimeKtx = "2.11.0"
 lifecycleRuntimeComposeAndroid = "2.11.0"
 activityCompose = "1.13.0"
-composeBom = "2026.06.00"
+composeBom = "2026.06.01"
 composeNavigation = "2.9.8"
 security = "1.1.0"
 datastorePreferences = "1.2.1"
@@ -50,9 +50,9 @@ mockk = "1.14.11"
 okhttp = "5.4.0"
 retrofit = "3.0.0"
 kotlinxSerializationJson = "1.11.0"
-daggerHilt = "2.60"
-hiltNavigationCompose = "1.3.0"
-hiltWork = "1.3.0"
+daggerHilt = "2.60.1"
+hiltNavigationCompose = "1.4.0"
+hiltWork = "1.4.0"
 coil = "3.5.0"
 timber = "5.0.1"
 lottieCompose = "6.7.1"
@@ -65,16 +65,16 @@ gmaAds = "1.0.1"
 metaAdsAdapter = "6.21.0.3"
 
 # Firebase
-firebaseBom = "34.15.0"
+firebaseBom = "34.16.0"
 firebaseCrashlyticsPlugin = "3.0.7"
 
 # ML Kit
 mlkitTextRecognition = "16.0.1"
 coroutinesPlayServices = "1.11.0"
 
-uiautomator = "2.3.0"
+uiautomator = "2.4.0"
 benchmarkMacroJunit4 = "1.4.1"
-baselineprofile = "1.5.0-alpha06"
+baselineprofile = "1.5.0-alpha07"
 profileinstaller = "1.4.1"
 runner = "1.7.0"
 


### PR DESCRIPTION
## 개요
열려 있는 Renovate PR 9건을 하나로 통합했습니다. (ads-mobile-sdk #840 제외)

## 포함된 업데이트
| 의존성 | 변경 | 대체 PR |
|---|---|---|
| firebase-bom | 34.15.0 → 34.16.0 | #884 |
| ksp | 2.3.9 → 2.3.10 | #883 |
| daggerHilt | 2.60 → 2.60.1 | #882 |
| kotlinx-collections-immutable | 0.5.0 → 0.5.1 | #881 |
| hiltWork | 1.3.0 → 1.4.0 | #880 |
| uiautomator | 2.3.0 → 2.4.0 | #878 |
| hilt-navigation-compose | 1.3.0 → 1.4.0 | #877 |
| compose-bom | 2026.06.00 → 2026.06.01 | #875 |
| baselineprofile | 1.5.0-alpha06 → 1.5.0-alpha07 | #874 |

머지 후 위 Renovate PR들은 자동으로 닫히거나 수동으로 닫으면 됩니다.