### PR TITLE
[CHORE] 릴리즈 PR에 release 빌드 검증 추가 및 QA 절차 문서 보완

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -8,10 +8,12 @@
 ## 릴리즈 체크리스트 ✅
 - [ ] `./gradlew spotlessApply` 실행 및 커밋
 - [ ] `./gradlew ktlintCheck` 통과
-- [ ] 베이스라인 프로파일 재생성 및 커밋 (`baseline-prof.txt`, `startup-prof.txt`)
-- [ ] 패치노트 작성 (`fastlane/metadata/android/ko-KR/changelogs/default.txt`) — 비어 있으면 배포가 중단된다
+- [ ] 베이스라인 프로파일 재생성 및 커밋 (`app/src/release/generated/baselineProfiles/`)
 - [ ] Firebase QA 빌드 배포 및 QA 통과
-- [ ] PR CI(lint / build) 통과
+- [ ] 패치노트 작성 (`fastlane/metadata/android/ko-KR/changelogs/default.txt`) — 비어 있으면 배포가 중단된다
+- [ ] PR CI(lint / build / release build) 통과
+
+순서는 권장일 뿐 강제되지 않는다. 패치노트는 머지 시점까지만 채워져 있으면 되므로, 릴리즈 노트를 QA 이후에 받는다면 나중에 커밋해도 된다.
 
 ## 이번 릴리즈 내용 ✏️
 - 내용

--- a/.github/workflows/pr_checker.yml
+++ b/.github/workflows/pr_checker.yml
@@ -87,3 +87,44 @@ jobs:
 
             - name: Build with Gradle
               run: ./gradlew :app:assembleDebug --stacktrace
+
+    release_build:
+        name: Release Build Check
+        # 릴리즈 PR 에서만 실행한다.
+        # QA 는 debug APK 로 도는데 스토어에 올라가는 것은 R8 이 적용된 release AAB 라,
+        # R8 관련 문제는 배포 단계에 가서야 드러난다. 머지 전에 미리 잡는다.
+        if: ${{ github.event_name == 'pull_request' && startsWith(github.head_ref, 'release/') }}
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v7
+
+            - name: Setup Gradle
+              uses: gradle/actions/setup-gradle@v6
+
+            - name: Set up JDK 17
+              uses: actions/setup-java@v5
+              with:
+                  java-version: 17
+                  distribution: 'temurin'
+
+            - name: Set up Android SDK
+              uses: android-actions/setup-android@v4
+
+            - name: Create required files from secrets
+              env:
+                  LOCAL_PROPERTIES: ${{ secrets.LOCAL_PROPERTIES }}
+                  GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+                  RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+              run: |
+                  printf "%s" "$LOCAL_PROPERTIES" > local.properties
+                  echo "sdk.dir=$ANDROID_SDK_ROOT" >> local.properties
+                  printf "%s" "$GOOGLE_SERVICES_JSON" > ./app/google-services.json
+                  mkdir -p ./keystore
+                  echo "$RELEASE_KEYSTORE_BASE64" | base64 --decode > ./keystore/hilingual-release-key.jks
+
+            - name: Grant permission to gradlew
+              run: chmod +x ./gradlew
+
+            - name: Build release bundle
+              run: ./gradlew :app:bundleRelease --stacktrace

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -53,9 +53,20 @@ Actions 탭에서 **Prepare Release**를 실행하고 버전을 입력합니다.
 - [ ] `./gradlew spotlessApply` 실행
 - [ ] `./gradlew ktlintCheck` 통과
 - [ ] 베이스라인 프로파일 재생성 (`app/src/release/generated/baselineProfiles/`)
+- [ ] Firebase QA 빌드 배포 및 QA 통과
 - [ ] 패치노트 작성 (`fastlane/metadata/android/ko-KR/changelogs/default.txt`)
 
-push할 때마다 Firebase App Distribution에 QA 빌드가 자동으로 배포되고, PR에서는 ktlint와 빌드 검증이 돕니다.
+push할 때마다 Firebase App Distribution에 QA 빌드가 자동으로 배포되고, PR에서는 ktlint와 빌드 검증이 돕니다. 릴리즈 PR에서는 `bundleRelease`까지 돌려 R8이 적용된 실제 배포 빌드가 통과하는지도 검증합니다.
+
+> [!NOTE]
+> 위 순서는 권장 순서일 뿐 강제되지 않습니다. **패치노트는 PR을 머지하는 시점까지만 채워져 있으면 됩니다.**
+> 릴리즈 노트를 QA 이후에 받는다면 QA를 먼저 돌리고 나중에 커밋하셔도 됩니다.
+
+### 사일로 기능 QA는 release 브랜치가 필요 없습니다
+
+`release/x.y.z`는 스토어 배포용입니다. 개별 기능 QA는 작업 브랜치에서 바로 QA 빌드를 뽑으면 됩니다.
+
+Actions 탭 → **Deploy QA Build to Firebase** → Run workflow → 브랜치 선택 후 실행합니다. 유닛 테스트를 돌리고 debug APK를 빌드해 Firebase App Distribution의 `qa-team` 그룹으로 배포합니다. QA 빌드의 릴리즈 노트에는 마지막 커밋 메시지가 자동으로 들어가므로, 여러 기능이 동시에 올라갈 때는 그것으로 구분합니다.
 
 ## 3. 머지
 
