### PR TITLE
[FEAT] 재연결 시 보류 다이얼로그 복원 및 액션 실패 안내 개선

### DIFF
--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -41,4 +41,6 @@ dependencies {
     // Firebase
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.crashlytics)
+
+    testImplementation(libs.junit)
 }

--- a/core/common/src/main/java/com/hilingual/core/common/trigger/DialogTrigger.kt
+++ b/core/common/src/main/java/com/hilingual/core/common/trigger/DialogTrigger.kt
@@ -26,9 +26,11 @@ enum class DialogType {
     NOT_FOUND,
 }
 
-enum class DialogReconnectPolicy {
-    RESTORE,
-    REPLACED_BY_RETRY,
+enum class DialogReconnectPolicy(
+    val shouldRestoreAfterReconnect: Boolean,
+) {
+    RESTORE(shouldRestoreAfterReconnect = true),
+    REPLACED_BY_RETRY(shouldRestoreAfterReconnect = false),
 }
 
 @Immutable

--- a/core/common/src/main/java/com/hilingual/core/common/trigger/DialogTrigger.kt
+++ b/core/common/src/main/java/com/hilingual/core/common/trigger/DialogTrigger.kt
@@ -26,6 +26,11 @@ enum class DialogType {
     NOT_FOUND,
 }
 
+enum class DialogReconnectPolicy {
+    RESTORE,
+    REPLACED_BY_RETRY,
+}
+
 @Immutable
 data class DialogState(
     val isVisible: Boolean = false,
@@ -35,25 +40,26 @@ data class DialogState(
 
 @Stable
 class DialogTrigger(
-    private val onShow: (DialogType, () -> Unit) -> Unit,
+    private val onShow: (DialogType, DialogReconnectPolicy, () -> Unit) -> Unit,
 ) {
     fun show(
         type: DialogType = DialogType.ERROR,
+        reconnectPolicy: DialogReconnectPolicy = DialogReconnectPolicy.RESTORE,
         onClick: () -> Unit,
     ) {
-        onShow(type, onClick)
+        onShow(type, reconnectPolicy, onClick)
     }
 }
 
 @Composable
 fun rememberDialogTrigger(
-    show: (DialogType, () -> Unit) -> Unit,
+    show: (DialogType, DialogReconnectPolicy, () -> Unit) -> Unit,
 ): DialogTrigger {
     val currentShow = rememberUpdatedState(show)
 
     return remember {
-        DialogTrigger { type, onClick ->
-            currentShow.value(type, onClick)
+        DialogTrigger { type, reconnectPolicy, onClick ->
+            currentShow.value(type, reconnectPolicy, onClick)
         }
     }
 }

--- a/core/common/src/test/java/com/hilingual/core/common/trigger/DialogTriggerTest.kt
+++ b/core/common/src/test/java/com/hilingual/core/common/trigger/DialogTriggerTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 The Hilingual Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hilingual.core.common.trigger
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DialogTriggerTest {
+    @Test
+    fun `기본 재연결 정책은 다이얼로그를 복원한다`() {
+        var actualPolicy: DialogReconnectPolicy? = null
+        val trigger = DialogTrigger { _, reconnectPolicy, _ ->
+            actualPolicy = reconnectPolicy
+        }
+
+        trigger.show(onClick = {})
+
+        assertEquals(DialogReconnectPolicy.RESTORE, actualPolicy)
+    }
+
+    @Test
+    fun `명시한 재연결 정책을 다이얼로그 요청에 전달한다`() {
+        var actualPolicy: DialogReconnectPolicy? = null
+        val trigger = DialogTrigger { _, reconnectPolicy, _ ->
+            actualPolicy = reconnectPolicy
+        }
+
+        trigger.show(
+            reconnectPolicy = DialogReconnectPolicy.REPLACED_BY_RETRY,
+            onClick = {},
+        )
+
+        assertEquals(DialogReconnectPolicy.REPLACED_BY_RETRY, actualPolicy)
+    }
+
+    @Test
+    fun `재연결 재시도로 대체된 요청만 복원하지 않는다`() {
+        assertTrue(DialogReconnectPolicy.RESTORE.shouldRestoreAfterReconnect)
+        assertFalse(DialogReconnectPolicy.REPLACED_BY_RETRY.shouldRestoreAfterReconnect)
+    }
+}

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackScreen.kt
@@ -144,7 +144,7 @@ internal fun DiaryFeedbackRoute(
             }
 
             is DiaryFeedbackSideEffect.ShowErrorDialog ->
-                dialogTrigger.show(onClick = navigateUp)
+                dialogTrigger.show(onClick = {})
 
             is DiaryFeedbackSideEffect.ShowDiaryPublishSnackbar -> {
                 messageController(

--- a/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackViewModel.kt
+++ b/presentation/diaryfeedback/src/main/java/com/hilingual/presentation/diaryfeedback/DiaryFeedbackViewModel.kt
@@ -148,10 +148,14 @@ internal class DiaryFeedbackViewModel @Inject constructor(
     @Deprecated("수정 기능이 도입되기 까지 지원 중단입니다.")
     fun deleteDiary() {
         viewModelScope.launch {
-            diaryRepository.deleteDiary(diaryId = diaryId).onSuccess {
-                showToast("삭제가 완료되었어요.")
-                _sideEffect.emit(DiaryFeedbackSideEffect.NavigateToHome)
-            }
+            diaryRepository.deleteDiary(diaryId = diaryId)
+                .onSuccess {
+                    showToast("삭제가 완료되었어요.")
+                    _sideEffect.emit(DiaryFeedbackSideEffect.NavigateToHome)
+                }
+                .onLogFailure {
+                    _sideEffect.emit(DiaryFeedbackSideEffect.ShowErrorDialog)
+                }
         }
     }
 
@@ -199,7 +203,9 @@ internal class DiaryFeedbackViewModel @Inject constructor(
                         else -> { }
                     }
                 }
-                .onLogFailure { }
+                .onLogFailure {
+                    _sideEffect.emit(DiaryFeedbackSideEffect.ShowErrorDialog)
+                }
         }
     }
 

--- a/presentation/feed/src/main/java/com/hilingual/presentation/feed/FeedViewModel.kt
+++ b/presentation/feed/src/main/java/com/hilingual/presentation/feed/FeedViewModel.kt
@@ -204,7 +204,7 @@ internal class FeedViewModel @Inject constructor(
                     }
                     if (isLiked) showLikeSnackbar()
                 }.onLogFailure {
-                    emitErrorDialogSideEffect { toggleIsLiked(diaryId, isLiked) }
+                    emitErrorDialogSideEffect { }
                 }
         }
     }
@@ -225,7 +225,7 @@ internal class FeedViewModel @Inject constructor(
                         )
                     }
                 }.onLogFailure {
-                    emitErrorDialogSideEffect { diaryUnpublish(diaryId) }
+                    emitErrorDialogSideEffect { }
                 }
         }
     }

