### PR TITLE
[CHORE/#942] 단어장 플래시카드 Amplitude 이벤트 추가

### DIFF
--- a/app/src/main/java/com/hilingual/analytics/AmplitudeTracker.kt
+++ b/app/src/main/java/com/hilingual/analytics/AmplitudeTracker.kt
@@ -45,22 +45,16 @@ class AmplitudeTracker @Inject constructor(
         )
     }
 
-    override fun setUserId(userId: Long) {
+    override fun logEvent(
+        eventName: String,
+        properties: Map<String, Any>,
+    ) {
         if (BuildConfig.DEBUG) {
-            Timber.tag("AmplitudeTracker").d("Set userId: $userId")
+            Timber.tag("AmplitudeTracker").d("Tracking event: $eventName, properties: $properties")
             return
         }
 
-        amplitude?.setUserId(userId.toString())
-    }
-
-    override fun clearUserId() {
-        if (BuildConfig.DEBUG) {
-            Timber.tag("AmplitudeTracker").d("Clear userId")
-            return
-        }
-
-        amplitude?.setUserId(null)
+        amplitude?.track(eventName, properties.toMutableMap())
     }
 
     override fun logGlobalAction(
@@ -98,5 +92,23 @@ class AmplitudeTracker @Inject constructor(
         }
 
         amplitude?.track(eventName, properties.toMutableMap())
+    }
+
+    override fun setUserId(userId: Long) {
+        if (BuildConfig.DEBUG) {
+            Timber.tag("AmplitudeTracker").d("Set userId: $userId")
+            return
+        }
+
+        amplitude?.setUserId(userId.toString())
+    }
+
+    override fun clearUserId() {
+        if (BuildConfig.DEBUG) {
+            Timber.tag("AmplitudeTracker").d("Clear userId")
+            return
+        }
+
+        amplitude?.setUserId(null)
     }
 }