@@ -130,8 +141,8 @@ main은 움직이지 않았고 태그도 생성되지 않았으므로 재시도�
 
 | 워크플로 | 트리거 | 하는 일 |
 | --- | --- | --- |
-| `pr_checker.yml` | `develop`/`main` 대상 PR, `develop` push | ktlint, assembleDebug |
-| `deploy-qa.yml` | `release/**` push | 유닛 테스트, Firebase App Distribution 배포 |
+| `pr_checker.yml` | `develop`/`main` 대상 PR, `develop` push | ktlint, assembleDebug (릴리즈 PR은 bundleRelease 추가) |
+| `deploy-qa.yml` | `release/**` push, 수동 실행 | 유닛 테스트, Firebase App Distribution 배포 |
 | `release-prepare.yml` | 수동 실행 | release 브랜치 생성, 버전 코드 커밋, draft PR 생성 |
 | `release-publish.yml` | `develop` 대상 PR 머지 | 사전 검증 → 배포 호출 → main 승격, 태그, Release |
 | `deploy-release.yml` | `release-publish`가 호출, 수동 실행 | AAB 빌드, Play Store 업로드 |


### PR DESCRIPTION
## Related issue 🛠
- 없음 (#930 문서에 들어온 질문 반영)

## Work Description ✏️
릴리즈 가이드를 읽은 팀원 질문에서 드러난 두 가지를 고쳤습니다.

### 1. 체크리스트 순서가 실제 제약과 달랐습니다
문서와 릴리즈 PR 템플릿 모두 패치노트가 QA보다 위에 있어, 그 순서대로 해야 하는 것처럼 읽혔습니다. 실제 제약은 **머지 시점에 패치노트가 비어 있지 않을 것** 하나뿐입니다. 릴리즈 노트를 QA 이후에 기획에서 받는 흐름과 어긋나 있었습니다.

- 체크리스트 순서를 QA → 패치노트로 변경
- "순서는 권장일 뿐이며 패치노트는 머지 시점까지만 채우면 된다"는 설명 추가

### 2. 사일로 기능 QA 절차가 문서에 없었습니다
`release/x.y.z`를 파야 하는지 묻는 질문이 나왔습니다. 필요 없습니다. `deploy-qa.yml`은 `workflow_dispatch`가 열려 있고 하는 일이 유닛 테스트 + `assembleDebug` + Firebase 업로드뿐이라 브랜치를 가리지 않습니다.

- "사일로 기능 QA는 release 브랜치가 필요 없습니다" 절 추가
- Actions에서 브랜치를 골라 수동 실행하는 방법, QA 빌드 릴리즈 노트에 마지막 커밋 메시지가 들어가 구분에 쓸 수 있다는 점 명시

### 3. 릴리즈 PR에 release 빌드 검증 추가
QA는 debug APK로 도는데 스토어에 올라가는 것은 R8이 적용된 release AAB입니다. 코드가 다르므로 #897(메타 광고 어댑터 `minifyReleaseWithR8` 실패) 같은 문제는 debug QA로 잡히지 않고 배포 단계에 가서야 드러납니다.

`pr_checker.yml`에 `release_build` 잡을 추가해 **head 브랜치가 `release/`로 시작하는 PR에서만** `:app:bundleRelease`를 돌립니다. 일반 기능 PR에는 영향이 없습니다.

```yaml
if: ${{ github.event_name == 'pull_request' && startsWith(github.head_ref, 'release/') }}
```

## Screenshot 📸
N/A

## Uncompleted Tasks 😅
- 없음

## To Reviewers 📢
- `release_build` 잡이 쓰는 시크릿 3개(`LOCAL_PROPERTIES`, `GOOGLE_SERVICES_JSON`, `RELEASE_KEYSTORE_BASE64`)가 저장소에 등록되어 있는 것을 확인했습니다. `deploy-release.yml`과 동일한 구성입니다.
- `actionlint 1.7.12` 통과했습니다.
- 이 잡은 다음 릴리즈 PR에서 처음 실행됩니다.