--- a/presentation/feed/src/main/java/com/hilingual/presentation/feed/FeedViewModel.kt
+++ b/presentation/feed/src/main/java/com/hilingual/presentation/feed/FeedViewModel.kt
@@ -203,7 +203,9 @@ internal class FeedViewModel @Inject constructor(
                         )
                     }
                     if (isLiked) showLikeSnackbar()
-                }.onLogFailure { }
+                }.onLogFailure {
+                    emitErrorDialogSideEffect { toggleIsLiked(diaryId, isLiked) }
+                }
         }
     }
 
@@ -222,7 +224,9 @@ internal class FeedViewModel @Inject constructor(
                             },
                         )
                     }
-                }.onLogFailure { }
+                }.onLogFailure {
+                    emitErrorDialogSideEffect { diaryUnpublish(diaryId) }
+                }
         }
     }
 

--- a/presentation/feed/src/main/java/com/hilingual/presentation/feed/search/FeedSearchScreen.kt
+++ b/presentation/feed/src/main/java/com/hilingual/presentation/feed/search/FeedSearchScreen.kt
@@ -60,7 +60,7 @@ internal fun FeedSearchRoute(
 
     viewModel.sideEffect.collectSideEffect { sideEffect ->
         when (sideEffect) {
-            is FeedSearchSideEffect.ShowErrorDialog -> dialogTrigger.show(onClick = sideEffect.onRetry)
+            FeedSearchSideEffect.ShowErrorDialog -> dialogTrigger.show(onClick = {})
         }
     }
 

--- a/presentation/feed/src/main/java/com/hilingual/presentation/feed/search/FeedSearchScreen.kt
+++ b/presentation/feed/src/main/java/com/hilingual/presentation/feed/search/FeedSearchScreen.kt
@@ -34,7 +34,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hilingual.core.common.extension.collectSideEffect
 import com.hilingual.core.common.extension.subScreenPadding
+import com.hilingual.core.common.trigger.LocalDialogTrigger
 import com.hilingual.core.common.util.UiState
 import com.hilingual.core.designsystem.component.indicator.HilingualLoadingIndicator
 import com.hilingual.core.designsystem.theme.HilingualTheme
@@ -54,6 +56,13 @@ internal fun FeedSearchRoute(
     viewModel: FeedSearchViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val dialogTrigger = LocalDialogTrigger.current
+
+    viewModel.sideEffect.collectSideEffect { sideEffect ->
+        when (sideEffect) {
+            is FeedSearchSideEffect.ShowErrorDialog -> dialogTrigger.show(onClick = sideEffect.onRetry)
+        }
+    }
 
     LaunchedEffect(Unit) {
         if (uiState.searchWord.isNotBlank()) {

--- a/presentation/feed/src/main/java/com/hilingual/presentation/feed/search/FeedSearchViewModel.kt
+++ b/presentation/feed/src/main/java/com/hilingual/presentation/feed/search/FeedSearchViewModel.kt
@@ -27,8 +27,11 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import jakarta.inject.Inject
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -40,6 +43,9 @@ internal class FeedSearchViewModel @Inject constructor(
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(FeedSearchUiState())
     val uiState: StateFlow<FeedSearchUiState> = _uiState.asStateFlow()
+
+    private val _sideEffect = MutableSharedFlow<FeedSearchSideEffect>()
+    val sideEffect: SharedFlow<FeedSearchSideEffect> = _sideEffect.asSharedFlow()
 
     fun updateSearchWord(searchWord: String) {
         _uiState.update { it.copy(searchWord = searchWord) }
@@ -96,7 +102,17 @@ internal class FeedSearchViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(searchResultUserList = UiState.Success(updatedList))
                 }
-            }.onLogFailure { }
+            }.onLogFailure {
+                _sideEffect.emit(
+                    FeedSearchSideEffect.ShowErrorDialog {
+                        updateFollowingState(userId, currentIsFollowing)
+                    },
+                )
+            }
         }
     }
+}
+
+sealed interface FeedSearchSideEffect {
+    data class ShowErrorDialog(val onRetry: () -> Unit) : FeedSearchSideEffect
 }