--- a/core/common/src/main/java/com/hilingual/core/common/analytics/FakeTracker.kt
+++ b/core/common/src/main/java/com/hilingual/core/common/analytics/FakeTracker.kt
@@ -16,6 +16,10 @@
 package com.hilingual.core.common.analytics
 
 class FakeTracker : Tracker {
+    override fun logEvent(
+        eventName: String,
+        properties: Map<String, Any>,
+    ) {}
     override fun logGlobalAction(
         trigger: TriggerType,
         action: String,

--- a/core/common/src/main/java/com/hilingual/core/common/analytics/Tracker.kt
+++ b/core/common/src/main/java/com/hilingual/core/common/analytics/Tracker.kt
@@ -16,6 +16,12 @@
 package com.hilingual.core.common.analytics
 
 interface Tracker {
+    // 이벤트명을 그대로 사용하는 액션 비종속 이벤트
+    fun logEvent(
+        eventName: String,
+        properties: Map<String, Any> = emptyMap(),
+    )
+
     // 페이지 비종속 액션 (공통 컴포넌트)
     // 포맷: {트리거유형}_{이벤트명}
     // 예: click_dropdown, bookmark_action

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
@@ -48,6 +48,7 @@ import com.hilingual.core.ads.interstitial.showInterstitialAd
 import com.hilingual.core.common.analytics.FakeTracker
 import com.hilingual.core.common.analytics.Page.FEEDBACK
 import com.hilingual.core.common.analytics.Page.FEEDBACK_LOADING
+import com.hilingual.core.common.analytics.Page.VOCABULARY
 import com.hilingual.core.common.analytics.Tracker
 import com.hilingual.core.common.analytics.TriggerType
 import com.hilingual.core.common.constant.UrlConstant
@@ -183,7 +184,15 @@ internal fun DiaryFeedbackRoute(
                     HilingualMessage.Snackbar(
                         message = it.message,
                         actionLabelText = it.actionLabel,
-                        onAction = navigateToVoca,
+                        onAction = {
+                            tracker.logGlobalAction(
+                                trigger = TriggerType.CLICK,
+                                action = "toast_action",
+                                properties = mapOf("toast_action" to "goto_voca"),
+                                currentPage = VOCABULARY,
+                            )
+                            navigateToVoca()
+                        },
                     ),
                 )
             }

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
@@ -153,15 +153,13 @@ internal fun DiaryFeedbackRoute(
                         message = it.message,
                         actionLabelText = it.actionLabel,
                         onAction = {
-                            tracker.logGlobalAction(
-                                trigger = TriggerType.CLICK,
-                                action = "toast_action",
+                            tracker.logEvent(
+                                eventName = "toast_action",
                                 properties = mapOf(
-                                    "toast_id" to "diary_post_success",
-                                    "toast_action" to "cta_click",
+                                    "toast_action" to "goto_voca",
                                     "entry_id" to viewModel.diaryId,
+                                    "page" to FEEDBACK.pageName,
                                 ),
-                                currentPage = FEEDBACK,
                             )
                             navigateToFeed()
                         },

--- a/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/FeedDiaryScreen.kt
+++ b/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/FeedDiaryScreen.kt
@@ -43,6 +43,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hilingual.core.common.analytics.FakeTracker
 import com.hilingual.core.common.analytics.Page
+import com.hilingual.core.common.analytics.Page.VOCABULARY
 import com.hilingual.core.common.analytics.Tracker
 import com.hilingual.core.common.analytics.TriggerType
 import com.hilingual.core.common.constant.UrlConstant
@@ -127,7 +128,15 @@ internal fun FeedDiaryRoute(
                     HilingualMessage.Snackbar(
                         message = it.message,
                         actionLabelText = it.actionLabel,
-                        onAction = navigateToVoca,
+                        onAction = {
+                            tracker.logGlobalAction(
+                                trigger = TriggerType.CLICK,
+                                action = "toast_action",
+                                properties = mapOf("toast_action" to "goto_voca"),
+                                currentPage = VOCABULARY,
+                            )
+                            navigateToVoca()
+                        },
                     ),
                 )
             }

--- a/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/FeedDiaryScreen.kt
+++ b/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/FeedDiaryScreen.kt
@@ -43,7 +43,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hilingual.core.common.analytics.FakeTracker
 import com.hilingual.core.common.analytics.Page
-import com.hilingual.core.common.analytics.Page.VOCABULARY
+import com.hilingual.core.common.analytics.Page.FEED
 import com.hilingual.core.common.analytics.Tracker
 import com.hilingual.core.common.analytics.TriggerType
 import com.hilingual.core.common.constant.UrlConstant
@@ -129,11 +129,13 @@ internal fun FeedDiaryRoute(
                         message = it.message,
                         actionLabelText = it.actionLabel,
                         onAction = {
-                            tracker.logGlobalAction(
-                                trigger = TriggerType.CLICK,
-                                action = "toast_action",
-                                properties = mapOf("toast_action" to "goto_voca"),
-                                currentPage = VOCABULARY,
+                            tracker.logEvent(
+                                eventName = "toast_action",
+                                properties = mapOf(
+                                    "toast_action" to "goto_voca",
+                                    "entry_id" to viewModel.diaryId,
+                                    "page" to FEED.pageName,
+                                ),
                             )
                             navigateToVoca()
                         },

--- a/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaScreen.kt
+++ b/presentation/voca/src/main/java/com/hilingual/presentation/voca/VocaScreen.kt
@@ -186,8 +186,20 @@ internal fun VocaRoute(
             onWriteDiaryClick = navigateToHome,
             onCloseButtonClick = viewModel::clearSearchKeyword,
             onRefresh = viewModel::refreshVocaList,
-            onFilterClick = viewModel::toggleUnmemorizedFilter,
+            onFilterClick = {
+                tracker.logPageAction(
+                    trigger = TriggerType.CLICK,
+                    page = VOCABULARY,
+                    action = "unknown_filter",
+                )
+                viewModel.toggleUnmemorizedFilter()
+            },
             onReviewClick = {
+                tracker.logPageAction(
+                    trigger = TriggerType.CLICK,
+                    page = VOCABULARY,
+                    action = "review_btn",
+                )
                 navigateToVocaReview(uiState.isUnmemorizedFilterOn, uiState.sortType.sortParam)
             },
         )


### PR DESCRIPTION
## PR chekList
- [x] ktLint 포맷을 지킨다.
- [x] indent(인덴트, 들여쓰기) depth를 3이 넘지 않도록 구현한다.
- [x] 함수(또는 메서드)가 한 가지 일만 하도록 최대한 작게 만든다.
- [x] class를 최대한 작게 만든다.
- [x] else를 지양한다(얼리 리턴 사용).

## Related issue 🛠
- closed #942

## Work Description ✏️
- 단어장 복습하기 버튼 클릭 시 `click_vocabulary.review_btn` 이벤트를 기록하도록 추가했습니다.
- 모르는 단어 필터 클릭 시 `click_vocabulary.unknown_filter` 이벤트를 기록하도록 추가했습니다.
- 단어 저장 성공 스낵바의 `보러가기` 클릭 시 `click_toast_action` 이벤트를 기록하도록 추가했습니다.
  - `toast_action`: `goto_voca`
  - `page`: `vocabulary`
- 일기 피드백과 피드 일기에서 노출되는 단어 저장 성공 스낵바에 동일한 이벤트를 적용했습니다.

## Screenshot 📸
- UI 변경 없음

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
- 이벤트명과 프로퍼티가 Amplitude 이벤트 정의와 일치하는지 확인 부탁드립니다.
- `presentation:voca`, `presentation:diaryfeedback`, `presentation:feeddiary` 모듈의 Debug Kotlin 컴파일을 확인했습니다.