### PR TITLE
[FIX] 메타 광고 어댑터 버전 되돌림 (R8 빌드 실패 해결)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,7 +63,7 @@ pebble = "0.1.0"
 balloonCompose = "1.7.6"
 richeditorCompose = "1.0.0"
 gmaAds = "1.0.1"
-metaAdsAdapter = "6.21.0.4"
+metaAdsAdapter = "6.21.0.3"
 
 # Firebase
 firebaseBom = "34.16.0"


### PR DESCRIPTION
## Related issue 🛠
- N/A

## Work Description ✏️
- 메타 광고 어댑터(`com.google.ads.mediation:facebook`)를 `6.21.0.4` → `6.21.0.3`으로 되돌립니다.

### 왜 되돌리나요
#888로 어댑터가 `6.21.0.4`로 올라간 뒤 릴리즈 빌드의 `:app:minifyReleaseWithR8`가 실패합니다.

```
Missing class com.google.android.gms.ads.AgeRestrictedTreatment
(referenced from: void com.google.ads.mediation.facebook.FacebookMediationAdapter.setMixedAudience(...))
```

바이트코드를 확인해보면 원인이 명확합니다.

- `6.21.0.3`의 `setMixedAudience`는 `AdSettings.setMixedAudience(Z)`만 호출합니다.
- `6.21.0.4`는 그 앞에 `RequestConfiguration.getAgeRestrictedTreatment()` 호출이 추가됐고, 반환 타입이 `com.google.android.gms.ads.AgeRestrictedTreatment`입니다.

`core/ads/build.gradle.kts`에서 신형 `ads-mobile-sdk`를 쓰기 위해 어댑터가 끌고 오는 `play-services-ads`를 exclude하고 있는데, 현재 사용 중인 `ads-mobile-sdk 1.0.1`에는 해당 클래스가 없습니다. (1.3.0에는 포함되어 있습니다.)

## Screenshot 📸
N/A

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
`./gradlew :app:minifyReleaseWithR8` BUILD SUCCESSFUL 확인했고, `app/build/outputs/mapping/release/missing_rules.txt`도 더 이상 생성되지 않습니다.

참고로 `renovate.json`에 이 패키지 예외 규칙이 없어서, 머지 후 Renovate가 `6.21.0.4` 업데이트 PR을 다시 올릴 수 있습니다. GMA SDK를 올릴 준비가 될 때까지는 무시해 주세요.