--- a/presentation/feed/src/main/java/com/hilingual/presentation/feed/search/FeedSearchViewModel.kt
+++ b/presentation/feed/src/main/java/com/hilingual/presentation/feed/search/FeedSearchViewModel.kt
@@ -103,16 +103,12 @@ internal class FeedSearchViewModel @Inject constructor(
                     it.copy(searchResultUserList = UiState.Success(updatedList))
                 }
             }.onLogFailure {
-                _sideEffect.emit(
-                    FeedSearchSideEffect.ShowErrorDialog {
-                        updateFollowingState(userId, currentIsFollowing)
-                    },
-                )
+                _sideEffect.emit(FeedSearchSideEffect.ShowErrorDialog)
             }
         }
     }
 }
 
 sealed interface FeedSearchSideEffect {
-    data class ShowErrorDialog(val onRetry: () -> Unit) : FeedSearchSideEffect
+    data object ShowErrorDialog : FeedSearchSideEffect
 }

--- a/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/FeedDiaryScreen.kt
+++ b/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/FeedDiaryScreen.kt
@@ -158,7 +158,7 @@ internal fun FeedDiaryRoute(
             }
 
             is FeedDiarySideEffect.ShowErrorDialog -> {
-                dialogTrigger.show(onClick = navigateUp)
+                dialogTrigger.show(onClick = {})
             }
         }
     }

--- a/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/FeedDiaryViewModel.kt
+++ b/presentation/feeddiary/src/main/java/com/hilingual/presentation/feeddiary/FeedDiaryViewModel.kt
@@ -138,7 +138,9 @@ internal class FeedDiaryViewModel @Inject constructor(
                     }
                     if (isLiked) showLikeSnackbar()
                 }
-                .onLogFailure { }
+                .onLogFailure {
+                    _sideEffect.emit(FeedDiarySideEffect.ShowErrorDialog)
+                }
         }
     }
 
@@ -147,7 +149,9 @@ internal class FeedDiaryViewModel @Inject constructor(
             userRepository.putBlockUser(userId)
                 .onSuccess {
                     _sideEffect.emit(FeedDiarySideEffect.NavigateToFeedProfile(userId))
-                }.onLogFailure { }
+                }.onLogFailure {
+                    _sideEffect.emit(FeedDiarySideEffect.ShowErrorDialog)
+                }
         }
     }
 
@@ -196,7 +200,9 @@ internal class FeedDiaryViewModel @Inject constructor(
                         else -> {} // 성공, 실패 외 기타 처리
                     }
                 }
-                .onLogFailure { }
+                .onLogFailure {
+                    _sideEffect.emit(FeedDiarySideEffect.ShowErrorDialog)
+                }
         }
     }
 
@@ -206,7 +212,9 @@ internal class FeedDiaryViewModel @Inject constructor(
                 .onSuccess {
                     _sideEffect.emit(FeedDiarySideEffect.ShowToast(message = "일기가 비공개 되었어요."))
                     _sideEffect.emit(FeedDiarySideEffect.NavigateToUp)
-                }.onLogFailure { }
+                }.onLogFailure {
+                    _sideEffect.emit(FeedDiarySideEffect.ShowErrorDialog)
+                }
         }
     }
 

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/FeedProfileScreen.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/FeedProfileScreen.kt
@@ -134,7 +134,7 @@ internal fun FeedProfileRoute(
 
             is FeedProfileSideEffect.ShowToast -> messageController(HilingualMessage.Toast(sideEffect.message))
 
-            is FeedProfileSideEffect.ShowErrorDialog -> dialogTrigger.show(onClick = navigateUp)
+            is FeedProfileSideEffect.ShowErrorDialog -> dialogTrigger.show(onClick = {})
         }
     }
 

--- a/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/follow/FollowListScreen.kt
+++ b/presentation/feedprofile/src/main/java/com/hilingual/presentation/feedprofile/follow/FollowListScreen.kt
@@ -65,7 +65,7 @@ internal fun FollowListRoute(
 
     viewModel.sideEffect.collectSideEffect { sideEffect ->
         when (sideEffect) {
-            is FollowListSideEffect.ShowErrorDialog -> dialogTrigger.show(onClick = navigateUp)
+            is FollowListSideEffect.ShowErrorDialog -> dialogTrigger.show(onClick = {})
         }
     }
 

--- a/presentation/main/src/main/java/com/hilingual/presentation/main/MainScreen.kt
+++ b/presentation/main/src/main/java/com/hilingual/presentation/main/MainScreen.kt
@@ -71,6 +71,7 @@ import com.hilingual.core.common.model.MessageDuration
 import com.hilingual.core.common.provider.LocalAppRestarter
 import com.hilingual.core.common.provider.LocalIsOffline
 import com.hilingual.core.common.provider.LocalTracker
+import com.hilingual.core.common.trigger.DialogReconnectPolicy
 import com.hilingual.core.common.trigger.DialogType
 import com.hilingual.core.common.trigger.LocalDialogTrigger
 import com.hilingual.core.common.trigger.LocalMessageController
@@ -140,10 +141,11 @@ internal fun MainScreen(
     var isNetworkErrorOverlayVisible by remember { mutableStateOf(false) }
     var pendingDialogRequest by remember { mutableStateOf<PendingDialogRequest?>(null) }
     val dialogTrigger = rememberDialogTrigger(
-        show = { type, onClick ->
+        show = { type, reconnectPolicy, onClick ->
             val request = PendingDialogRequest(
                 backStackEntry = currentBackStackEntry,
                 type = type,
+                reconnectPolicy = reconnectPolicy,
                 onClick = onClick,
             )
             if (isNetworkErrorOverlayVisible) {
@@ -469,6 +471,7 @@ internal fun MainScreen(
 private data class PendingDialogRequest(
     val backStackEntry: NavBackStackEntry?,
     val type: DialogType,
+    val reconnectPolicy: DialogReconnectPolicy,
     val onClick: () -> Unit,
 )
 

--- a/presentation/main/src/main/java/com/hilingual/presentation/main/MainScreen.kt
+++ b/presentation/main/src/main/java/com/hilingual/presentation/main/MainScreen.kt
@@ -211,8 +211,7 @@ internal fun MainScreen(
         } else {
             pendingDialogRequest?.let { request ->
                 pendingDialogRequest = null
-                // Retryable errors are replaced by the reconnect request; terminal errors still need user action.
-                if (request.type == DialogType.NOT_FOUND) {
+                if (request.reconnectPolicy.shouldRestoreAfterReconnect) {
                     appState.dialogStateHolder.showDialog(request.type, request.onClick)
                 }
             }

--- a/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/blockeduser/BlockedUserScreen.kt
+++ b/presentation/mypage/src/main/java/com/hilingual/presentation/mypage/blockeduser/BlockedUserScreen.kt
@@ -71,7 +71,7 @@ internal fun BlockedUserRoute(
 
     viewModel.sideEffect.collectSideEffect { sideEffect ->
         when (sideEffect) {
-            is BlockedUserSideEffect.ShowErrorDialog -> dialogTrigger.show(onClick = navigateUp)
+            is BlockedUserSideEffect.ShowErrorDialog -> dialogTrigger.show(onClick = {})
         }
     }
 

--- a/presentation/notification/src/main/java/com/hilingual/presentation/notification/setting/NotificationSettingScreen.kt
+++ b/presentation/notification/src/main/java/com/hilingual/presentation/notification/setting/NotificationSettingScreen.kt
@@ -80,8 +80,8 @@ internal fun NotificationSettingRoute(
                 isNotificationSettingDialogVisible = true
             }
 
-            is NotificationSettingSideEffect.ShowErrorDialog -> {
-                dialogTrigger.show(onClick = sideEffect.onRetry)
+            NotificationSettingSideEffect.ShowErrorDialog -> {
+                dialogTrigger.show(onClick = {})
             }
         }
     }

--- a/presentation/notification/src/main/java/com/hilingual/presentation/notification/setting/NotificationSettingScreen.kt
+++ b/presentation/notification/src/main/java/com/hilingual/presentation/notification/setting/NotificationSettingScreen.kt
@@ -37,6 +37,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hilingual.core.common.extension.collectSideEffect
+import com.hilingual.core.common.trigger.LocalDialogTrigger
 import com.hilingual.core.common.util.RetryOnReconnect
 import com.hilingual.core.common.util.UiState
 import com.hilingual.core.designsystem.component.indicator.HilingualLoadingIndicator
@@ -60,6 +61,7 @@ internal fun NotificationSettingRoute(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val isNotificationGranted by viewModel.isNotificationGranted.collectAsStateWithLifecycle()
     val context = LocalContext.current
+    val dialogTrigger = LocalDialogTrigger.current
 
     var isNotificationSettingDialogVisible by remember { mutableStateOf(false) }
 
@@ -76,6 +78,10 @@ internal fun NotificationSettingRoute(
         when (sideEffect) {
             NotificationSettingSideEffect.ShowPermissionDialog -> {
                 isNotificationSettingDialogVisible = true
+            }
+
+            is NotificationSettingSideEffect.ShowErrorDialog -> {
+                dialogTrigger.show(onClick = sideEffect.onRetry)
             }
         }
     }

--- a/presentation/notification/src/main/java/com/hilingual/presentation/notification/setting/NotificationSettingViewModel.kt
+++ b/presentation/notification/src/main/java/com/hilingual/presentation/notification/setting/NotificationSettingViewModel.kt
@@ -139,11 +139,7 @@ internal class NotificationSettingViewModel @Inject constructor(
                 }
                 .onLogFailure {
                     _uiState.update { UiState.Success(serverState.value) }
-                    _sideEffect.emit(
-                        NotificationSettingSideEffect.ShowErrorDialog {
-                            updateNotificationSetting(notiType)
-                        },
-                    )
+                    _sideEffect.emit(NotificationSettingSideEffect.ShowErrorDialog)
                 }
         }
     }
@@ -156,5 +152,5 @@ private enum class NotiType {
 
 internal sealed interface NotificationSettingSideEffect {
     data object ShowPermissionDialog : NotificationSettingSideEffect
-    data class ShowErrorDialog(val onRetry: () -> Unit) : NotificationSettingSideEffect
+    data object ShowErrorDialog : NotificationSettingSideEffect
 }

--- a/presentation/notification/src/main/java/com/hilingual/presentation/notification/setting/NotificationSettingViewModel.kt
+++ b/presentation/notification/src/main/java/com/hilingual/presentation/notification/setting/NotificationSettingViewModel.kt
@@ -139,6 +139,11 @@ internal class NotificationSettingViewModel @Inject constructor(
                 }
                 .onLogFailure {
                     _uiState.update { UiState.Success(serverState.value) }
+                    _sideEffect.emit(
+                        NotificationSettingSideEffect.ShowErrorDialog {
+                            updateNotificationSetting(notiType)
+                        },
+                    )
                 }
         }
     }
@@ -151,4 +156,5 @@ private enum class NotiType {
 
 internal sealed interface NotificationSettingSideEffect {
     data object ShowPermissionDialog : NotificationSettingSideEffect
+    data class ShowErrorDialog(val onRetry: () -> Unit) : NotificationSettingSideEffect
 }

--- a/presentation/voca/src/main/java/com/hilingual/presentation/voca/review/VocaReviewScreen.kt
+++ b/presentation/voca/src/main/java/com/hilingual/presentation/voca/review/VocaReviewScreen.kt
@@ -82,7 +82,7 @@ internal fun VocaReviewRoute(
 
     viewModel.sideEffect.collectSideEffect {
         when (it) {
-            VocaReviewSideEffect.ShowErrorDialog -> dialogTrigger.show(onClick = viewModel::saveResults)
+            VocaReviewSideEffect.ShowErrorDialog -> dialogTrigger.show(onClick = {})
         }
     }
 


### PR DESCRIPTION
## PR chekList
- [x] ktLint 포맷을 지킨다.
- [x] indent(인덴트, 들여쓰기) depth를 3이 넘지 않도록 구현한다.
- [x] 함수(또는 메서드)가 한 가지 일만 하도록 최대한 작게 만든다.
- [x] class를 최대한 작게 만든다.
- [x] else를 지양한다(얼리 리턴 사용).

## Related issue 🛠

- closed #910

## Work Description ✏️

### 보류 다이얼로그의 재연결 복원 정책 분리

네트워크 오버레이가 표시되는 동안 보류된 요청은 기존에 `NOT_FOUND`만 복원하고 `ERROR`는 폐기했습니다. 하지만 화면이 `Success`인 상태에서 발생한 액션 실패는 재연결 자동 재시도 대상이 아니므로, 오류 안내가 사라질 수 있었습니다.

- `DialogReconnectPolicy`를 추가해 다이얼로그 종류와 복원 여부를 분리했습니다.
  - `RESTORE`: 오버레이 종료 시 보류 요청 복원. 기본값으로 사용합니다.
  - `REPLACED_BY_RETRY`: 재연결 재시도로 대체되는 요청이므로 복원하지 않습니다.
- `DialogTrigger.show()`와 `rememberDialogTrigger()`에서 복원 정책을 전달하도록 확장했습니다.
- `MainScreen`의 `PendingDialogRequest`에 정책을 함께 보관하고, `shouldRestoreAfterReconnect`를 기준으로 복원 여부를 판단하도록 변경했습니다.
- 다른 화면의 요청이 복원되지 않도록 현재 백스택 엔트리와 요청의 엔트리를 비교하는 기존 처리는 유지했습니다.

### 액션 실패 시 오류 다이얼로그 추가

기존에 실패 로그만 남기던 아래 요청에 오류 다이얼로그 표시를 추가했습니다.

| 화면 | 오류 안내를 추가한 요청 |
| --- | --- |
| 일기 피드백 | 표현 북마크 변경, 일기 삭제(현재 지원 중단된 메서드) |
| 피드 | 좋아요 변경, 일기 비공개 전환 |
| 피드 검색 | 팔로우/언팔로우 |
| 피드 일기 상세 | 좋아요 변경, 사용자 차단, 표현 북마크 변경, 일기 비공개 전환 |
| 알림 설정 | 알림 설정 변경 |

- 피드 검색에 `FeedSearchSideEffect.ShowErrorDialog`와 화면의 이벤트 수집 처리를 추가했습니다.
- 알림 설정 변경 실패 시 기존 서버 상태로 되돌리는 처리를 유지하면서 오류 안내를 추가했습니다.

### 오류 다이얼로그 확인 동작 변경

- 일기 피드백, 피드 일기 상세, 피드 프로필, 팔로우 목록, 차단 사용자 목록에서 오류 다이얼로그 확인 시 뒤로 이동하던 콜백을 제거했습니다.
- 단어 복습에서 오류 다이얼로그 확인 시 `saveResults()`를 재호출하던 콜백을 제거했습니다. 저장은 화면의 저장 버튼을 통해 다시 시도할 수 있습니다.
- 변경된 오류 다이얼로그는 `onClick = {}`를 사용해 확인 시 별도 화면 이동이나 요청 재실행을 수행하지 않습니다.

### 복원 정책 단위 테스트 추가

- `core:common`에 JUnit 테스트 의존성과 `DialogTriggerTest`를 추가했습니다.
- 기본 정책이 `RESTORE`인지, 명시한 정책이 요청에 전달되는지, `REPLACED_BY_RETRY`만 복원하지 않는지 확인하는 테스트 3개를 작성했습니다.

## Screenshot 📸

<!-- 재연결 후 보류 오류 다이얼로그가 표시되는 영상 또는 스크린샷을 첨부해주세요. -->
<!-- <img src="첨부 이미지 URL" width="360"/> -->

## Uncompleted Tasks 😅
- [ ] 액션 요청 진행 중 오프라인 화면 이동 → 네트워크 오버레이 표시 → 실패 응답 도착 → 재연결 순서에서 보류 오류 다이얼로그가 복원되는지 확인
- [ ] 오버레이 표시 중 다른 화면으로 이동하면 이전 화면의 보류 요청이 표시되지 않는지 확인
- [ ] 변경된 화면에서 오류 다이얼로그 확인 후 현재 화면이 유지되고, 필요 시 화면의 액션 버튼으로 다시 요청할 수 있는지 확인
- [ ] 알림 설정 변경 실패 시 토글 상태 복원 및 오류 안내 확인
- [ ] 재연결 시나리오 영상 또는 스크린샷 첨부

## To Reviewers 📢
- 네트워크가 연결되지 않거나 통신 상태가 불안정한 경우 다이얼로그 확인 버튼을 눌렀을 때 요청을 계속 시도하며 다이얼로그를 닫을 수 없는 문제가 있었습니다. 이에, 사용자가 오류 이후에도 다른 동작을 자유롭게 할 수 있도록 확인 버튼에서 뒤로 이동하거나 저장을 다시 시도하던 동작도 함께 제거했습니다. 각 화면에서 오류 안내를 닫은 뒤 사용자가 이어서 조작할 수 있는지 함께 봐주시면 좋겠습니다.
